### PR TITLE
chore(deps): fix EF Core version conflict warnings (MSB3277)

### DIFF
--- a/src/Modules/Catalog/RallyAPI.Catalog.Infrastructure/RallyAPI.Catalog.Infrastructure.csproj
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Infrastructure/RallyAPI.Catalog.Infrastructure.csproj
@@ -8,6 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.23" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.23" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
 	</ItemGroup>
 

--- a/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/RallyAPI.Delivery.Infrastructure.csproj
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/RallyAPI.Delivery.Infrastructure.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.23" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.23" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
   </ItemGroup>
 

--- a/src/Modules/Orders/RallyAPI.Orders.Infrastructure/RallyAPI.Orders.Infrastructure.csproj
+++ b/src/Modules/Orders/RallyAPI.Orders.Infrastructure/RallyAPI.Orders.Infrastructure.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.23" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.23" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.23">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Modules/Pricing/RallyAPI.Pricing.Infrastructure/RallyAPI.Pricing.Infrastructure.csproj
+++ b/src/Modules/Pricing/RallyAPI.Pricing.Infrastructure/RallyAPI.Pricing.Infrastructure.csproj
@@ -13,6 +13,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.23" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.23" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
 		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/RallyAPI.Users.Infrastructure.csproj
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/RallyAPI.Users.Infrastructure.csproj
@@ -4,6 +4,7 @@
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.22" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.23" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.23" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.23">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Pin Microsoft.EntityFrameworkCore.Relational to 8.0.23 in all 5 Infrastructure projects. Npgsql.EntityFrameworkCore.PostgreSQL 8.0.11 transitively pulls in .Relational 8.0.11, conflicting with the direct EF Core 8.0.23 references. Explicit pin resolves all MSB3277 assembly binding warnings (was ~45 warning lines, now 0).