### PR TITLE
fix(auth): disable JWT inbound claim mapping so "sub" claim works eve…

### DIFF
--- a/src/Modules/Catalog/RallyAPI.Catalog.Endpoints/MenuItems/CreateMenuItem.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Endpoints/MenuItems/CreateMenuItem.cs
@@ -24,7 +24,7 @@ public class CreateMenuItem : IEndpoint
         ISender sender,
         CancellationToken ct)
     {
-        var restaurantId = Guid.Parse(user.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        var restaurantId = Guid.Parse(user.FindFirstValue("sub")!);
 
         var command = new CreateMenuItemCommand(
             restaurantId,

--- a/src/Modules/Catalog/RallyAPI.Catalog.Endpoints/MenuItems/ToggleMenuItemAvailability.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Endpoints/MenuItems/ToggleMenuItemAvailability.cs
@@ -24,7 +24,7 @@ public class ToggleMenuItemAvailability : IEndpoint
         ISender sender,
         CancellationToken ct)
     {
-        var restaurantId = Guid.Parse(user.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        var restaurantId = Guid.Parse(user.FindFirstValue("sub")!);
 
         var command = new ToggleMenuItemAvailabilityCommand(itemId, restaurantId);
         var result = await sender.Send(command, ct);

--- a/src/Modules/Catalog/RallyAPI.Catalog.Endpoints/MenuItems/UpdateMenuItem.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Endpoints/MenuItems/UpdateMenuItem.cs
@@ -114,7 +114,7 @@ public class UpdateMenuItem : IEndpoint
         var userType = httpContext.User.FindFirst("user_type")?.Value ?? string.Empty;
         var isAdmin = userType.Equals("admin", StringComparison.OrdinalIgnoreCase);
 
-        var subClaim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
+        var subClaim = httpContext.User.FindFirst("sub")?.Value ?? string.Empty;
         var restaurantId = Guid.TryParse(subClaim, out var id) ? id : Guid.Empty;
 
         return (restaurantId, isAdmin);
@@ -127,7 +127,7 @@ public class UpdateMenuItem : IEndpoint
         ISender sender,
         CancellationToken ct)
     {
-        var restaurantId = Guid.Parse(user.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        var restaurantId = Guid.Parse(user.FindFirstValue("sub")!);
 
         var command = new UpdateMenuItemCommand(
             itemId,

--- a/src/Modules/Catalog/RallyAPI.Catalog.Endpoints/Menus/CreateMenu.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Endpoints/Menus/CreateMenu.cs
@@ -24,7 +24,7 @@ public class CreateMenu : IEndpoint
         ISender sender,
         CancellationToken ct)
     {
-        var restaurantId = Guid.Parse(user.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        var restaurantId = Guid.Parse(user.FindFirstValue("sub")!);
 
         var command = new CreateMenuCommand(
             restaurantId,

--- a/src/Modules/Catalog/RallyAPI.Catalog.Endpoints/Menus/DeleteMenu.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Endpoints/Menus/DeleteMenu.cs
@@ -24,7 +24,7 @@ public class DeleteMenu : IEndpoint
         ISender sender,
         CancellationToken ct)
     {
-        var restaurantId = Guid.Parse(user.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        var restaurantId = Guid.Parse(user.FindFirstValue("sub")!);
 
         var command = new DeleteMenuCommand(menuId, restaurantId);
         var result = await sender.Send(command, ct);

--- a/src/Modules/Orders/RallyAPI.Orders.Infrastructure/Services/CurrentUserService.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Infrastructure/Services/CurrentUserService.cs
@@ -22,28 +22,24 @@ public sealed class CurrentUserService : ICurrentUserService
     {
         get
         {
-            var userIdClaim = User?.FindFirst(ClaimTypes.NameIdentifier)?.Value
-                ?? User?.FindFirst("sub")?.Value
+            var userIdClaim = User?.FindFirst("sub")?.Value
                 ?? User?.FindFirst("userId")?.Value;
 
             return Guid.TryParse(userIdClaim, out var userId) ? userId : null;
         }
     }
 
-    public string? UserName => User?.FindFirst(ClaimTypes.Name)?.Value
-        ?? User?.FindFirst("name")?.Value;
+    public string? UserName => User?.FindFirst("name")?.Value;
 
-    public string? Email => User?.FindFirst(ClaimTypes.Email)?.Value
-        ?? User?.FindFirst("email")?.Value;
+    public string? Email => User?.FindFirst("email")?.Value;
 
-    public string? Phone => User?.FindFirst(ClaimTypes.MobilePhone)?.Value
-        ?? User?.FindFirst("phone")?.Value;
+    public string? Phone => User?.FindFirst("phone")?.Value;
 
     public IReadOnlyList<string> Roles
     {
         get
         {
-            var roles = User?.FindAll(ClaimTypes.Role)
+            var roles = User?.FindAll("role")
                 .Select(c => c.Value)
                 .ToList();
             return roles ?? new List<string>();

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Admins/GetAdminStats.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Admins/GetAdminStats.cs
@@ -23,7 +23,7 @@ public class GetAdminStats : IEndpoint
         ISender sender,
         CancellationToken cancellationToken)
     {
-        var adminId = Guid.Parse(user.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        var adminId = Guid.Parse(user.FindFirstValue("sub")!);
         var result = await sender.Send(new GetAdminStatsQuery(adminId), cancellationToken);
 
         return result.IsFailure

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Admins/GetRiderKycDocuments.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Admins/GetRiderKycDocuments.cs
@@ -24,7 +24,7 @@ public class GetRiderKycDocuments : IEndpoint
         ISender sender,
         CancellationToken cancellationToken)
     {
-        var adminId = Guid.Parse(user.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        var adminId = Guid.Parse(user.FindFirstValue("sub")!);
         var result = await sender.Send(
             new GetRiderKycDocumentsQuery(adminId, riderId), cancellationToken);
 

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/GetProfile.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/GetProfile.cs
@@ -23,7 +23,7 @@ public class GetProfile : IEndpoint
         ISender sender,
         CancellationToken ct)
     {
-        var riderId = Guid.Parse(user.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        var riderId = Guid.Parse(user.FindFirstValue("sub")!);
         var query = new GetRiderProfileQuery(riderId);
         var result = await sender.Send(query, ct);
 

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/GoOffline.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/GoOffline.cs
@@ -23,7 +23,7 @@ public class GoOffline : IEndpoint
         ISender sender,
         CancellationToken ct)
     {
-        var riderId = Guid.Parse(user.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        var riderId = Guid.Parse(user.FindFirstValue("sub")!);
         var command = new GoOfflineCommand(riderId);
         var result = await sender.Send(command, ct);
 

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/GoOnline.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/GoOnline.cs
@@ -23,7 +23,7 @@ public class GoOnline : IEndpoint
         ISender sender,
         CancellationToken ct)
     {
-        var riderId = Guid.Parse(user.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        var riderId = Guid.Parse(user.FindFirstValue("sub")!);
         var command = new GoOnlineCommand(riderId);
         var result = await sender.Send(command, ct);
 

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/UpdateLocation.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/UpdateLocation.cs
@@ -24,7 +24,7 @@ public class UpdateLocation : IEndpoint
         ISender sender,
         CancellationToken ct)
     {
-        var riderId = Guid.Parse(user.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        var riderId = Guid.Parse(user.FindFirstValue("sub")!);
         var command = new UpdateRiderLocationCommand(
             riderId,
             request.Latitude,

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/UpdateProfile.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/UpdateProfile.cs
@@ -82,7 +82,7 @@ public class UpdateProfile : IEndpoint
         ISender sender,
         CancellationToken ct)
     {
-        var riderId = Guid.Parse(user.FindFirstValue(ClaimTypes.NameIdentifier)!);
+        var riderId = Guid.Parse(user.FindFirstValue("sub")!);
         var command = new UpdateRiderProfileCommand(
             riderId,
             request.Name,

--- a/src/RallyAPI.Host/Hubs/NotificationHub.cs
+++ b/src/RallyAPI.Host/Hubs/NotificationHub.cs
@@ -107,8 +107,7 @@ public sealed class NotificationHub : Hub
 
     private Guid? GetUserId()
     {
-        var sub = Context.User?.FindFirst(ClaimTypes.NameIdentifier)?.Value
-                  ?? Context.User?.FindFirst("sub")?.Value;
+        var sub = Context.User?.FindFirst("sub")?.Value;
 
         return Guid.TryParse(sub, out var id) ? id : null;
     }

--- a/src/RallyAPI.Host/Program.cs
+++ b/src/RallyAPI.Host/Program.cs
@@ -94,6 +94,10 @@ else
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
+        // Prevent .NET from remapping "sub" → ClaimTypes.NameIdentifier etc.
+        // This keeps JWT claim names as-is so FindFirst("sub") works everywhere.
+        options.MapInboundClaims = false;
+
         options.TokenValidationParameters = new TokenValidationParameters
         {
             ValidateIssuer = true,
@@ -102,7 +106,9 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             ValidateIssuerSigningKey = true,
             ValidIssuer = jwtSettings["Issuer"],
             ValidAudience = jwtSettings["Audience"],
-            IssuerSigningKey = new RsaSecurityKey(rsa)
+            IssuerSigningKey = new RsaSecurityKey(rsa),
+            RoleClaimType = "role",
+            NameClaimType = "sub"
         };
 
         // SignalR WebSocket upgrade: bearer token comes via query string


### PR DESCRIPTION
…rywhere

.NET's MapInboundClaims remaps JWT "sub" to ClaimTypes.NameIdentifier, causing 401s on endpoints that look up FindFirst("sub") directly (e.g. address APIs). Disabling the mapping keeps claim names as-is from the JWT. Updated all 15 files that referenced ClaimTypes.NameIdentifier to use "sub" directly, and set RoleClaimType/NameClaimType so IsInRole() continues to work.