### PR TITLE
fix(payments): remove fake PaymentId exploit — orders start Pending, …

### DIFF
--- a/src/Modules/Orders/RallyAPI.Orders.Application/Commands/PlaceOrder/PlaceOrderCommand.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/Commands/PlaceOrder/PlaceOrderCommand.cs
@@ -6,8 +6,8 @@ using RallyAPI.SharedKernel.Results;
 namespace RallyAPI.Orders.Application.Commands.PlaceOrder;
 
 /// <summary>
-/// Command to create a paid order.
-/// Called AFTER payment is successful.
+/// Command to create a pending order awaiting payment.
+/// Payment is handled separately via InitiatePayment + PayU webhook.
 /// </summary>
 public sealed record PlaceOrderCommand : IRequest<Result<OrderDto>>
 {
@@ -16,10 +16,6 @@ public sealed record PlaceOrderCommand : IRequest<Result<OrderDto>>
     public string CustomerName { get; init; } = string.Empty;
     public string? CustomerPhone { get; init; }
     public string? CustomerEmail { get; init; }
-
-    // Payment info (REQUIRED - order is already paid)
-    public string PaymentId { get; init; } = string.Empty;
-    public string? PaymentTransactionId { get; init; }
 
     // Delivery quote (from Delivery Module)
     public string? DeliveryQuoteId { get; init; }
@@ -30,9 +26,7 @@ public sealed record PlaceOrderCommand : IRequest<Result<OrderDto>>
     public static PlaceOrderCommand Create(
         Guid customerId,
         string customerName,
-        string paymentId,
         PlaceOrderRequest request,
-        string? paymentTransactionId = null,
         string? deliveryQuoteId = null,
         string? customerPhone = null,
         string? customerEmail = null)
@@ -41,8 +35,6 @@ public sealed record PlaceOrderCommand : IRequest<Result<OrderDto>>
         {
             CustomerId = customerId,
             CustomerName = customerName,
-            PaymentId = paymentId,
-            PaymentTransactionId = paymentTransactionId,
             DeliveryQuoteId = deliveryQuoteId,
             CustomerPhone = customerPhone,
             CustomerEmail = customerEmail,

--- a/src/Modules/Orders/RallyAPI.Orders.Application/Commands/PlaceOrder/PlaceOrderCommandHandler.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/Commands/PlaceOrder/PlaceOrderCommandHandler.cs
@@ -14,7 +14,7 @@ namespace RallyAPI.Orders.Application.Commands.PlaceOrder;
 
 /// <summary>
 /// Handler for PlaceOrderCommand.
-/// Creates order AFTER payment is successful.
+/// Creates a PENDING order. Payment is handled separately via InitiatePayment + PayU webhook.
 /// If the customer has a persisted cart, its items are used instead of the request body items.
 /// The cart is cleared after a successful order creation.
 /// </summary>
@@ -50,18 +50,11 @@ public sealed class PlaceOrderCommandHandler : IRequestHandler<PlaceOrderCommand
         try
         {
             _logger.LogInformation(
-                "Creating paid order for Customer {CustomerId}, Restaurant {RestaurantId}, Payment {PaymentId}",
+                "Creating pending order for Customer {CustomerId}, Restaurant {RestaurantId}",
                 command.CustomerId,
-                command.Request.RestaurantId,
-                command.PaymentId);
+                command.Request.RestaurantId);
 
-            // Step 1: Validate payment ID exists
-            if (string.IsNullOrWhiteSpace(command.PaymentId))
-            {
-                return Result.Failure<OrderDto>(OrderErrors.PaymentIdRequired);
-            }
-
-            // Step 2: Validate customer
+            // Step 1: Validate customer
             var customerValidation = await _validationService.ValidateCustomerAsync(
                 command.CustomerId, cancellationToken);
 
@@ -170,8 +163,8 @@ public sealed class PlaceOrderCommandHandler : IRequestHandler<PlaceOrderCommand
             _logger.LogInformation("OrderPricing created - SubTotal: {Sub}, Total: {Total}",
             pricing.SubTotal.Amount, pricing.Total.Amount);
 
-            // Step 9: Create paid order
-            var order = Order.CreatePaidOrder(
+            // Step 9: Create pending order (payment handled separately)
+            var order = Order.CreatePendingOrder(
                 orderNumber,
                 command.CustomerId,
                 command.CustomerName,
@@ -179,8 +172,6 @@ public sealed class PlaceOrderCommandHandler : IRequestHandler<PlaceOrderCommand
                 command.Request.RestaurantName,
                 deliveryInfo,
                 pricing,
-                command.PaymentId,
-                command.PaymentTransactionId,
                 command.DeliveryQuoteId,
                 command.CustomerPhone,
                 command.CustomerEmail,
@@ -196,8 +187,8 @@ public sealed class PlaceOrderCommandHandler : IRequestHandler<PlaceOrderCommand
             order.Pricing.Tax.Amount,
             order.Pricing.Total.Amount);
 
-            // Step 11: Finalize and save
-            order.FinalizeOrder();
+            // Step 11: Validate and save (OrderPaidEvent fires only after webhook confirms payment)
+            order.ValidateOrder();
 
             await _orderRepository.AddAsync(order, cancellationToken);
 
@@ -219,7 +210,7 @@ public sealed class PlaceOrderCommandHandler : IRequestHandler<PlaceOrderCommand
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation(
-                "Paid order {OrderNumber} created successfully. Total: {Total}. Awaiting restaurant response.",
+                "Pending order {OrderNumber} created successfully. Total: {Total}. Awaiting payment.",
                 order.OrderNumber.Value,
                 order.Pricing.Total.ToDisplayString());
 

--- a/src/Modules/Orders/RallyAPI.Orders.Application/Commands/PlaceOrder/PlaceOrderCommandValidator.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/Commands/PlaceOrder/PlaceOrderCommandValidator.cs
@@ -124,10 +124,6 @@ public sealed class PlaceOrderCommandValidator : AbstractValidator<PlaceOrderCom
             .MaximumLength(200)
             .WithMessage("Customer name is required");
 
-        RuleFor(x => x.PaymentId)
-            .NotEmpty()
-            .WithMessage("Payment ID is required");
-
         RuleFor(x => x.Request.RestaurantId)
             .NotEmpty()
             .WithMessage("Restaurant ID is required");

--- a/src/Modules/Orders/RallyAPI.Orders.Application/Commands/ProcessPayuWebhook/ProcessPayuWebhookCommandHandler.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/Commands/ProcessPayuWebhook/ProcessPayuWebhookCommandHandler.cs
@@ -2,6 +2,7 @@
 
 using MediatR;
 using Microsoft.Extensions.Logging;
+using RallyAPI.Orders.Domain.Abstractions;
 using RallyAPI.Orders.Domain.Repositories;
 using RallyAPI.SharedKernel;
 using RallyAPI.SharedKernel.Results;
@@ -13,15 +14,21 @@ public class ProcessPayuWebhookCommandHandler
     : IRequestHandler<ProcessPayuWebhookCommand, Result<bool>>
 {
     private readonly IPaymentRepository _paymentRepository;
+    private readonly IOrderRepository _orderRepository;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly IPayUService _payUService;
     private readonly ILogger<ProcessPayuWebhookCommandHandler> _logger;
 
     public ProcessPayuWebhookCommandHandler(
         IPaymentRepository paymentRepository,
+        IOrderRepository orderRepository,
+        IUnitOfWork unitOfWork,
         IPayUService payUService,
         ILogger<ProcessPayuWebhookCommandHandler> logger)
     {
         _paymentRepository = paymentRepository;
+        _orderRepository = orderRepository;
+        _unitOfWork = unitOfWork;
         _payUService = payUService;
         _logger = logger;
     }
@@ -77,9 +84,19 @@ public class ProcessPayuWebhookCommandHandler
         {
             payment.MarkSuccess(payuId, mode, bankRefNum);
 
+            // Transition order from Pending → Paid (the ONLY trusted path)
+            var order = await _orderRepository.GetByIdAsync(payment.OrderId, ct);
+            if (order is not null && order.Status == Domain.Enums.OrderStatus.Pending)
+            {
+                order.ConfirmPayment(payment.TxnId, payuId);
+                _logger.LogInformation(
+                    "Order {OrderId} transitioned Pending → Paid via webhook for TxnId {TxnId}",
+                    payment.OrderId, txnId);
+            }
+
             try
             {
-                await _paymentRepository.UpdateAsync(payment, ct);
+                await _unitOfWork.SaveChangesAsync(ct);
             }
             catch (Exception ex)
             {
@@ -95,12 +112,6 @@ public class ProcessPayuWebhookCommandHandler
             _logger.LogInformation(
                 "Payment SUCCESS for Order {OrderId}, TxnId: {TxnId}, PayuId: {PayuId}, Mode: {Mode}",
                 payment.OrderId, txnId, payuId, mode);
-
-            // TODO: If using payment-first flow where Order doesn't exist yet,
-            // trigger PlaceOrder here via MediatR.
-            // For now, the Order already exists (created before payment initiation).
-            // Update the Order's PaymentStatus:
-            // await _mediator.Send(new UpdateOrderPaymentStatusCommand(payment.OrderId, payuId, txnId));
         }
         else
         {
@@ -108,7 +119,7 @@ public class ProcessPayuWebhookCommandHandler
 
             try
             {
-                await _paymentRepository.UpdateAsync(payment, ct);
+                await _unitOfWork.SaveChangesAsync(ct);
             }
             catch (Exception ex)
             {

--- a/src/Modules/Orders/RallyAPI.Orders.Application/Commands/VerifyPayment/VerifyPaymentCommandHandler.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/Commands/VerifyPayment/VerifyPaymentCommandHandler.cs
@@ -4,6 +4,7 @@
 
 using MediatR;
 using Microsoft.Extensions.Logging;
+using RallyAPI.Orders.Domain.Abstractions;
 using RallyAPI.Orders.Domain.Repositories;
 using RallyAPI.Orders.Application.Abstractions;
 using RallyAPI.SharedKernel;
@@ -15,15 +16,21 @@ public class VerifyPaymentCommandHandler
     : IRequestHandler<VerifyPaymentCommand, Result<VerifyPaymentResponse>>
 {
     private readonly IPaymentRepository _paymentRepository;
+    private readonly IOrderRepository _orderRepository;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly IPayUService _payUService;
     private readonly ILogger<VerifyPaymentCommandHandler> _logger;
 
     public VerifyPaymentCommandHandler(
         IPaymentRepository paymentRepository,
+        IOrderRepository orderRepository,
+        IUnitOfWork unitOfWork,
         IPayUService payUService,
         ILogger<VerifyPaymentCommandHandler> logger)
     {
         _paymentRepository = paymentRepository;
+        _orderRepository = orderRepository;
+        _unitOfWork = unitOfWork;
         _payUService = payUService;
         _logger = logger;
     }
@@ -61,7 +68,18 @@ public class VerifyPaymentCommandHandler
             && payment.Status != Domain.Enums.PaymentStatus.Paid)
         {
             payment.MarkSuccess(result.PayuId, result.Mode ?? "", result.BankRefNum);
-            await _paymentRepository.UpdateAsync(payment, ct);
+
+            // Also transition order Pending → Paid (safety net for delayed/lost webhooks)
+            var order = await _orderRepository.GetByIdAsync(payment.OrderId, ct);
+            if (order is not null && order.Status == Domain.Enums.OrderStatus.Pending)
+            {
+                order.ConfirmPayment(payment.TxnId, result.PayuId);
+                _logger.LogInformation(
+                    "Order {OrderId} transitioned Pending → Paid via verify API for TxnId {TxnId}",
+                    payment.OrderId, command.TxnId);
+            }
+
+            await _unitOfWork.SaveChangesAsync(ct);
 
             _logger.LogInformation(
                 "Payment verified as SUCCESS via API for TxnId {TxnId} (webhook may have been delayed)",

--- a/src/Modules/Orders/RallyAPI.Orders.Application/DTOs/Requests/PlaceOrderRequest.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/DTOs/Requests/PlaceOrderRequest.cs
@@ -7,9 +7,6 @@
 public sealed record PlaceOrderRequest
 {
 
-    // === PAYMENT INFO (Required - order is post-payment) ===
-    public string PaymentId { get; init; } = string.Empty;
-    public string? PaymentTransactionId { get; init; }
     public string? DeliveryQuoteId { get; init; }
 
 

--- a/src/Modules/Orders/RallyAPI.Orders.Domain/Entities/Order.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Domain/Entities/Order.cs
@@ -87,8 +87,6 @@ public sealed class Order : AggregateRoot
         string? restaurantPhone,
         DeliveryInfo deliveryInfo,
         OrderPricing pricing,
-        string? paymentId,
-        string? paymentTransactionId,
         string? deliveryQuoteId,
         string? specialInstructions)
     {
@@ -104,15 +102,13 @@ public sealed class Order : AggregateRoot
         RestaurantName = restaurantName;
         RestaurantPhone = restaurantPhone;
 
-        // Order starts as PAID (customer already paid)
-        Status = OrderStatus.Paid;
-        PaymentStatus = PaymentStatus.Paid;
+        // Order starts as PENDING — only webhook can transition to Paid
+        Status = OrderStatus.Pending;
+        PaymentStatus = PaymentStatus.Pending;
 
         DeliveryInfo = deliveryInfo;
         Pricing = pricing;
 
-        PaymentId = paymentId;
-        PaymentTransactionId = paymentTransactionId;
         DeliveryQuoteId = deliveryQuoteId;
 
         SpecialInstructions = specialInstructions;
@@ -124,10 +120,10 @@ public sealed class Order : AggregateRoot
     #region Factory Methods
 
     /// <summary>
-    /// Creates a new paid order.
-    /// Called AFTER payment is successful.
+    /// Creates a new pending order awaiting payment.
+    /// Only the PayU webhook (after hash verification) can transition to Paid.
     /// </summary>
-    public static Order CreatePaidOrder(
+    public static Order CreatePendingOrder(
         OrderNumber orderNumber,
         Guid customerId,
         string customerName,
@@ -135,8 +131,6 @@ public sealed class Order : AggregateRoot
         string restaurantName,
         DeliveryInfo deliveryInfo,
         OrderPricing pricing,
-        string paymentId,
-        string? paymentTransactionId = null,
         string? deliveryQuoteId = null,
         string? customerPhone = null,
         string? customerEmail = null,
@@ -161,9 +155,6 @@ public sealed class Order : AggregateRoot
         if (pricing is null)
             throw new ArgumentNullException(nameof(pricing));
 
-        if (string.IsNullOrWhiteSpace(paymentId))
-            throw new ArgumentException("Payment ID is required", nameof(paymentId));
-
         var order = new Order(
             orderNumber,
             customerId,
@@ -175,8 +166,6 @@ public sealed class Order : AggregateRoot
             restaurantPhone?.Trim(),
             deliveryInfo,
             pricing,
-            paymentId,
-            paymentTransactionId,
             deliveryQuoteId,
             specialInstructions?.Trim());
 
@@ -216,6 +205,33 @@ public sealed class Order : AggregateRoot
     #endregion
 
     #region Status Transitions
+
+    /// <summary>
+    /// Confirms payment and transitions order from Pending to Paid.
+    /// Called ONLY by the PayU webhook handler (after hash verification) or
+    /// the VerifyPayment handler (as a delayed-webhook safety net).
+    /// </summary>
+    public void ConfirmPayment(string paymentId, string? paymentTransactionId)
+    {
+        if (Status == OrderStatus.Paid)
+            return; // Idempotent
+
+        if (Status != OrderStatus.Pending)
+            throw new InvalidOperationException($"Cannot confirm payment for order in {Status} status");
+
+        if (string.IsNullOrWhiteSpace(paymentId))
+            throw new ArgumentException("Payment ID is required", nameof(paymentId));
+
+        Status = OrderStatus.Paid;
+        PaymentStatus = PaymentStatus.Paid;
+        PaymentId = paymentId;
+        PaymentTransactionId = paymentTransactionId;
+        UpdatedAt = DateTime.UtcNow;
+
+        AddDomainEvent(new OrderPaidEvent(
+            Id, OrderNumber.Value, CustomerId, RestaurantId,
+            Pricing.Total.Amount, _items.Count));
+    }
 
     /// <summary>
     /// Restaurant confirms/accepts the order.
@@ -400,6 +416,7 @@ public sealed class Order : AggregateRoot
     {
         return Status switch
         {
+            OrderStatus.Pending => new[] { OrderStatus.Paid, OrderStatus.Cancelled },
             OrderStatus.Paid => new[] { OrderStatus.Confirmed, OrderStatus.Rejected, OrderStatus.Cancelled },
             OrderStatus.Confirmed => new[] { OrderStatus.Preparing, OrderStatus.Cancelled },
             OrderStatus.Preparing => new[] { OrderStatus.ReadyForPickup },
@@ -452,24 +469,16 @@ public sealed class Order : AggregateRoot
     #region Finalization
 
     /// <summary>
-    /// Finalizes the order after all items are set.
-    /// Raises OrderPaidEvent (order is ready for restaurant).
+    /// Validates the order after all items are set.
+    /// Called during order creation to ensure order is valid before persisting.
     /// </summary>
-    public void FinalizeOrder()
+    public void ValidateOrder()
     {
         if (!_items.Any())
-            throw new InvalidOperationException("Cannot finalize order without items");
+            throw new InvalidOperationException("Cannot create order without items");
 
         if (Pricing.Total.Amount <= 0)
             throw new InvalidOperationException("Order total must be greater than zero");
-
-        AddDomainEvent(new OrderPaidEvent(
-            Id,
-            OrderNumber.Value,
-            CustomerId,
-            RestaurantId,
-            Pricing.Total.Amount,
-            _items.Count));
     }
 
     #endregion

--- a/src/Modules/Orders/RallyAPI.Orders.Domain/Enums/CancellationReason.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Domain/Enums/CancellationReason.cs
@@ -30,6 +30,9 @@ public enum CancellationReason
     /// <summary>Order timeout - not confirmed in time</summary>
     Timeout = 70,
 
+    /// <summary>Payment not received within time limit</summary>
+    PaymentTimeout = 75,
+
     /// <summary>System/technical error</summary>
     SystemError = 80,
 
@@ -53,6 +56,7 @@ public static class CancellationReasonExtensions
         CancellationReason.RestaurantClosed => true,
         CancellationReason.NoRidersAvailable => true,
         CancellationReason.PaymentFailed => false,
+        CancellationReason.PaymentTimeout => false,  // No payment was made
         CancellationReason.DeliveryAddressIssue => true,
         CancellationReason.Timeout => true,
         CancellationReason.SystemError => true,
@@ -72,6 +76,7 @@ public static class CancellationReasonExtensions
         CancellationReason.RestaurantClosed => "System",
         CancellationReason.NoRidersAvailable => "System",
         CancellationReason.PaymentFailed => "System",
+        CancellationReason.PaymentTimeout => "System",
         CancellationReason.DeliveryAddressIssue => "Rider",
         CancellationReason.Timeout => "System",
         CancellationReason.SystemError => "System",

--- a/src/Modules/Orders/RallyAPI.Orders.Domain/Enums/OrderStatus.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Domain/Enums/OrderStatus.cs
@@ -6,6 +6,9 @@
 /// </summary>
 public enum OrderStatus
 {
+    /// <summary>Order created, awaiting payment</summary>
+    Pending = -5,
+
     /// <summary>Payment completed, waiting for restaurant response</summary>
     Paid = 0,
 
@@ -63,6 +66,7 @@ public static class OrderStatusExtensions
     /// </summary>
     public static bool IsActive(this OrderStatus status) => status switch
     {
+        OrderStatus.Pending => true,
         OrderStatus.Paid => true,
         OrderStatus.Confirmed => true,
         OrderStatus.Preparing => true,
@@ -76,6 +80,7 @@ public static class OrderStatusExtensions
     /// </summary>
     public static bool CanBeCancelled(this OrderStatus status) => status switch
     {
+        OrderStatus.Pending => true,    // Before payment completes
         OrderStatus.Paid => true,       // Before restaurant confirms
         OrderStatus.Confirmed => true,  // Before preparation starts
         _ => false
@@ -103,6 +108,7 @@ public static class OrderStatusExtensions
     /// </summary>
     public static string GetDisplayName(this OrderStatus status) => status switch
     {
+        OrderStatus.Pending => "Pending Payment",
         OrderStatus.Paid => "Paid - Awaiting Restaurant",
         OrderStatus.Confirmed => "Confirmed",
         OrderStatus.Preparing => "Preparing",

--- a/src/Modules/Orders/RallyAPI.Orders.Endpoints/OrderEndpoints.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Endpoints/OrderEndpoints.cs
@@ -50,6 +50,7 @@ public static class OrderEndpoints
             .WithName("PlaceOrder")
             .WithSummary("Place a new order")
             .RequireAuthorization("Customer")
+            .RequireRateLimiting("login")
             .Produces<OrderDto>(StatusCodes.Status201Created)
             .Produces<ProblemDetails>(StatusCodes.Status400BadRequest)
             .Produces<ProblemDetails>(StatusCodes.Status401Unauthorized);
@@ -250,21 +251,10 @@ public static class OrderEndpoints
         var command = PlaceOrderCommand.Create(
             customerId: currentUser.UserId.Value,
             customerName: currentUser.UserName ?? "Customer",
-            paymentId: request.PaymentId,
             request: request,
-            paymentTransactionId: request.PaymentTransactionId,
             deliveryQuoteId: request.DeliveryQuoteId,
             customerPhone: currentUser.Phone,
             customerEmail: currentUser.Email);
-
-
-        //var command = PlaceOrderCommand.Create(
-        //    currentUser.UserId.Value,
-        //    currentUser.UserName ?? "Customer",
-        //     paymentId: request.PaymentId,
-        //    request,
-        //    currentUser.Phone,
-        //    currentUser.Email);
 
         var result = await mediator.Send(command, cancellationToken);
 

--- a/src/Modules/Orders/RallyAPI.Orders.Infrastructure/BackgroundServices/AutoCancelOptions.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Infrastructure/BackgroundServices/AutoCancelOptions.cs
@@ -23,4 +23,9 @@ public sealed class AutoCancelOptions
     /// Must be greater than EscalationMinutes.
     /// </summary>
     public int HardCancelMinutes { get; set; } = 3;
+
+    /// <summary>
+    /// Minutes after Pending order creation before auto-cancelling unpaid orders. Default: 15
+    /// </summary>
+    public int PaymentTimeoutMinutes { get; set; } = 15;
 }

--- a/src/Modules/Orders/RallyAPI.Orders.Infrastructure/BackgroundServices/OrderAutoCancelService.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Infrastructure/BackgroundServices/OrderAutoCancelService.cs
@@ -37,10 +37,12 @@ public sealed class OrderAutoCancelService : BackgroundService
             "OrderAutoCancelService started. " +
             "Check interval: {IntervalSeconds}s | " +
             "Escalate after: {EscalationMinutes} min | " +
-            "Hard cancel after: {HardCancelMinutes} min",
+            "Hard cancel after: {HardCancelMinutes} min | " +
+            "Payment timeout: {PaymentTimeoutMinutes} min",
             _options.CheckIntervalSeconds,
             _options.EscalationMinutes,
-            _options.HardCancelMinutes);
+            _options.HardCancelMinutes,
+            _options.PaymentTimeoutMinutes);
 
         using var timer = new PeriodicTimer(TimeSpan.FromSeconds(_options.CheckIntervalSeconds));
 
@@ -64,10 +66,40 @@ public sealed class OrderAutoCancelService : BackgroundService
         var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
 
         var now = DateTime.UtcNow;
+
+        // Auto-cancel unpaid Pending orders (payment timeout)
+        var paymentTimeoutCutoff = now.AddMinutes(-_options.PaymentTimeoutMinutes);
+        var pendingOrders = await orderRepository.GetOrdersByStatusOlderThanAsync(
+            OrderStatus.Pending,
+            paymentTimeoutCutoff,
+            cancellationToken);
+
+        var paymentTimeoutCount = 0;
+        foreach (var pending in pendingOrders)
+        {
+            try
+            {
+                pending.Cancel(CancellationReason.PaymentTimeout, notes: "Auto-cancelled: payment not received within time limit");
+                paymentTimeoutCount++;
+
+                _logger.LogWarning(
+                    "AUTO-CANCELLED unpaid order {OrderId} ({OrderNumber}). " +
+                    "Payment not received after {TimeoutMinutes} minutes",
+                    pending.Id, pending.OrderNumber, _options.PaymentTimeoutMinutes);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to auto-cancel pending order {OrderId}", pending.Id);
+            }
+        }
+
+        if (paymentTimeoutCount > 0)
+            await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        // Escalate / hard-cancel unconfirmed Paid orders
         var escalationCutoff = now.AddMinutes(-_options.EscalationMinutes);
         var hardCancelCutoff = now.AddMinutes(-_options.HardCancelMinutes);
 
-        // Get all orders still in Paid status older than the escalation threshold
         var staleOrders = await orderRepository.GetOrdersByStatusOlderThanAsync(
             OrderStatus.Paid,
             escalationCutoff,

--- a/tests/Modules/Orders/RallyAPI.Orders.Application.Tests/ConfirmOrderCommandHandlerTests.cs
+++ b/tests/Modules/Orders/RallyAPI.Orders.Application.Tests/ConfirmOrderCommandHandlerTests.cs
@@ -128,15 +128,20 @@ public class ConfirmOrderCommandHandlerTests
 
         var pricing = OrderPricing.CreateSimple(subTotal: 300m, deliveryFee: 50m);
 
-        return Order.CreatePaidOrder(
+        var order = Order.CreatePendingOrder(
             orderNumber: OrderNumber.Create(dailySequence: 42),
             customerId: Guid.NewGuid(),
             customerName: "Priya Singh",
             restaurantId: restaurantId,
             restaurantName: "Dosa Corner",
             deliveryInfo: deliveryInfo,
-            pricing: pricing,
-            paymentId: "PAY-TEST-001");
+            pricing: pricing);
+
+        order.AddItem(OrderItem.Create(
+            Guid.NewGuid(), "Test Item",
+            Money.FromDecimal(300m, "INR"), 1));
+        order.ConfirmPayment("PAY-TEST-001", null);
+        return order;
     }
 
     #endregion

--- a/tests/Modules/Orders/RallyAPI.Orders.Domain.Tests/OrderAggregateTests.cs
+++ b/tests/Modules/Orders/RallyAPI.Orders.Domain.Tests/OrderAggregateTests.cs
@@ -11,7 +11,7 @@ public class OrderAggregateTests
 {
     #region Test Helpers
 
-    private static Order CreatePaidOrder(
+    private static Order CreatePendingOrder(
         Guid? customerId = null,
         Guid? restaurantId = null)
     {
@@ -33,44 +33,111 @@ public class OrderAggregateTests
             subTotal: 250m,
             deliveryFee: 40m);
 
-        return Order.CreatePaidOrder(
+        return Order.CreatePendingOrder(
             orderNumber: OrderNumber.Create(dailySequence: 1),
             customerId: customerId ?? Guid.NewGuid(),
             customerName: "Ravi Kumar",
             restaurantId: restaurantId ?? Guid.NewGuid(),
             restaurantName: "Biryani House",
             deliveryInfo: deliveryInfo,
-            pricing: pricing,
-            paymentId: "PAY-001");
+            pricing: pricing);
+    }
+
+    private static Order CreatePaidOrder(
+        Guid? customerId = null,
+        Guid? restaurantId = null)
+    {
+        var order = CreatePendingOrder(customerId, restaurantId);
+        order.AddItem(OrderItem.Create(
+            Guid.NewGuid(), "Test Item",
+            Money.FromDecimal(250m, "INR"), 1));
+        order.ConfirmPayment("PAY-001", null);
+        return order;
     }
 
     #endregion
 
-    #region CreatePaidOrder
+    #region CreatePendingOrder
 
     [Fact]
-    public void CreatePaidOrder_WithValidData_ShouldHavePaidStatus()
+    public void CreatePendingOrder_WithValidData_ShouldHavePendingStatus()
     {
-        var order = CreatePaidOrder();
+        var order = CreatePendingOrder();
 
-        order.Status.Should().Be(OrderStatus.Paid);
-        order.PaymentStatus.Should().Be(PaymentStatus.Paid);
+        order.Status.Should().Be(OrderStatus.Pending);
+        order.PaymentStatus.Should().Be(PaymentStatus.Pending);
+        order.PaymentId.Should().BeNull();
     }
 
     [Fact]
-    public void CreatePaidOrder_WithEmptyCustomerId_ShouldThrow()
+    public void CreatePendingOrder_WithEmptyCustomerId_ShouldThrow()
     {
-        var act = () => CreatePaidOrder(customerId: Guid.Empty);
+        var act = () => CreatePendingOrder(customerId: Guid.Empty);
 
         act.Should().Throw<ArgumentException>().WithMessage("*Customer ID*");
     }
 
     [Fact]
-    public void CreatePaidOrder_WithEmptyRestaurantId_ShouldThrow()
+    public void CreatePendingOrder_WithEmptyRestaurantId_ShouldThrow()
     {
-        var act = () => CreatePaidOrder(restaurantId: Guid.Empty);
+        var act = () => CreatePendingOrder(restaurantId: Guid.Empty);
 
         act.Should().Throw<ArgumentException>().WithMessage("*Restaurant ID*");
+    }
+
+    #endregion
+
+    #region ConfirmPayment
+
+    [Fact]
+    public void ConfirmPayment_WhenPending_ShouldTransitionToPaid()
+    {
+        var order = CreatePendingOrder();
+        order.AddItem(OrderItem.Create(
+            Guid.NewGuid(), "Biryani",
+            Money.FromDecimal(250m, "INR"), 1));
+
+        order.ConfirmPayment("PAY-001", "PAYU-123");
+
+        order.Status.Should().Be(OrderStatus.Paid);
+        order.PaymentStatus.Should().Be(PaymentStatus.Paid);
+        order.PaymentId.Should().Be("PAY-001");
+        order.PaymentTransactionId.Should().Be("PAYU-123");
+    }
+
+    [Fact]
+    public void ConfirmPayment_WhenPending_ShouldRaiseOrderPaidEvent()
+    {
+        var order = CreatePendingOrder();
+        order.AddItem(OrderItem.Create(
+            Guid.NewGuid(), "Biryani",
+            Money.FromDecimal(250m, "INR"), 1));
+
+        order.ConfirmPayment("PAY-001", null);
+
+        order.DomainEvents.Should().ContainSingle(e => e is OrderPaidEvent);
+    }
+
+    [Fact]
+    public void ConfirmPayment_WhenAlreadyPaid_ShouldBeIdempotent()
+    {
+        var order = CreatePaidOrder();
+
+        order.ConfirmPayment("PAY-002", null);
+
+        order.Status.Should().Be(OrderStatus.Paid);
+        order.PaymentId.Should().Be("PAY-001"); // Original payment ID preserved
+    }
+
+    [Fact]
+    public void ConfirmPayment_WhenConfirmed_ShouldThrow()
+    {
+        var order = CreatePaidOrder();
+        order.Confirm();
+
+        var act = () => order.ConfirmPayment("PAY-002", null);
+
+        act.Should().Throw<InvalidOperationException>();
     }
 
     #endregion


### PR DESCRIPTION
…only webhook can mark Paid

Previously any authenticated user could place a free order by passing a fake PaymentId. Now orders are created in Pending status with no payment reference. Only the PayU webhook (after hash verification) or the server-side VerifyPayment safety net can transition Pending → Paid via Order.ConfirmPayment(). Also adds auto-cancel for unpaid orders (15 min timeout), PaymentTimeout cancellation reason, and rate limiting on PlaceOrder.