### PR TITLE
fix(users): fix 2 failing OTP tests caused by Redis overload mismatch

### DIFF
--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Services/OtpService.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Services/OtpService.cs
@@ -1,12 +1,7 @@
-﻿
-using MediatR;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using RallyAPI.Users.Application.Abstractions;
 using StackExchange.Redis;
-using System.Collections.Generic;
-using System.Numerics;
 using System.Security.Cryptography;
-using static System.Net.WebRequestMethods;
 
 namespace RallyAPI.Users.Infrastructure.Services;
 
@@ -60,20 +55,24 @@ public class OtpService : IOtpService
         await _redis.StringSetAsync(
             $"otp:code:{phoneKey}",
             hashedOtp,
-            TimeSpan.FromMinutes(OtpExpiryMinutes));
+            TimeSpan.FromMinutes(OtpExpiryMinutes),
+            When.Always,
+            CommandFlags.None);
 
         // Reset attempt counter
         await _redis.StringSetAsync(
             $"otp:attempts:{phoneKey}",
             0,
-            TimeSpan.FromMinutes(OtpExpiryMinutes));
+            TimeSpan.FromMinutes(OtpExpiryMinutes),
+            When.Always,
+            CommandFlags.None);
 
         // Increment rate limit counter
         await _redis.StringIncrementAsync(rateKey);
         // Set expiry only if this is the first request in the window
         if (!currentRate.HasValue)
         {
-            await _redis.KeyExpireAsync(rateKey, TimeSpan.FromMinutes(RateLimitWindowMinutes));
+            await _redis.KeyExpireAsync(rateKey, TimeSpan.FromMinutes(RateLimitWindowMinutes), CommandFlags.None);
         }
 
         // TODO: Send via SMS provider (Twilio/MSG91)
@@ -119,7 +118,9 @@ public class OtpService : IOtpService
             await _redis.StringSetAsync(
                 $"otp:lock:{phoneKey}",
                 "locked",
-                TimeSpan.FromMinutes(LockoutMinutes));
+                TimeSpan.FromMinutes(LockoutMinutes),
+                When.Always,
+                CommandFlags.None);
 
             // Clean up OTP keys
             await CleanupKeys(phoneKey);


### PR DESCRIPTION
StackExchange.Redis 2.11 added new overloads for StringSetAsync and KeyExpireAsync. The implicit optional parameters caused C# to resolve to different overloads than the NSubstitute mocks expected, silently breaking 2 tests.

Fix: pass explicit When.Always/CommandFlags.None params to pin the overload resolution to the 5-param StringSetAsync and 3-param KeyExpireAsync that the test mocks intercept.

Also remove unused usings (MediatR, System.Numerics, etc.) from OtpService.