### PR TITLE
fix(swagger): resolve schema ID conflict for duplicate type names

### DIFF
--- a/src/RallyAPI.Host/Program.cs
+++ b/src/RallyAPI.Host/Program.cs
@@ -1,6 +1,9 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
 using RallyAPI.Catalog.Endpoints;
 using RallyAPI.Delivery.Endpoints;
 using RallyAPI.Infrastructure;
@@ -11,10 +14,8 @@ using RallyAPI.SharedKernel.Extensions;
 using RallyAPI.SharedKernel.Infrastructure;
 using RallyAPI.Users.Endpoints;
 using System.Security.Cryptography;
-using System.Threading.RateLimiting;
-using Microsoft.Extensions.Diagnostics.HealthChecks;
 using System.Text.Json;
-using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using System.Threading.RateLimiting;
 
 
 var builder = WebApplication.CreateBuilder(args);
@@ -114,22 +115,28 @@ builder.Services.AddPricingInfrastructure(builder.Configuration);
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {
-    c.AddSecurityDefinition("Bearer", new Microsoft.OpenApi.Models.OpenApiSecurityScheme
+    // 1. FIX: Resolve the schema ID conflict by using the Full Name
+    c.CustomSchemaIds(type => type.FullName);
+
+    // 2. Your existing Security Definition
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
     {
         Name = "Authorization",
-        Type = Microsoft.OpenApi.Models.SecuritySchemeType.Http,
+        Type = SecuritySchemeType.Http,
         Scheme = "bearer",
         BearerFormat = "JWT",
-        In = Microsoft.OpenApi.Models.ParameterLocation.Header
+        In = ParameterLocation.Header
     });
-    c.AddSecurityRequirement(new Microsoft.OpenApi.Models.OpenApiSecurityRequirement
+
+    // 3. Your existing Security Requirement
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
     {
         {
-            new Microsoft.OpenApi.Models.OpenApiSecurityScheme
+            new OpenApiSecurityScheme
             {
-                Reference = new Microsoft.OpenApi.Models.OpenApiReference
+                Reference = new OpenApiReference
                 {
-                    Type = Microsoft.OpenApi.Models.ReferenceType.SecurityScheme,
+                    Type = ReferenceType.SecurityScheme,
                     Id = "Bearer"
                 }
             },

--- a/src/RallyAPI.Host/obj/Debug/net8.0/RallyAPI.Host.csproj.FileListAbsolute.txt
+++ b/src/RallyAPI.Host/obj/Debug/net8.0/RallyAPI.Host.csproj.FileListAbsolute.txt
@@ -188,3 +188,4 @@ C:\Users\vishw\source\repos\Rally\src\RallyAPI.Host\bin\Debug\net8.0\Microsoft.E
 C:\Users\vishw\source\repos\Rally\src\RallyAPI.Host\bin\Debug\net8.0\Microsoft.Extensions.Hosting.Abstractions.dll
 C:\Users\vishw\source\repos\Rally\src\RallyAPI.Host\bin\Debug\net8.0\AWSSDK.Core.dll
 C:\Users\vishw\source\repos\Rally\src\RallyAPI.Host\bin\Debug\net8.0\AWSSDK.S3.dll
+C:\Users\vishw\source\repos\Rally\src\RallyAPI.Host\obj\Debug\net8.0\staticwebassets.upToDateCheck.txt


### PR DESCRIPTION
swagger bug fix : Two types named `GenerateUploadUrlRequest` exist in different modules
(Users.Restaurants.UpdateProfile and Catalog.MenuItems.UpdateMenuItem),
causing Swashbuckle to fail when generating swagger.json.

Fix: Added `c.CustomSchemaIds(type => type.FullName)` to use fully
qualified type names as schema IDs, preventing collisions.