### PR TITLE
feat(users): add Google Maps address integration with PlaceId

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,618 @@
+# RallyAPI — Project Context
+
+> This file is read by Claude Code, Codex, Cursor, and Antigravity.
+> It describes the project so AI generates code that fits THIS architecture exactly.
+> Last updated: 2026-03-24
+
+## Project Overview
+
+**Rally** is a food delivery platform for the Indian market. Three user roles:
+- **Customers** — Browse restaurants, order food, track delivery in real-time
+- **Restaurant Partners** — Receive orders, manage menus, update availability
+- **Delivery Riders** — Accept delivery offers, navigate to pickup/drop, update status
+
+### Launch Strategy (Updated March 14, 2026)
+
+**Web-first launch.** All user-facing apps are React web apps, NOT Flutter.
+- Flutter mobile apps come LATER (post-launch)
+- FCM (push notifications) is DEFERRED — not needed for web
+- **SignalR** replaces FCM for real-time web notifications
+- PayU browser redirect works the same without WebView
+
+### Who Builds What
+
+| App | Tech | Developer | Status |
+|-----|------|-----------|--------|
+| Backend (RallyAPI) | .NET 8, PostgreSQL | You | Core working |
+| Customer Web App | React + TS + Tailwind + GSAP | Other developer | In progress |
+| Rider Web App | React + TS + Tailwind + GSAP | Other developer | In progress |
+| Restaurant Dashboard | React + TS + Tailwind | You | Not started |
+| Admin Panel | React + TS + Tailwind | You | Not started |
+| Flutter Apps (later) | Flutter | Other developer | Deferred |
+
+---
+
+## Tech Stack — Backend
+
+| Layer | Technology |
+|-------|-----------|
+| Runtime | .NET 8 / ASP.NET Core |
+| Language | C# 12 |
+| API Style | Minimal APIs |
+| Architecture | Modular Monolith (Clean Architecture per module) |
+| Database | PostgreSQL (EF Core + Npgsql) |
+| Cache | Redis (OTP storage, rate limiting) |
+| Auth | RS256 JWT (RSA-2048), BCrypt passwords, SHA256 OTP, refresh token rotation with theft detection |
+| Patterns | CQRS via MediatR, DDD (aggregates, value objects, domain events), FluentValidation, Repository + Unit of Work |
+| Payments | PayU India (Hosted Checkout + S2S webhook) |
+| Maps/Routing | Google Maps API (Routes, Geocoding, Places Autocomplete) + ProRouting integration |
+| Real-time | SignalR (for web-first launch, replacing FCM) |
+| Hosting | Railway |
+| Database Hosting | Railway Postgres + Redis |
+| Image Storage | Cloudflare R2 (pending) |
+| Local Dev | Docker |
+
+### Planned / In Progress
+
+- Firebase Cloud Messaging — DEFERRED until Flutter apps ship
+- MSG91 WhatsApp OTP — code complete, blocked on Meta Business Verification
+- Petpooja POS integration
+- Sentry (error tracking) — NOT YET ADDED
+- Serilog (structured logging) — ADDED (feat/logging branch merged)
+- GitHub Actions (CI/CD) — ADDED (build + unit tests + integration tests)
+- Google Maps Geocoding + Places Autocomplete — ADDED (feat/maps-address branch)
+- Customer Pickup Orders — ADDED (feat/pickup-orders branch, PR pending)
+
+## Tech Stack — Frontend (React Apps)
+
+| Layer | Technology |
+|-------|-----------|
+| Framework | React 18+ with TypeScript |
+| Styling | Tailwind CSS |
+| Animation | GSAP |
+| State Management | TBD (React Query recommended for server state) |
+| Real-time | SignalR client (@microsoft/signalr) |
+| Build | Vite |
+
+---
+
+## Project Structure (ACTUAL)
+
+```
+RallyAPI/
+|
+|-- src/
+|   |-- RallyAPI.Host/                          # Entry point: Program.cs, middleware, DI config
+|   |   |-- Keys/                               # RSA keys for JWT signing
+|   |   \-- Properties/                         # launchSettings.json
+|   |
+|   |-- Modules/
+|   |   |-- Catalog/                            # Restaurant & menu management
+|   |   |   |-- RallyAPI.Catalog.Domain/
+|   |   |   |   |-- Enums/
+|   |   |   |   |-- MenuItems/                  # MenuItem entity/aggregate
+|   |   |   |   \-- Menus/                      # Menu entity/aggregate
+|   |   |   |-- RallyAPI.Catalog.Application/
+|   |   |   |   |-- Abstractions/
+|   |   |   |   |-- MenuItems/
+|   |   |   |   |   |-- Commands/               # CreateMenuItem, ToggleMenuItemAvailability, UpdateMenuItem
+|   |   |   |   |   \-- Queries/                # GetMenuItemById, GetMenuItemsByMenu
+|   |   |   |   |-- Menus/
+|   |   |   |   |   |-- Commands/               # CreateMenu, DeleteMenu, UpdateMenu
+|   |   |   |   |   \-- Queries/                # GetMenusByRestaurant
+|   |   |   |   \-- Restaurants/
+|   |   |   |       \-- Queries/                # GetRestaurantMenu, GetRestaurants, SearchMenuItems
+|   |   |   |-- RallyAPI.Catalog.Endpoints/
+|   |   |   |   |-- MenuItems/
+|   |   |   |   |-- Menus/
+|   |   |   |   \-- Restaurants/
+|   |   |   \-- RallyAPI.Catalog.Infrastructure/
+|   |   |       \-- Persistence/
+|   |   |           |-- Configurations/
+|   |   |           |-- Migrations/
+|   |   |           \-- Repositories/
+|   |   |
+|   |   |-- Orders/                             # Order lifecycle + payments
+|   |   |   |-- RallyAPI.Orders.Domain/
+|   |   |   |   |-- Abstractions/
+|   |   |   |   |-- Entities/
+|   |   |   |   |-- Enums/
+|   |   |   |   |-- Errors/
+|   |   |   |   |-- Events/
+|   |   |   |   |-- Repositories/               # Repository interfaces
+|   |   |   |   \-- ValueObjects/
+|   |   |   |-- RallyAPI.Orders.Application/
+|   |   |   |   |-- Abstractions/
+|   |   |   |   |-- Behaviors/                  # MediatR pipeline behaviors
+|   |   |   |   |-- Commands/                   # PlaceOrder, ConfirmOrder, CancelOrder, RejectOrder,
+|   |   |   |   |                               # AssignRider, UpdateOrderStatus, InitiatePayment,
+|   |   |   |   |                               # ProcessPayuWebhook, VerifyPayment, RefundPayment
+|   |   |   |   |-- DTOs/
+|   |   |   |   |   \-- Requests/
+|   |   |   |   |-- EventHandlers/
+|   |   |   |   |-- Mappings/
+|   |   |   |   \-- Queries/                    # GetOrderById, GetOrderByNumber, GetOrdersByCustomer,
+|   |   |   |                                   # GetOrdersByRestaurant, GetActiveOrders
+|   |   |   |-- RallyAPI.Orders.Endpoints/
+|   |   |   \-- RallyAPI.Orders.Infrastructure/
+|   |   |       |-- BackgroundServices/
+|   |   |       |-- Configurations/
+|   |   |       |-- Migrations/
+|   |   |       |-- Repositories/
+|   |   |       \-- Services/
+|   |   |           \-- PayU/                   # PayU payment gateway integration
+|   |   |
+|   |   |-- Delivery/                           # Rider dispatch, tracking, delivery lifecycle
+|   |   |   |-- RallyAPI.Delivery.Domain/
+|   |   |   |   |-- Abstractions/
+|   |   |   |   |-- Entities/
+|   |   |   |   |-- Enums/
+|   |   |   |   |-- Errors/
+|   |   |   |   \-- Events/
+|   |   |   |-- RallyAPI.Delivery.Application/
+|   |   |   |   |-- Commands/                   # AcceptDeliveryOffer, CreateDeliveryRequest,
+|   |   |   |   |                               # GetQuote, MarkDelivered, MarkFailed,
+|   |   |   |   |                               # MarkPickedUp, TriggerDispatch
+|   |   |   |   |-- DTOs/
+|   |   |   |   |-- EventHandlers/
+|   |   |   |   |-- Queries/                    # GetTrackingInfo
+|   |   |   |   \-- Services/
+|   |   |   |-- RallyAPI.Delivery.Endpoints/
+|   |   |   |   \-- Requests/
+|   |   |   \-- RallyAPI.Delivery.Infrastructure/
+|   |   |       |-- Migrations/
+|   |   |       |-- Persistence/
+|   |   |       |   \-- Configurations/
+|   |   |       |-- Repositories/
+|   |   |       \-- Services/
+|   |   |
+|   |   |-- Pricing/                            # Delivery fee calculation, surge pricing
+|   |   |   |-- RallyAPI.Pricing.Domain/
+|   |   |   |   |-- Abstractions/
+|   |   |   |   |-- Entities/
+|   |   |   |   |-- Enums/
+|   |   |   |   |-- Errors/
+|   |   |   |   |-- Repositories/
+|   |   |   |   \-- ValueObjects/
+|   |   |   |-- RallyAPI.Pricing.Application/
+|   |   |   |   |-- Abstractions/
+|   |   |   |   |-- DTOs/
+|   |   |   |   |-- Queries/                    # CalculateDeliveryFee
+|   |   |   |   |-- Rules/                      # Pricing rules engine
+|   |   |   |   \-- Services/
+|   |   |   |-- RallyAPI.Pricing.Endpoints/
+|   |   |   |   \-- Endpoints/
+|   |   |   \-- RallyAPI.Pricing.Infrastructure/
+|   |   |       |-- Persistence/
+|   |   |       |   \-- Configurations/
+|   |   |       |-- Providers/
+|   |   |       |-- Repositories/
+|   |   |       \-- Services/
+|   |   |
+|   |   |-- Users/                              # All user roles: auth, profiles, addresses, KYC
+|   |   |   |-- RallyAPI.Users.Domain/
+|   |   |   |   |-- Entities/
+|   |   |   |   |-- Enums/
+|   |   |   |   |-- Events/
+|   |   |   |   \-- ValueObjects/
+|   |   |   |-- RallyAPI.Users.Application/
+|   |   |   |   |-- Abstractions/
+|   |   |   |   |-- Admins/
+|   |   |   |   |   |-- Commands/               # CreateAdmin, CreateRestaurant, CreateRider, Login, UpdateRiderKyc
+|   |   |   |   |   \-- Queries/                # GetProfile, ListRestaurants, ListRiders
+|   |   |   |   |-- Auth/
+|   |   |   |   |   \-- Commands/               # RefreshToken, RevokeToken
+|   |   |   |   |-- Customers/
+|   |   |   |   |   |-- Commands/               # SendOtp, VerifyOtp, AddAddress, DeleteAddress,
+|   |   |   |   |   |                           # SetDefaultAddress, UpdateAddress, UpdateProfile
+|   |   |   |   |   \-- Queries/                # GetProfile, GetAddresses
+|   |   |   |   |-- Restaurants/
+|   |   |   |   |   |-- Commands/               # Login, SetAvailability, SetBusinessHours,
+|   |   |   |   |   |                           # UpdateProfile, UploadLogo
+|   |   |   |   |   \-- Queries/                # GetProfile
+|   |   |   |   \-- Riders/
+|   |   |   |       |-- Commands/               # SendOtp, VerifyOtp, GoOnline, GoOffline,
+|   |   |   |       |                           # UpdateLocation, UpdateProfile, UploadKyc
+|   |   |   |       \-- Queries/                # GetProfile
+|   |   |   |-- RallyAPI.Users.Endpoints/
+|   |   |   |   |-- Admins/
+|   |   |   |   |-- Auth/
+|   |   |   |   |-- Customers/
+|   |   |   |   |-- Restaurants/
+|   |   |   |   \-- Riders/
+|   |   |   \-- RallyAPI.Users.Infrastructure/
+|   |   |       |-- Persistence/
+|   |   |       |   |-- Configurations/
+|   |   |       |   |-- Migrations/
+|   |   |       |   \-- Repositories/
+|   |   |       \-- Services/
+|   |   |
+|   |   \-- Integrations/
+|   |       \-- ProRouting/                     # External route optimization
+|   |           \-- Models/
+|   |
+|   |-- RallyAPI.SharedKernel/                  # Cross-cutting concerns (shared by ALL modules)
+|   |   |-- Abstractions/
+|   |   |   |-- Delivery/
+|   |   |   |-- Distance/
+|   |   |   |-- Geocoding/                      # IGeocodingService, ReverseGeocodeResult, PlaceSuggestion, PlaceDetail
+|   |   |   |-- Notifications/
+|   |   |   |-- Orders/
+|   |   |   |-- Pricing/
+|   |   |   |-- Restaurants/
+|   |   |   \-- Riders/
+|   |   |-- Domain/
+|   |   |   \-- IntegrationEvents/
+|   |   |       |-- Delivery/
+|   |   |       \-- Orders/
+|   |   |-- Infrastructure/
+|   |   |-- Middleware/
+|   |   |-- Results/                            # Result<T> pattern
+|   |   |-- Storage/
+|   |   \-- Utilities/
+|   |
+|   \-- RallyAPI.Infrastructure/                # Shared infrastructure (Google Maps, Storage)
+|       |-- GoogleMaps/
+|       |   |-- Models/
+|       |   |-- GoogleMapsDistanceCalculator.cs  # Routes API (distance/duration)
+|       |   |-- GoogleGeocodingService.cs        # Geocoding + Places Autocomplete + Place Details
+|       |   \-- GoogleMapsOptions.cs
+|       \-- Storage/
+|
+|-- RallyAPI.Integrations.ProRouting.Tests/     # Integration tests
+|-- specs/                                       # Feature specifications
+\-- reviews/                                     # Daily AI workflow reviews
+```
+
+---
+
+## Module Responsibilities
+
+| Module | What It Owns | Key Entities |
+|--------|-------------|--------------|
+| **Catalog** | Restaurant listings, menus, menu items, search | Menu, MenuItem |
+| **Orders** | Order lifecycle, PayU payments, order queries | Order, OrderItem, Payment |
+| **Delivery** | Rider dispatch, delivery offers, tracking, status updates | DeliveryRequest, DeliveryOffer |
+| **Pricing** | Delivery fee calculation, surge pricing rules | PricingRule, DeliveryFee |
+| **Users** | All user types (Customer, Restaurant, Rider, Admin), auth, OTP, addresses, KYC | Customer, Restaurant, Rider, Admin, Address |
+| **Integrations/ProRouting** | External route optimization | ProRouting API models |
+
+## Cross-Module Communication
+
+Modules NEVER import each other's internal types. They communicate via:
+
+1. **SharedKernel.Abstractions/{ModuleName}/** — Shared interfaces per domain area
+2. **SharedKernel.Domain.IntegrationEvents/{ModuleName}/** — Cross-module events
+3. **MediatR Notifications** — Domain events published in one module, handled in another
+
+| From | To | Via | Example |
+|------|----|-----|---------|
+| Orders | Delivery | IntegrationEvent (via SharedKernel) | Order confirmed -> Create delivery request (skipped for pickup orders) |
+| Orders | Pricing | SharedKernel.Abstractions.Pricing | Get delivery fee during order placement |
+| Delivery | Orders | IntegrationEvent (via SharedKernel) | Rider picked up -> Update order status |
+| Users | (all) | SharedKernel.Abstractions | Auth/profile lookups via shared interfaces |
+
+---
+
+## Key Architecture Rules
+
+1. **Module boundaries are STRICT.** Never reference `RallyAPI.Orders.Domain` from `RallyAPI.Delivery.Application`. Use SharedKernel abstractions or integration events.
+2. **CQRS via MediatR.** Every write = Command + Handler. Every read = Query + Handler. Handlers in `Application/`.
+3. **Domain layer has ZERO dependencies.** No EF Core, no MediatR, no external packages in any `.Domain` project.
+4. **FluentValidation for all commands.** Validators live next to their command in `Application/Commands/{CommandName}/`.
+5. **Repository pattern.** Interfaces in `Domain/Repositories/` (Orders) or `Application/Abstractions/` (other modules). Implementations in `Infrastructure/`.
+6. **Endpoints are THIN.** Deserialize -> `mediator.Send(command)` -> return response. Zero business logic.
+7. **Result<T> pattern.** Use `SharedKernel.Results` for handler return types. No exceptions for business errors.
+8. **PayU webhook is the source of truth.** Never trust frontend payment redirect alone. Verify via S2S webhook in `Orders.Infrastructure/Services/PayU/`.
+9. **Users module uses sub-grouping.** Commands/Queries are organized by role: `Admins/`, `Customers/`, `Restaurants/`, `Riders/`, plus shared `Auth/`.
+
+## EF Core Conventions
+
+- DbContext per module (e.g., `CatalogDbContext` in `Catalog.Infrastructure/Persistence/`)
+- Entity configs via `IEntityTypeConfiguration<T>` in `Persistence/Configurations/` or `Configurations/`
+- Migrations per module in `Infrastructure/Migrations/`
+- `DateTimeOffset` for ALL timestamps, never `DateTime`
+- Soft delete via `IsDeleted` + global query filter
+- Audit fields: `CreatedAt`, `UpdatedAt`, `CreatedBy`, `UpdatedBy`
+- Decimal precision: `.HasPrecision(18, 2)` for money
+
+## Auth Pattern
+
+- RSA keys stored in `RallyAPI.Host/Keys/`
+- RS256 JWT with RSA-2048 asymmetric signing
+- Access token (short-lived) + Refresh token (long-lived, rotated)
+- Theft detection: reused refresh token -> revoke entire token family
+- BCrypt for passwords (restaurant/admin login via `Restaurants/Commands/Login`, `Admins/Commands/Login`)
+- SHA256 for OTP hashing (customer/rider via `Customers/Commands/SendOtp+VerifyOtp`, `Riders/Commands/SendOtp+VerifyOtp`)
+- Auth endpoints in `Users.Endpoints/Auth/` (RefreshToken, RevokeToken)
+
+## Payment Flow (PayU India)
+
+1. `InitiatePayment` command -> creates PayU hash -> returns redirect URL
+2. Frontend redirects to PayU Hosted Checkout
+3. User pays -> PayU redirects back to frontend
+4. PayU sends S2S webhook -> `ProcessPayuWebhook` command
+5. `VerifyPayment` validates hash -> updates order + payment status
+6. `RefundPayment` for cancellations
+7. All PayU code in: `Orders.Infrastructure/Services/PayU/`
+
+## Order Fulfillment (Delivery vs Pickup)
+
+Orders have a `FulfillmentType` enum: `Delivery` (default) or `Pickup`.
+
+### Status Flow by Fulfillment Type
+```
+Delivery: Paid → Confirmed → Preparing → ReadyForPickup → PickedUp → Delivered
+Pickup:   Paid → Confirmed → Preparing → ReadyForPickup → Delivered (skip rider)
+```
+
+### Key Rules
+- **Pickup orders have NO DeliveryInfo** — `Order.DeliveryInfo` is nullable. Always null-check before accessing.
+- **No DeliveryRequest created** for pickup orders — `OrderConfirmedIntegrationEventHandler` checks `IsPickupOrder` and returns early.
+- **No rider assignment** for pickup orders — `AssignRider()`, `MarkPickedUp()`, `UpdateRiderInfo()` throw if `FulfillmentType == Pickup`.
+- **DeliveryFee should be 0** for pickup orders — frontend must send `deliveryFee: 0` in pricing.
+- **Customer pickup endpoint**: `PUT /api/orders/{id}/customer-pickup` (authorized: Admin or Restaurant) — transitions `ReadyForPickup → Delivered`.
+- **Backward compatible**: `FulfillmentType` defaults to `Delivery` if omitted in request. Existing orders default to `Delivery` in the database.
+
+### Pickup Order Request (Frontend)
+```json
+POST /api/orders
+{
+  "fulfillmentType": "Pickup",
+  "restaurantId": "...",
+  "pickupLatitude": 28.63,
+  "pickupLongitude": 77.21,
+  "pickupPincode": "110001",
+  "items": [...],
+  "pricing": { "subTotal": 500, "deliveryFee": 0, ... },
+  "paymentId": "..."
+}
+```
+Note: `deliveryAddress` is NOT required for pickup orders.
+
+---
+
+## Google Maps Address Integration
+
+Server-side proxy for Google Maps APIs. The Google API key stays on the backend — frontend never calls Google directly.
+
+### Geocoding Endpoints
+
+| Endpoint | Auth | Purpose |
+|----------|------|---------|
+| `GET /api/places/autocomplete?input=&lat=&lng=` | Customer | Type-ahead address search. Returns up to 5 suggestions with `placeId`, `description`, `mainText`, `secondaryText`. Biased to India. |
+| `GET /api/places/{placeId}` | Customer | Resolve a Place ID to full details: `formattedAddress`, `latitude`, `longitude`, `locality`, `pincode`. |
+| `GET /api/geocode/reverse?lat=&lng=` | Customer | Pin drop → formatted address. Returns `formattedAddress`, `placeId`, `locality`, `pincode`. India bounds validated. |
+
+### Address Entry Flow (Frontend)
+
+Two address entry methods (both supported):
+
+**Method A — Autocomplete (user types):**
+1. User types → `GET /api/places/autocomplete?input=Koramangala`
+2. Show suggestions dropdown
+3. User selects → `GET /api/places/{placeId}` to get lat/lng
+4. Pre-fill address form with `formattedAddress`, `latitude`, `longitude`, `placeId`
+5. User adds label (Home/Work/Other) and optional landmark
+6. `POST /api/customers/addresses` with all fields including `placeId`
+
+**Method B — Pin drop (user taps map):**
+1. User drops pin on map → capture lat/lng
+2. `GET /api/geocode/reverse?lat=12.93&lng=77.63`
+3. Pre-fill `formattedAddress` and `placeId`
+4. User confirms/edits, adds label and landmark
+5. `POST /api/customers/addresses`
+
+### Address Value Object
+
+```json
+{
+  "addressLine": "123 MG Road, Koramangala",
+  "landmark": "Near Forum Mall",
+  "latitude": 12.9352,
+  "longitude": 77.6245,
+  "label": "Home",
+  "placeId": "ChIJLfyY2E4UrjsRVq4AjI7zgRY"
+}
+```
+
+`PlaceId` is optional but recommended — allows re-fetching details and avoids duplicate geocoding.
+
+---
+
+## Common Commands (Windows PowerShell)
+
+```powershell
+# Backend
+dotnet run --project src/RallyAPI.Host                              # Start API
+dotnet build                                                         # Build all
+dotnet test                                                          # Run all tests
+
+# EF Core Migrations (per module)
+dotnet ef migrations add MigrationName `
+  --context CatalogDbContext `
+  --project src/Modules/Catalog/RallyAPI.Catalog.Infrastructure `
+  --startup-project src/RallyAPI.Host
+
+dotnet ef database update `
+  --context CatalogDbContext `
+  --startup-project src/RallyAPI.Host
+
+# Docker (local dev)
+docker compose up -d                         # Start Postgres + Redis
+docker compose down
+
+# Railway
+railway up                                   # Deploy
+railway logs                                 # View logs
+```
+
+## Environment Variables
+
+```
+DATABASE_URL=postgresql://...
+REDIS_URL=redis://...
+JWT_ISSUER=rally-api
+JWT_AUDIENCE=rally-app
+JWT_ACCESS_TOKEN_EXPIRY_MINUTES=15
+JWT_REFRESH_TOKEN_EXPIRY_DAYS=30
+PAYU_MERCHANT_KEY=
+PAYU_MERCHANT_SALT=
+PAYU_BASE_URL=
+GOOGLE_MAPS_API_KEY=
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY=
+R2_SECRET_KEY=
+R2_BUCKET_NAME=
+MSG91_AUTH_KEY=
+MSG91_TEMPLATE_ID=
+```
+
+---
+
+## AI Agent Instructions
+
+### Before Writing Any Code
+
+1. **Read this entire file** — understand the modular monolith structure.
+2. **Search existing code** — Grep/Glob for related handlers, entities, endpoints. Don't create duplicates.
+3. **Identify the correct module** — Catalog? Orders? Delivery? Users? Pricing?
+4. **Follow the layer order** — Domain -> Application -> Infrastructure -> Endpoints.
+5. **Check existing patterns** — Look at how similar features are implemented in the same module.
+
+### When Adding a Feature to an Existing Module
+
+1. Check `specs/` for a spec
+2. Look at existing commands/queries in that module for the pattern to follow
+3. Create Domain changes first (if any), then Application (Command + Handler + Validator), then Infrastructure, then Endpoint
+4. FluentValidation validator for EVERY new command
+5. `dotnet build` then `dotnet test`
+
+### When Creating a New Module (e.g., Notifications for SignalR)
+
+1. Create four projects:
+   - `src/Modules/{Name}/RallyAPI.{Name}.Domain`
+   - `src/Modules/{Name}/RallyAPI.{Name}.Application`
+   - `src/Modules/{Name}/RallyAPI.{Name}.Infrastructure`
+   - `src/Modules/{Name}/RallyAPI.{Name}.Endpoints`
+2. Add shared abstractions to `SharedKernel/Abstractions/{Name}/` if needed
+3. Add integration events to `SharedKernel/Domain/IntegrationEvents/{Name}/` if needed
+4. Register services in `RallyAPI.Host/Program.cs`
+5. Add to solution file
+
+## Common Mistakes
+
+Mistakes observed in practice. Check these before writing test or module code.
+
+### 1. Test Project `ProjectReference` depth is 4 levels, not 3
+
+Test projects live at `tests/Modules/{Module}/RallyAPI.{Module}.Tests/`.
+That is **4 directories deep** from the repo root, so the path to `src/` is `../../../../src/`.
+
+```xml
+<!-- WRONG — only 3 levels up -->
+<ProjectReference Include="../../../src/Modules/Orders/RallyAPI.Orders.Domain/..." />
+
+<!-- CORRECT -->
+<ProjectReference Include="../../../../src/Modules/Orders/RallyAPI.Orders.Domain/..." />
+```
+
+### 2. Always read the enum file before using enum values
+
+Enum member names are not guessable. Wrong names compile only if you misread the type.
+Always `grep` or open the enum file first.
+
+```csharp
+// WRONG — "CustomerRequest" does not exist
+order.Cancel(CancellationReason.CustomerRequest, ...);
+
+// CORRECT — the actual member name
+order.Cancel(CancellationReason.CustomerRequested, ...);
+```
+
+Same rule applies to `OrderStatus`, `PaymentStatus`, `DeliveryStatus`, `FleetType`, etc.
+When writing tests that send enum values as JSON strings, the string must exactly match the C# member name (e.g. `"CustomerRequested"`, not `"Changed my mind"`).
+
+### 3. xUnit needs an explicit `using Xunit;`
+
+xUnit is **not** included in `ImplicitUsings`. Every test file must have it explicitly.
+
+```csharp
+using Xunit; // required — not pulled in by ImplicitUsings
+```
+
+FluentAssertions and NSubstitute also need explicit usings:
+
+```csharp
+using FluentAssertions;
+using NSubstitute;
+```
+
+### 4. Microsoft.Extensions packages require version 8.0.2 in test projects
+
+Do **not** pin `Microsoft.Extensions.*` packages to `8.0.0` in test project `.csproj` files.
+The transitive dependency chain (e.g. `SharedKernel → Extensions.Logging 8.0.1 → Abstractions >= 8.0.2`) requires at least `8.0.2`, causing a restore failure if you pin lower.
+
+```xml
+<!-- WRONG — causes NuGet restore failure -->
+<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+
+<!-- CORRECT — omit the reference and let NuGet resolve transitively -->
+<!-- Or pin to 8.0.2 if an explicit reference is truly needed -->
+<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+```
+
+### 5. Never call SaveChangesAsync after ExecuteDeleteAsync
+
+`ExecuteDeleteAsync` (EF Core 7+) executes a `DELETE` directly against the database — it does not go through the change tracker. Calling `SaveChangesAsync` afterwards is a no-op at best and misleading at worst.
+
+```csharp
+// WRONG
+await _context.CartItems.Where(x => x.CartId == cartId).ExecuteDeleteAsync(ct);
+await _context.SaveChangesAsync(ct); // ← unnecessary, remove it
+
+// CORRECT
+await _context.CartItems.Where(x => x.CartId == cartId).ExecuteDeleteAsync(ct);
+```
+
+Same rule applies to `ExecuteUpdateAsync`.
+
+### 6. Always specify schema in manual SQL migrations
+
+When writing a raw SQL migration (e.g. `migrationBuilder.Sql(...)`), always qualify table names with their schema. Without the schema, Postgres defaults to `public` and the statement silently targets the wrong table or throws.
+
+```csharp
+// WRONG — targets public."Carts" if schema is "orders"
+migrationBuilder.Sql("CREATE INDEX ...");
+
+// CORRECT — always qualify
+migrationBuilder.Sql(@"CREATE INDEX ... ON orders.""Carts"" ...");
+// For the users module:
+migrationBuilder.Sql(@"ALTER TABLE users.""Riders"" ...");
+```
+
+### 7. Add JsonStringEnumConverter to BOTH JSON option chains in Program.cs
+
+`Program.cs` configures JSON serialization in two places. Missing either one causes enum values to serialize as integers in some responses.
+
+```csharp
+// Both chains must include the converter:
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.Converters.Add(new JsonStringEnumConverter()); // ← required here
+});
+
+builder.Services.AddControllers().AddJsonOptions(options =>
+{
+    options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()); // ← AND here
+});
+```
+
+### Security Checklist (ALWAYS)
+
+- [ ] No secrets in code — use environment variables or `Host/Keys/`
+- [ ] All command inputs validated with FluentValidation
+- [ ] Auth required on endpoint (`.RequireAuthorization("RoleName")`)
+- [ ] PayU webhook hash verified in `ProcessPayuWebhook`
+- [ ] Rate limiting on OTP endpoints (SendOtp)
+- [ ] CORS configured for allowed origins only

--- a/reviews/2026-03-24.md
+++ b/reviews/2026-03-24.md
@@ -1,0 +1,80 @@
+# Daily AI Workflow Review — Rally
+
+> 10-15 min every day. Save as `reviews/YYYY-MM-DD.md`
+
+---
+
+## Date: 2026-03-24
+
+## 1. What did AI build today?
+
+| Task | Tool Used | Module | Time Saved (est.) | Quality (1-5) |
+|------|-----------|--------|-------------------|----------------|
+| Google Maps Geocoding service (reverse geocode, autocomplete, place details) | Claude Code | SharedKernel + Infrastructure | 2-3 hrs | 5 |
+| 3 new geocoding API endpoints (autocomplete, reverse geocode, place detail) | Claude Code | Users.Endpoints | 1 hr | 5 |
+| PlaceId added to Address value object + EF config + migration | Claude Code | Users.Domain + Infrastructure | 30 min | 5 |
+| Updated AddAddress/UpdateAddress commands + handlers + endpoints for PlaceId | Claude Code | Users.Application + Endpoints | 30 min | 5 |
+| Updated GetProfile + GetAddresses to return PlaceId | Claude Code | Users.Application | 15 min | 5 |
+| CLAUDE.md updated with geocoding architecture + endpoints | Claude Code | Documentation | 15 min | 5 |
+| Notion dev log (MAR 24) | Claude Code | Documentation | 20 min | 5 |
+
+**Total: Full Google Maps address integration (7 new files, 8 modified), documentation updates**
+
+---
+
+## 2. Where did AI go wrong?
+
+- No errors this session. All 60 unit tests passed.
+- Pre-existing OtpServiceTests build error (missing `IHostEnvironment` parameter) still present — not from our changes.
+- Migration created manually (same as Mar 23 — Redis not running locally blocks `dotnet ef migrations add`).
+
+**What to add to CLAUDE.md to prevent this:**
+> Nothing new — patterns followed correctly.
+
+## 3. Context Engineering Updates
+
+### CLAUDE.md
+- [x] Added Google Maps Geocoding + Places Autocomplete to Planned/In Progress
+- [x] Added Customer Pickup Orders to Planned/In Progress
+- [x] Added Geocoding abstractions to SharedKernel in project structure
+- [x] Added GoogleGeocodingService to Infrastructure in project structure
+- [x] Added new "Google Maps Address Integration" section with endpoints, flow, and value object docs
+
+### New Spec Needed?
+- [ ] None — implementation was straightforward, well-scoped
+
+### New Rule Needed?
+- [x] Google Maps API key must NEVER be exposed to frontend — all calls proxied through backend
+
+## 4. Tool Check
+
+### Claude Code
+- [x] MCP servers connected? (Notion)
+- [ ] GitHub CLI not authenticated — need `gh auth login` for PR creation
+- [x] Using `/compact` between tasks?
+- [x] Using model for complex architecture
+
+## 5. Weekly Metrics (fill on Fridays)
+
+| Metric | This Week | Last Week |
+|--------|-----------|-----------|
+| Backend endpoints shipped | 4 (3 geocoding + 1 customer-pickup) | |
+| Frontend pages/components shipped | 0 | |
+| Bugs caught by AI review | 0 | |
+| Hours saved (estimate) | 5-6 hrs | |
+| Token cost ($) | | |
+| CLAUDE.md updates made | 5 | |
+
+## 6. Tomorrow
+
+### Priority tasks:
+1. Create PRs for feat/pickup-orders and feat/maps-address (set up gh auth first)
+2. Run migrations on Railway after merge
+3. Frontend dev: share geocoding API contract for address integration
+
+### Specs to write first:
+- [ ] Restaurant dashboard spec (incoming orders page)
+
+### Tool assignments:
+- Claude Code: PR creation, frontend spec
+- Claude Chat: Architecture for restaurant dashboard

--- a/src/Modules/Users/RallyAPI.Users.Application/Customers/Commands/AddAddress/AddCustomerAddressCommand.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Customers/Commands/AddAddress/AddCustomerAddressCommand.cs
@@ -9,4 +9,5 @@ public sealed record AddCustomerAddressCommand(
     string? Landmark,
     decimal Latitude,
     decimal Longitude,
-    string Label) : IRequest<Result<Guid>>;
+    string Label,
+    string? PlaceId = null) : IRequest<Result<Guid>>;

--- a/src/Modules/Users/RallyAPI.Users.Application/Customers/Commands/AddAddress/AddCustomerAddressCommandHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Customers/Commands/AddAddress/AddCustomerAddressCommandHandler.cs
@@ -30,7 +30,8 @@ internal sealed class AddCustomerAddressCommandHandler
             request.Landmark,
             request.Latitude,
             request.Longitude,
-            request.Label);
+            request.Label,
+            request.PlaceId);
 
         if (addressResult.IsFailure)
             return Result.Failure<Guid>(addressResult.Error);

--- a/src/Modules/Users/RallyAPI.Users.Application/Customers/Commands/UpdateAddress/UpdateCustomerAddressCommand.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Customers/Commands/UpdateAddress/UpdateCustomerAddressCommand.cs
@@ -12,4 +12,5 @@ public sealed record UpdateCustomerAddressCommand(
     string? Landmark,
     decimal Latitude,
     decimal Longitude,
-    string Label) : IRequest<Result>;
+    string Label,
+    string? PlaceId = null) : IRequest<Result>;

--- a/src/Modules/Users/RallyAPI.Users.Application/Customers/Commands/UpdateAddress/UpdateCustomerAddressCommandHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Customers/Commands/UpdateAddress/UpdateCustomerAddressCommandHandler.cs
@@ -40,7 +40,8 @@ internal sealed class UpdateCustomerAddressCommandHandler
             request.Landmark,
             request.Latitude,
             request.Longitude,
-            request.Label);
+            request.Label,
+            request.PlaceId);
 
         if (newAddress.IsFailure)
             return Result.Failure(newAddress.Error);

--- a/src/Modules/Users/RallyAPI.Users.Application/Customers/Queries/GetAddresses/GetCustomerAddressesQueryHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Customers/Queries/GetAddresses/GetCustomerAddressesQueryHandler.cs
@@ -39,7 +39,8 @@ internal sealed class GetCustomerAddressesQueryHandler
                 a.Address.Latitude,
                 a.Address.Longitude,
                 a.Address.Label,
-                a.IsDefault))
+                a.IsDefault,
+                a.Address.PlaceId))
             .ToList();
 
         return Result<List<CustomerAddressResponse>>.Success(addresses);

--- a/src/Modules/Users/RallyAPI.Users.Application/Customers/Queries/GetProfile/GetCustomerProfileQuery.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Customers/Queries/GetProfile/GetCustomerProfileQuery.cs
@@ -20,4 +20,5 @@ public sealed record CustomerAddressResponse(
     decimal Latitude,
     decimal Longitude,
     string Label,
-    bool IsDefault);
+    bool IsDefault,
+    string? PlaceId = null);

--- a/src/Modules/Users/RallyAPI.Users.Application/Customers/Queries/GetProfile/GetCustomerProfileQueryHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Customers/Queries/GetProfile/GetCustomerProfileQueryHandler.cs
@@ -29,7 +29,8 @@ internal sealed class GetCustomerProfileQueryHandler
             a.Address.Latitude,
             a.Address.Longitude,
             a.Address.Label,
-            a.IsDefault)).ToList();
+            a.IsDefault,
+            a.Address.PlaceId)).ToList();
 
         var response = new CustomerProfileResponse(
             customer.Id,

--- a/src/Modules/Users/RallyAPI.Users.Domain/ValueObjects/Address.cs
+++ b/src/Modules/Users/RallyAPI.Users.Domain/ValueObjects/Address.cs
@@ -10,19 +10,22 @@ public sealed class Address : ValueObject
     public decimal Latitude { get; }
     public decimal Longitude { get; }
     public string Label { get; } // Home, Work, Other
+    public string? PlaceId { get; } // Google Places ID for re-fetching details
 
     private Address(
         string addressLine,
         string? landmark,
         decimal latitude,
         decimal longitude,
-        string label)
+        string label,
+        string? placeId)
     {
         AddressLine = addressLine;
         Landmark = landmark;
         Latitude = latitude;
         Longitude = longitude;
         Label = label;
+        PlaceId = placeId;
     }
 
     public static Result<Address> Create(
@@ -30,7 +33,8 @@ public sealed class Address : ValueObject
         string? landmark,
         decimal latitude,
         decimal longitude,
-        string? label)
+        string? label,
+        string? placeId = null)
     {
         if (string.IsNullOrWhiteSpace(addressLine))
             return Result.Failure<Address>(Error.Validation("Address line is required."));
@@ -47,7 +51,7 @@ public sealed class Address : ValueObject
 
         var validLabels = new[] { "Home", "Work", "Other" };
         var normalizedLabel = label?.Trim() ?? "Other";
-        
+
         if (!validLabels.Contains(normalizedLabel, StringComparer.OrdinalIgnoreCase))
             normalizedLabel = "Other";
 
@@ -56,7 +60,8 @@ public sealed class Address : ValueObject
             landmark?.Trim(),
             latitude,
             longitude,
-            normalizedLabel);
+            normalizedLabel,
+            placeId?.Trim());
     }
 
     protected override IEnumerable<object> GetEqualityComponents()
@@ -66,5 +71,6 @@ public sealed class Address : ValueObject
         yield return Latitude;
         yield return Longitude;
         yield return Label;
+        yield return PlaceId ?? string.Empty;
     }
 }

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Customers/AddAddress.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Customers/AddAddress.cs
@@ -24,7 +24,8 @@ public class AddAddress : IEndpoint
         decimal Latitude,
         decimal Longitude,
         string Label,
-        bool IsDefault);
+        bool IsDefault,
+        string? PlaceId = null);
 
     private static async Task<IResult> HandleAsync(
         AddCustomerAddressRequest request,
@@ -43,7 +44,8 @@ public class AddAddress : IEndpoint
             request.Landmark,
             request.Latitude,
             request.Longitude,
-            request.Label);
+            request.Label,
+            request.PlaceId);
         //Removed this parameter        request.IsDefault
 
     var result = await sender.Send(command, cancellationToken);

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Customers/PlaceDetail.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Customers/PlaceDetail.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Abstractions.Geocoding;
+
+namespace RallyAPI.Users.Endpoints.Customers;
+
+public class PlaceDetail : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/places/{placeId}", HandleAsync)
+            .WithName("GetPlaceDetail")
+            .WithTags("Geocoding")
+            .RequireAuthorization("Customer");
+    }
+
+    private static async Task<IResult> HandleAsync(
+        string placeId,
+        IGeocodingService geocodingService,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(placeId))
+            return Results.BadRequest(new { error = "Place ID is required" });
+
+        var detail = await geocodingService.GetPlaceDetailAsync(placeId, cancellationToken);
+
+        if (detail is null)
+            return Results.NotFound(new { error = "Place not found" });
+
+        return Results.Ok(new
+        {
+            placeId = detail.PlaceId,
+            formattedAddress = detail.FormattedAddress,
+            latitude = detail.Latitude,
+            longitude = detail.Longitude,
+            locality = detail.Locality,
+            pincode = detail.Pincode
+        });
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Customers/PlacesAutocomplete.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Customers/PlacesAutocomplete.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Abstractions.Geocoding;
+
+namespace RallyAPI.Users.Endpoints.Customers;
+
+public class PlacesAutocomplete : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/places/autocomplete", HandleAsync)
+            .WithName("PlacesAutocomplete")
+            .WithTags("Geocoding")
+            .RequireAuthorization("Customer");
+    }
+
+    private static async Task<IResult> HandleAsync(
+        string input,
+        double? lat,
+        double? lng,
+        IGeocodingService geocodingService,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(input) || input.Length < 2)
+            return Results.BadRequest(new { error = "Input must be at least 2 characters" });
+
+        var suggestions = await geocodingService.AutocompleteAsync(
+            input, lat, lng, maxResults: 5, ct: cancellationToken);
+
+        return Results.Ok(new { suggestions });
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Customers/ReverseGeocode.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Customers/ReverseGeocode.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Abstractions.Geocoding;
+
+namespace RallyAPI.Users.Endpoints.Customers;
+
+public class ReverseGeocode : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/geocode/reverse", HandleAsync)
+            .WithName("ReverseGeocode")
+            .WithTags("Geocoding")
+            .RequireAuthorization("Customer");
+    }
+
+    private static async Task<IResult> HandleAsync(
+        double lat,
+        double lng,
+        IGeocodingService geocodingService,
+        CancellationToken cancellationToken)
+    {
+        if (lat < 6 || lat > 38 || lng < 68 || lng > 98)
+            return Results.BadRequest(new { error = "Coordinates outside India bounds" });
+
+        var result = await geocodingService.ReverseGeocodeAsync(lat, lng, cancellationToken);
+
+        if (!result.IsSuccess)
+            return Results.BadRequest(new { error = result.Error });
+
+        return Results.Ok(new
+        {
+            formattedAddress = result.FormattedAddress,
+            placeId = result.PlaceId,
+            locality = result.Locality,
+            pincode = result.Pincode
+        });
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Customers/UpdateAddress.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Customers/UpdateAddress.cs
@@ -25,7 +25,8 @@ public class UpdateAddress : IEndpoint
         string? Landmark,
         decimal Latitude,
         decimal Longitude,
-        string Label);
+        string Label,
+        string? PlaceId = null);
 
     private static async Task<IResult> HandleAsync(
         Guid addressId,
@@ -45,7 +46,8 @@ public class UpdateAddress : IEndpoint
             request.Landmark,
             request.Latitude,
             request.Longitude,
-            request.Label);
+            request.Label,
+            request.PlaceId);
 
         var result = await sender.Send(command, cancellationToken);
 

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Configurations/CustomerAddressConfiguration.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Configurations/CustomerAddressConfiguration.cs
@@ -50,6 +50,11 @@ public class CustomerAddressConfiguration : IEntityTypeConfiguration<CustomerAdd
              .HasColumnName("label")
              .HasMaxLength(50)
              .IsRequired();
+
+            addressBuilder.Property(addr => addr.PlaceId)
+                .HasColumnName("place_id")
+                .HasMaxLength(300)
+                .IsRequired(false);
         });
 
         // IsDefault

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Migrations/20260324100000_AddPlaceIdToCustomerAddresses.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Migrations/20260324100000_AddPlaceIdToCustomerAddresses.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RallyAPI.Users.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPlaceIdToCustomerAddresses : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "place_id",
+                schema: "users",
+                table: "customer_addresses",
+                type: "character varying(300)",
+                maxLength: 300,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "place_id",
+                schema: "users",
+                table: "customer_addresses");
+        }
+    }
+}

--- a/src/RallyAPI.Infrastructure/DependencyInjection.cs
+++ b/src/RallyAPI.Infrastructure/DependencyInjection.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using RallyAPI.Infrastructure.GoogleMaps;
 using RallyAPI.Infrastructure.Storage;
 using RallyAPI.SharedKernel.Abstractions.Distance;
+using RallyAPI.SharedKernel.Abstractions.Geocoding;
 
 namespace RallyAPI.Infrastructure;
 
@@ -16,10 +17,17 @@ public static class DependencyInjection
         services.Configure<GoogleMapsOptions>(
             configuration.GetSection(GoogleMapsOptions.SectionName));
 
+        var timeout = TimeSpan.FromSeconds(
+            configuration.GetValue<int>("GoogleMaps:TimeoutSeconds", 10));
+
         services.AddHttpClient<IDistanceCalculator, GoogleMapsDistanceCalculator>(client =>
         {
-            client.Timeout = TimeSpan.FromSeconds(
-                configuration.GetValue<int>("GoogleMaps:TimeoutSeconds", 10));
+            client.Timeout = timeout;
+        });
+
+        services.AddHttpClient<IGeocodingService, GoogleGeocodingService>(client =>
+        {
+            client.Timeout = timeout;
         });
 
         services.AddStorageServices(configuration);

--- a/src/RallyAPI.Infrastructure/GoogleMaps/GoogleGeocodingService.cs
+++ b/src/RallyAPI.Infrastructure/GoogleMaps/GoogleGeocodingService.cs
@@ -1,0 +1,281 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RallyAPI.SharedKernel.Abstractions.Geocoding;
+
+namespace RallyAPI.Infrastructure.GoogleMaps;
+
+/// <summary>
+/// Google Maps Geocoding + Places (New) API implementation.
+/// Proxies requests server-side so the API key never reaches the browser.
+/// </summary>
+public sealed class GoogleGeocodingService : IGeocodingService
+{
+    private readonly HttpClient _httpClient;
+    private readonly GoogleMapsOptions _options;
+    private readonly ILogger<GoogleGeocodingService> _logger;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public GoogleGeocodingService(
+        HttpClient httpClient,
+        IOptions<GoogleMapsOptions> options,
+        ILogger<GoogleGeocodingService> logger)
+    {
+        _httpClient = httpClient;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<ReverseGeocodeResult> ReverseGeocodeAsync(
+        double latitude, double longitude, CancellationToken ct = default)
+    {
+        if (!_options.Enabled)
+            return ReverseGeocodeResult.Failure("Google Maps API is disabled");
+
+        try
+        {
+            var url = $"https://maps.googleapis.com/maps/api/geocode/json" +
+                      $"?latlng={latitude},{longitude}" +
+                      $"&key={_options.ApiKey}" +
+                      $"&region={_options.Region}" +
+                      $"&language=en";
+
+            var response = await _httpClient.GetFromJsonAsync<GeocodeApiResponse>(url, JsonOptions, ct);
+
+            if (response?.Status != "OK" || response.Results is not { Count: > 0 })
+            {
+                _logger.LogWarning("Reverse geocode failed: status={Status}", response?.Status);
+                return ReverseGeocodeResult.Failure(response?.Status ?? "Empty response");
+            }
+
+            var best = response.Results[0];
+            var locality = ExtractComponent(best, "locality");
+            var pincode = ExtractComponent(best, "postal_code");
+
+            return ReverseGeocodeResult.Success(
+                best.FormattedAddress,
+                best.PlaceId,
+                locality,
+                pincode);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Reverse geocode error for ({Lat}, {Lng})", latitude, longitude);
+            return ReverseGeocodeResult.Failure("Geocoding service unavailable");
+        }
+    }
+
+    public async Task<IReadOnlyList<PlaceSuggestion>> AutocompleteAsync(
+        string input,
+        double? sessionLatitude = null,
+        double? sessionLongitude = null,
+        int maxResults = 5,
+        CancellationToken ct = default)
+    {
+        if (!_options.Enabled)
+            return [];
+
+        try
+        {
+            var url = $"https://maps.googleapis.com/maps/api/place/autocomplete/json" +
+                      $"?input={Uri.EscapeDataString(input)}" +
+                      $"&key={_options.ApiKey}" +
+                      $"&components=country:in" +
+                      $"&language=en";
+
+            if (sessionLatitude.HasValue && sessionLongitude.HasValue)
+            {
+                url += $"&location={sessionLatitude.Value},{sessionLongitude.Value}&radius=50000";
+            }
+
+            var response = await _httpClient.GetFromJsonAsync<AutocompleteApiResponse>(url, JsonOptions, ct);
+
+            if (response?.Status != "OK" || response.Predictions is null)
+            {
+                _logger.LogWarning("Autocomplete failed: status={Status}", response?.Status);
+                return [];
+            }
+
+            return response.Predictions
+                .Take(maxResults)
+                .Select(p => new PlaceSuggestion(
+                    p.PlaceId,
+                    p.Description,
+                    p.StructuredFormatting?.MainText ?? p.Description,
+                    p.StructuredFormatting?.SecondaryText ?? string.Empty))
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Autocomplete error for input: {Input}", input);
+            return [];
+        }
+    }
+
+    public async Task<PlaceDetail?> GetPlaceDetailAsync(string placeId, CancellationToken ct = default)
+    {
+        if (!_options.Enabled)
+            return null;
+
+        try
+        {
+            var url = $"https://maps.googleapis.com/maps/api/place/details/json" +
+                      $"?place_id={Uri.EscapeDataString(placeId)}" +
+                      $"&key={_options.ApiKey}" +
+                      $"&fields=place_id,formatted_address,geometry,address_components" +
+                      $"&language=en";
+
+            var response = await _httpClient.GetFromJsonAsync<PlaceDetailApiResponse>(url, JsonOptions, ct);
+
+            if (response?.Status != "OK" || response.Result is null)
+            {
+                _logger.LogWarning("Place detail failed: status={Status}", response?.Status);
+                return null;
+            }
+
+            var r = response.Result;
+            var locality = ExtractComponent(r, "locality");
+            var pincode = ExtractComponent(r, "postal_code");
+
+            return new PlaceDetail(
+                r.PlaceId,
+                r.FormattedAddress,
+                r.Geometry.Location.Lat,
+                r.Geometry.Location.Lng,
+                locality,
+                pincode);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Place detail error for placeId: {PlaceId}", placeId);
+            return null;
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────
+
+    private static string? ExtractComponent(GeocodeResult result, string type)
+    {
+        return result.AddressComponents?
+            .FirstOrDefault(c => c.Types.Contains(type))?
+            .LongName;
+    }
+
+    private static string? ExtractComponent(PlaceDetailResult result, string type)
+    {
+        return result.AddressComponents?
+            .FirstOrDefault(c => c.Types.Contains(type))?
+            .LongName;
+    }
+
+    // ── Google API response DTOs ────────────────────────────
+
+    private sealed class GeocodeApiResponse
+    {
+        [JsonPropertyName("status")]
+        public string Status { get; set; } = string.Empty;
+
+        [JsonPropertyName("results")]
+        public List<GeocodeResult> Results { get; set; } = new();
+    }
+
+    private sealed class GeocodeResult
+    {
+        [JsonPropertyName("formatted_address")]
+        public string FormattedAddress { get; set; } = string.Empty;
+
+        [JsonPropertyName("place_id")]
+        public string PlaceId { get; set; } = string.Empty;
+
+        [JsonPropertyName("address_components")]
+        public List<AddressComponent>? AddressComponents { get; set; }
+    }
+
+    private sealed class AutocompleteApiResponse
+    {
+        [JsonPropertyName("status")]
+        public string Status { get; set; } = string.Empty;
+
+        [JsonPropertyName("predictions")]
+        public List<AutocompletePrediction>? Predictions { get; set; }
+    }
+
+    private sealed class AutocompletePrediction
+    {
+        [JsonPropertyName("place_id")]
+        public string PlaceId { get; set; } = string.Empty;
+
+        [JsonPropertyName("description")]
+        public string Description { get; set; } = string.Empty;
+
+        [JsonPropertyName("structured_formatting")]
+        public StructuredFormatting? StructuredFormatting { get; set; }
+    }
+
+    private sealed class StructuredFormatting
+    {
+        [JsonPropertyName("main_text")]
+        public string MainText { get; set; } = string.Empty;
+
+        [JsonPropertyName("secondary_text")]
+        public string SecondaryText { get; set; } = string.Empty;
+    }
+
+    private sealed class PlaceDetailApiResponse
+    {
+        [JsonPropertyName("status")]
+        public string Status { get; set; } = string.Empty;
+
+        [JsonPropertyName("result")]
+        public PlaceDetailResult? Result { get; set; }
+    }
+
+    private sealed class PlaceDetailResult
+    {
+        [JsonPropertyName("place_id")]
+        public string PlaceId { get; set; } = string.Empty;
+
+        [JsonPropertyName("formatted_address")]
+        public string FormattedAddress { get; set; } = string.Empty;
+
+        [JsonPropertyName("geometry")]
+        public Geometry Geometry { get; set; } = new();
+
+        [JsonPropertyName("address_components")]
+        public List<AddressComponent>? AddressComponents { get; set; }
+    }
+
+    private sealed class Geometry
+    {
+        [JsonPropertyName("location")]
+        public LatLng Location { get; set; } = new();
+    }
+
+    private sealed class LatLng
+    {
+        [JsonPropertyName("lat")]
+        public double Lat { get; set; }
+
+        [JsonPropertyName("lng")]
+        public double Lng { get; set; }
+    }
+
+    private sealed class AddressComponent
+    {
+        [JsonPropertyName("long_name")]
+        public string LongName { get; set; } = string.Empty;
+
+        [JsonPropertyName("short_name")]
+        public string ShortName { get; set; } = string.Empty;
+
+        [JsonPropertyName("types")]
+        public List<string> Types { get; set; } = new();
+    }
+}

--- a/src/RallyAPI.SharedKernel/Abstractions/Geocoding/GeocodingModels.cs
+++ b/src/RallyAPI.SharedKernel/Abstractions/Geocoding/GeocodingModels.cs
@@ -1,0 +1,48 @@
+namespace RallyAPI.SharedKernel.Abstractions.Geocoding;
+
+/// <summary>
+/// Result of a reverse geocode lookup.
+/// </summary>
+public sealed record ReverseGeocodeResult
+{
+    public bool IsSuccess { get; init; }
+    public string? FormattedAddress { get; init; }
+    public string? PlaceId { get; init; }
+    public string? Locality { get; init; }
+    public string? Pincode { get; init; }
+    public string? Error { get; init; }
+
+    public static ReverseGeocodeResult Success(
+        string formattedAddress, string placeId, string? locality, string? pincode)
+        => new()
+        {
+            IsSuccess = true,
+            FormattedAddress = formattedAddress,
+            PlaceId = placeId,
+            Locality = locality,
+            Pincode = pincode
+        };
+
+    public static ReverseGeocodeResult Failure(string error)
+        => new() { IsSuccess = false, Error = error };
+}
+
+/// <summary>
+/// A single autocomplete suggestion from Google Places.
+/// </summary>
+public sealed record PlaceSuggestion(
+    string PlaceId,
+    string Description,
+    string MainText,
+    string SecondaryText);
+
+/// <summary>
+/// Full details for a resolved Place ID.
+/// </summary>
+public sealed record PlaceDetail(
+    string PlaceId,
+    string FormattedAddress,
+    double Latitude,
+    double Longitude,
+    string? Locality,
+    string? Pincode);

--- a/src/RallyAPI.SharedKernel/Abstractions/Geocoding/IGeocodingService.cs
+++ b/src/RallyAPI.SharedKernel/Abstractions/Geocoding/IGeocodingService.cs
@@ -1,0 +1,32 @@
+namespace RallyAPI.SharedKernel.Abstractions.Geocoding;
+
+/// <summary>
+/// Reverse geocoding and places autocomplete — wraps Google Maps APIs.
+/// </summary>
+public interface IGeocodingService
+{
+    /// <summary>
+    /// Reverse geocode lat/lng to a formatted address.
+    /// </summary>
+    Task<ReverseGeocodeResult> ReverseGeocodeAsync(
+        double latitude,
+        double longitude,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Autocomplete a partial address query. Returns up to <paramref name="maxResults"/> suggestions.
+    /// </summary>
+    Task<IReadOnlyList<PlaceSuggestion>> AutocompleteAsync(
+        string input,
+        double? sessionLatitude = null,
+        double? sessionLongitude = null,
+        int maxResults = 5,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Get full place details (lat/lng, formatted address) from a Place ID.
+    /// </summary>
+    Task<PlaceDetail?> GetPlaceDetailAsync(
+        string placeId,
+        CancellationToken ct = default);
+}


### PR DESCRIPTION
Server-side proxy for Google Maps Geocoding, Places Autocomplete, and Place Details APIs. API key stays on backend — frontend never calls Google directly.

- Add IGeocodingService interface + models in SharedKernel
- Implement GoogleGeocodingService wrapping 3 Google APIs
- New endpoints: GET /api/places/autocomplete, GET /api/places/{id}, GET /api/geocode/reverse
- Add PlaceId to Address value object (optional, backward compatible)
- Update AddAddress/UpdateAddress commands + endpoints for PlaceId
- Return PlaceId in GetProfile and GetAddresses responses
- EF migration: place_id column on customer_addresses
- Update CLAUDE.md with geocoding architecture docs