### PR TITLE
chore(ci): enable integration tests in CI, fix workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Rally CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [master, main, develop]
   pull_request:
-    branches: [main, develop]
+    branches: [master, main, develop]
 
 env:
   DOTNET_VERSION: '8.0.x'
@@ -34,9 +34,27 @@ jobs:
           dotnet test tests/Modules/Orders/RallyAPI.Orders.Application.Tests/ --no-build --configuration Release --verbosity normal
           dotnet test tests/Modules/Delivery/RallyAPI.Delivery.Application.Tests/ --no-build --configuration Release --verbosity normal
           dotnet test tests/Modules/Pricing/RallyAPI.Pricing.Application.Tests/ --no-build --configuration Release --verbosity normal
+          dotnet test tests/Modules/Users/RallyAPI.Users.Infrastructure.Tests/ --no-build --configuration Release --verbosity normal
           dotnet test RallyAPI.Integrations.ProRouting.Tests/ --no-build --configuration Release --verbosity normal
 
-      # Integration tests skipped in CI (require Docker for TestContainers)
-      # Uncomment below when GitHub Actions Docker support is configured
-      # - name: Run integration tests
-      #   run: dotnet test tests/RallyAPI.Integration.Tests/ --no-build --configuration Release --verbosity normal
+  integration-tests:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Run integration tests
+        run: dotnet test tests/RallyAPI.Integration.Tests/ --no-build --configuration Release --verbosity normal


### PR DESCRIPTION
- Add master branch to push/PR triggers (was only main/develop)
- Add Users.Infrastructure.Tests to unit test step
- Enable integration tests as a separate job (depends on unit tests) GitHub Actions ubuntu-latest has Docker, so Testcontainers works
- Split into two jobs: build-and-test (unit) → integration-tests