### PR TITLE
feat(users): add restaurant details + settings management APIs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -591,6 +591,10 @@ migrationBuilder.Sql(@"CREATE INDEX ... ON orders.""Carts"" ...");
 migrationBuilder.Sql(@"ALTER TABLE users.""Riders"" ...");
 ```
 
+**Even better — don't hand-write DDL that EF can model.** Use `migrationBuilder.AlterColumn(...)`, `AddColumn(...)`, `DropColumn(...)`, `CreateTable(...)` etc. These read the real table/column names from your `IEntityTypeConfiguration<T>` mappings, so typos become impossible. Reserve `migrationBuilder.Sql(...)` for data migrations, sequences, or raw DDL that EF genuinely can't express (triggers, extensions, complex constraints).
+
+Real incident (2026-04-21): a hand-written `ALTER TABLE orders."DeliveryInfos" ALTER COLUMN "OrderId"` migration crashed every Railway startup because the actual table is `orders.delivery_info` with column `order_id`. Auto-generated `AlterColumn(...)` would have used the right names.
+
 ### 7. Add JsonStringEnumConverter to BOTH JSON option chains in Program.cs
 
 `Program.cs` configures JSON serialization in two places. Missing either one causes enum values to serialize as integers in some responses.
@@ -616,3 +620,25 @@ builder.Services.AddControllers().AddJsonOptions(options =>
 - [ ] PayU webhook hash verified in `ProcessPayuWebhook`
 - [ ] Rate limiting on OTP endpoints (SendOtp)
 - [ ] CORS configured for allowed origins only
+
+### Pre-Commit Checklist — Migrations (MANDATORY)
+
+If the commit touches any file under `**/Migrations/**` OR changes any EF entity/configuration, run through this before `git commit`:
+
+- [ ] **Migration is auto-generated, not hand-written** — ran `dotnet ef migrations add X` rather than pasting raw SQL. Raw `migrationBuilder.Sql(...)` is allowed only for sequences, data migrations, or DDL EF can't model.
+- [ ] **Table and column names verified** — if you DID write raw SQL, grep the initial migration or the `IEntityTypeConfiguration<T>` to confirm the exact casing (`delivery_info` not `"DeliveryInfos"`, `order_id` not `"OrderId"`).
+- [ ] **Schema qualified** — every `migrationBuilder.Sql(...)` includes the schema (`orders.`, `users.`, etc.).
+- [ ] **Applied locally** — ran `dotnet ef database update --context <Name>DbContext --project src/Modules/<Module>/.../Infrastructure --startup-project src/RallyAPI.Host` against local Postgres and it succeeded.
+- [ ] **`dotnet build` is green** with zero errors.
+- [ ] **Startup smoke test** — `dotnet run --project src/RallyAPI.Host` boots without throwing in the migration block (`Migrating X database...` lines all succeed).
+
+Why this checklist exists: a bad migration crashes Railway startup silently — the old container keeps serving traffic with stale schema, and you only find out hours later when a query hits a missing column. Catch it locally.
+
+### Pre-Commit Reminder for AI Agents
+
+Before proposing `git commit`, always prompt the user with:
+1. The pre-commit migration checklist above if any migration/entity file changed.
+2. A confirmation that `dotnet build` succeeded.
+3. A reminder that Railway auto-migrates on boot — if the migration is broken, the deploy silently stays on the old container.
+
+Never run `git commit` without explicit user approval when migration files are in the diff.

--- a/reviews/2026-04-21.md
+++ b/reviews/2026-04-21.md
@@ -1,0 +1,49 @@
+# Daily Review — April 21, 2026
+
+## Branch: `feat/pickup-orders`
+
+## What Was Done
+
+### Merged `master` into `feat/pickup-orders`
+Resolved 3 content conflicts where master's security fix (PR #71: remove fake PaymentId exploit) collided with pickup-orders' FulfillmentType/DeliveryInfo additions:
+- `Order.cs` — dropped `paymentId`/`paymentTransactionId` factory params; kept `fulfillmentType`/`deliveryInfo`.
+- `PlaceOrderCommandHandler.cs` — removed PaymentId from `CreatePendingOrder` call.
+- `PlaceOrderCommandValidator.cs` — removed PaymentId validator; kept FulfillmentType validator.
+
+Merge commit: `57e9497`. Pushed to `origin/feat/pickup-orders`. Build: 0 errors, 50 pre-existing warnings.
+
+### Production Incident: `GET /api/orders/restaurant/{id}` returning 500
+- **Symptom:** All restaurant order queries returning `InternalError` with traceId only (generic message from `ExceptionHandlingMiddleware`).
+- **Railway log showed:** `column o.fulfillment_type does not exist` — deployed code was querying the column, but the DB didn't have it.
+- **Root cause:** Three pending migrations were never applied to Railway Postgres:
+  1. `20260323000001_AddOrderNumberSequence`
+  2. `20260323100000_AddFulfillmentTypeToOrders`
+  3. `20260331100000_AddPayoutTables`
+- **Why auto-migration didn't run:** Migration #2 had a hand-written `migrationBuilder.Sql(@"ALTER TABLE orders.""DeliveryInfos"" ALTER COLUMN ""OrderId""...")` — but the real table is `orders.delivery_info` with column `order_id` (snake_case, not the PascalCase the migration assumed). `Database.Migrate()` threw `relation does not exist` on every startup, the app crashed, and Railway kept the previous container running with stale schema.
+- **Fix:** Generated manual SQL for all 3 migrations, applied via pgAdmin inside a transaction, recorded in `orders."__EFMigrationsHistory"`. Also corrected the migration source file to use `orders.delivery_info.order_id`.
+
+## Lessons Learned
+
+- **Hand-written `migrationBuilder.Sql(...)` is a typo hazard.** Auto-generated `AlterColumn(...)` / `AddColumn(...)` read entity config, so table/column names are always correct. Reserve raw SQL for sequences, data migrations, or DDL EF can't express.
+- **Railway doesn't loudly surface startup crashes.** When `Database.Migrate()` throws, the new container dies but the old one keeps serving traffic with stale schema. You only find out when a query hits the missing column.
+- **Generic 500 responses hide real errors on purpose.** `ExceptionHandlingMiddleware` returns `{ "error": "InternalError" }` with a traceId — the actual exception is in Railway logs. Always pull logs by traceId.
+- **Run migrations locally before committing.** `dotnet ef database update` against local Postgres catches these bugs in 10 seconds.
+- **Verify schema, not just the migration history row.** (Carried forward from Apr 6 lesson — a migration can be recorded as applied without the DDL actually executing.)
+
+## Action Items
+- [ ] Wire migration completeness into `/health` — return 503 until `Database.GetPendingMigrationsAsync()` is empty. Then Railway will mark a bad deploy as unhealthy instead of silently rolling forward.
+- [ ] Add a CI step that boots the app against an ephemeral Postgres (GitHub Actions `postgres` service). Broken migrations fail the build, never reach Railway.
+- [ ] Commit + push the `20260323100000_AddFulfillmentTypeToOrders.cs` source fix so future fresh deploys apply cleanly.
+
+## Files Changed (key files only)
+- `src/Modules/Orders/RallyAPI.Orders.Domain/Entities/Order.cs` — merge conflict resolved
+- `src/Modules/Orders/RallyAPI.Orders.Application/Commands/PlaceOrder/PlaceOrderCommandHandler.cs` — merge conflict resolved
+- `src/Modules/Orders/RallyAPI.Orders.Application/Commands/PlaceOrder/PlaceOrderCommandValidator.cs` — merge conflict resolved
+- `src/Modules/Orders/RallyAPI.Orders.Infrastructure/Migrations/20260323100000_AddFulfillmentTypeToOrders.cs` — fixed wrong table/column names
+- `CLAUDE.md` — added "Pre-Commit Checklist — Migrations" and strengthened Common Mistake #6
+- `reviews/2026-04-21.md` — this file
+
+## Status
+- Railway DB manually reconciled via pgAdmin.
+- `GET /api/orders/restaurant/{id}` should now return 200 after service restart.
+- Migration source fix pending commit + push.

--- a/src/Modules/Orders/RallyAPI.Orders.Infrastructure/Migrations/20260323100000_AddFulfillmentTypeToOrders.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Infrastructure/Migrations/20260323100000_AddFulfillmentTypeToOrders.cs
@@ -20,7 +20,7 @@ namespace RallyAPI.Orders.Infrastructure.Migrations
 
             // Make delivery_info FK nullable (pickup orders have no DeliveryInfo)
             migrationBuilder.Sql(
-                @"ALTER TABLE orders.""DeliveryInfos"" ALTER COLUMN ""OrderId"" DROP NOT NULL;");
+                @"ALTER TABLE orders.delivery_info ALTER COLUMN order_id DROP NOT NULL;");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
@@ -31,7 +31,7 @@ namespace RallyAPI.Orders.Infrastructure.Migrations
                 table: "orders");
 
             migrationBuilder.Sql(
-                @"ALTER TABLE orders.""DeliveryInfos"" ALTER COLUMN ""OrderId"" SET NOT NULL;");
+                @"ALTER TABLE orders.delivery_info ALTER COLUMN order_id SET NOT NULL;");
         }
     }
 }

--- a/src/Modules/Users/RallyAPI.Users.Application/Abstractions/IRestaurantRepository.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Abstractions/IRestaurantRepository.cs
@@ -6,6 +6,7 @@ namespace RallyAPI.Users.Application.Abstractions;
 public interface IRestaurantRepository
 {
     Task<Restaurant?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<Restaurant?> GetByIdWithScheduleAsync(Guid id, CancellationToken cancellationToken = default);
     Task<Restaurant?> GetByEmailAsync(Email email, CancellationToken cancellationToken = default);
     Task<bool> ExistsByEmailAsync(Email email, CancellationToken cancellationToken = default);
     Task AddAsync(Restaurant restaurant, CancellationToken cancellationToken = default);

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateBasics/UpdateRestaurantBasicsCommand.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateBasics/UpdateRestaurantBasicsCommand.cs
@@ -1,0 +1,15 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdateBasics;
+
+public sealed record UpdateRestaurantBasicsCommand(
+    Guid RestaurantId,
+    string? Name,
+    string? Phone,
+    string? Email,
+    string? FssaiNumber,
+    string? AddressLine,
+    decimal? Latitude,
+    decimal? Longitude,
+    string? Description) : IRequest<Result>;

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateBasics/UpdateRestaurantBasicsCommandHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateBasics/UpdateRestaurantBasicsCommandHandler.cs
@@ -1,0 +1,76 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Application.Abstractions;
+using RallyAPI.Users.Domain.ValueObjects;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdateBasics;
+
+internal sealed class UpdateRestaurantBasicsCommandHandler
+    : IRequestHandler<UpdateRestaurantBasicsCommand, Result>
+{
+    private readonly IRestaurantRepository _restaurantRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public UpdateRestaurantBasicsCommandHandler(
+        IRestaurantRepository restaurantRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _restaurantRepository = restaurantRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result> Handle(
+        UpdateRestaurantBasicsCommand request,
+        CancellationToken cancellationToken)
+    {
+        var restaurant = await _restaurantRepository.GetByIdAsync(request.RestaurantId, cancellationToken);
+        if (restaurant is null)
+            return Result.Failure(Error.NotFound("Restaurant", request.RestaurantId));
+
+        PhoneNumber? phone = null;
+        if (!string.IsNullOrWhiteSpace(request.Phone))
+        {
+            var phoneResult = PhoneNumber.Create(request.Phone);
+            if (phoneResult.IsFailure) return Result.Failure(phoneResult.Error);
+            phone = phoneResult.Value;
+        }
+
+        var profileResult = restaurant.UpdateProfile(request.Name, request.AddressLine, phone);
+        if (profileResult.IsFailure) return profileResult;
+
+        if (!string.IsNullOrWhiteSpace(request.Email))
+        {
+            var emailResult = Email.Create(request.Email);
+            if (emailResult.IsFailure) return Result.Failure(emailResult.Error);
+
+            if (!restaurant.Email.Equals(emailResult.Value))
+            {
+                var exists = await _restaurantRepository.ExistsByEmailAsync(emailResult.Value, cancellationToken);
+                if (exists) return Result.Failure(Error.Validation("Email is already in use by another restaurant."));
+                var setEmailResult = restaurant.SetEmail(emailResult.Value);
+                if (setEmailResult.IsFailure) return setEmailResult;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.FssaiNumber))
+        {
+            var fssaiResult = restaurant.SetFssaiNumber(request.FssaiNumber);
+            if (fssaiResult.IsFailure) return fssaiResult;
+        }
+
+        if (request.Latitude.HasValue && request.Longitude.HasValue)
+        {
+            var locResult = restaurant.UpdateLocation(request.Latitude.Value, request.Longitude.Value);
+            if (locResult.IsFailure) return locResult;
+        }
+
+        if (request.Description is not null)
+        {
+            var descResult = restaurant.SetDescription(request.Description);
+            if (descResult.IsFailure) return descResult;
+        }
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+        return Result.Success();
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateBasics/UpdateRestaurantBasicsCommandValidator.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateBasics/UpdateRestaurantBasicsCommandValidator.cs
@@ -1,0 +1,43 @@
+using FluentValidation;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdateBasics;
+
+public sealed class UpdateRestaurantBasicsCommandValidator
+    : AbstractValidator<UpdateRestaurantBasicsCommand>
+{
+    public UpdateRestaurantBasicsCommandValidator()
+    {
+        RuleFor(x => x.RestaurantId).NotEmpty();
+
+        RuleFor(x => x.Name)
+            .NotEmpty().MaximumLength(255)
+            .When(x => x.Name is not null);
+
+        RuleFor(x => x.Phone)
+            .Matches(@"^[6-9]\d{9}$")
+            .WithMessage("Phone must be a valid 10-digit Indian mobile number.")
+            .When(x => !string.IsNullOrWhiteSpace(x.Phone));
+
+        RuleFor(x => x.Email)
+            .EmailAddress().MaximumLength(255)
+            .When(x => !string.IsNullOrWhiteSpace(x.Email));
+
+        RuleFor(x => x.FssaiNumber)
+            .Length(14, 20)
+            .When(x => !string.IsNullOrWhiteSpace(x.FssaiNumber));
+
+        RuleFor(x => x.AddressLine)
+            .NotEmpty().MaximumLength(500)
+            .When(x => x.AddressLine is not null);
+
+        RuleFor(x => x.Description)
+            .MaximumLength(2000)
+            .When(x => x.Description is not null);
+
+        When(x => x.Latitude.HasValue || x.Longitude.HasValue, () =>
+        {
+            RuleFor(x => x.Latitude).NotNull().InclusiveBetween(6m, 38m);
+            RuleFor(x => x.Longitude).NotNull().InclusiveBetween(68m, 98m);
+        });
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateDelivery/UpdateRestaurantDeliveryCommand.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateDelivery/UpdateRestaurantDeliveryCommand.cs
@@ -1,0 +1,9 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Domain.Enums;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdateDelivery;
+
+public sealed record UpdateRestaurantDeliveryCommand(
+    Guid RestaurantId,
+    DeliveryMode DeliveryMode) : IRequest<Result>;

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateDelivery/UpdateRestaurantDeliveryCommandHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateDelivery/UpdateRestaurantDeliveryCommandHandler.cs
@@ -1,0 +1,35 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Application.Abstractions;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdateDelivery;
+
+internal sealed class UpdateRestaurantDeliveryCommandHandler
+    : IRequestHandler<UpdateRestaurantDeliveryCommand, Result>
+{
+    private readonly IRestaurantRepository _restaurantRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public UpdateRestaurantDeliveryCommandHandler(
+        IRestaurantRepository restaurantRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _restaurantRepository = restaurantRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result> Handle(
+        UpdateRestaurantDeliveryCommand request,
+        CancellationToken cancellationToken)
+    {
+        var restaurant = await _restaurantRepository.GetByIdAsync(request.RestaurantId, cancellationToken);
+        if (restaurant is null)
+            return Result.Failure(Error.NotFound("Restaurant", request.RestaurantId));
+
+        var r = restaurant.SetDeliveryMode(request.DeliveryMode);
+        if (r.IsFailure) return r;
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+        return Result.Success();
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateDelivery/UpdateRestaurantDeliveryCommandValidator.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateDelivery/UpdateRestaurantDeliveryCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdateDelivery;
+
+public sealed class UpdateRestaurantDeliveryCommandValidator
+    : AbstractValidator<UpdateRestaurantDeliveryCommand>
+{
+    public UpdateRestaurantDeliveryCommandValidator()
+    {
+        RuleFor(x => x.RestaurantId).NotEmpty();
+        RuleFor(x => x.DeliveryMode).IsInEnum();
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateDietary/UpdateRestaurantDietaryCommand.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateDietary/UpdateRestaurantDietaryCommand.cs
@@ -1,0 +1,12 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Domain.Enums;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdateDietary;
+
+public sealed record UpdateRestaurantDietaryCommand(
+    Guid RestaurantId,
+    DietaryType? DietaryType,
+    bool? IsVeganFriendly,
+    bool? HasJainOptions,
+    List<string>? CuisineTypes) : IRequest<Result>;

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateDietary/UpdateRestaurantDietaryCommandHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateDietary/UpdateRestaurantDietaryCommandHandler.cs
@@ -1,0 +1,53 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Application.Abstractions;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdateDietary;
+
+internal sealed class UpdateRestaurantDietaryCommandHandler
+    : IRequestHandler<UpdateRestaurantDietaryCommand, Result>
+{
+    private readonly IRestaurantRepository _restaurantRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public UpdateRestaurantDietaryCommandHandler(
+        IRestaurantRepository restaurantRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _restaurantRepository = restaurantRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result> Handle(
+        UpdateRestaurantDietaryCommand request,
+        CancellationToken cancellationToken)
+    {
+        var restaurant = await _restaurantRepository.GetByIdAsync(request.RestaurantId, cancellationToken);
+        if (restaurant is null)
+            return Result.Failure(Error.NotFound("Restaurant", request.RestaurantId));
+
+        if (request.DietaryType.HasValue)
+        {
+            var dtResult = restaurant.SetDietaryType(request.DietaryType.Value);
+            if (dtResult.IsFailure) return dtResult;
+        }
+
+        if (request.IsVeganFriendly.HasValue || request.HasJainOptions.HasValue)
+        {
+            var flagsResult = restaurant.SetDietaryAttributes(
+                restaurant.IsPureVeg,
+                request.IsVeganFriendly ?? restaurant.IsVeganFriendly,
+                request.HasJainOptions ?? restaurant.HasJainOptions);
+            if (flagsResult.IsFailure) return flagsResult;
+        }
+
+        if (request.CuisineTypes is not null)
+        {
+            var cuisineResult = restaurant.SetCuisineTypes(request.CuisineTypes);
+            if (cuisineResult.IsFailure) return cuisineResult;
+        }
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+        return Result.Success();
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateDietary/UpdateRestaurantDietaryCommandValidator.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateDietary/UpdateRestaurantDietaryCommandValidator.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdateDietary;
+
+public sealed class UpdateRestaurantDietaryCommandValidator
+    : AbstractValidator<UpdateRestaurantDietaryCommand>
+{
+    public UpdateRestaurantDietaryCommandValidator()
+    {
+        RuleFor(x => x.RestaurantId).NotEmpty();
+
+        RuleFor(x => x.DietaryType)
+            .IsInEnum()
+            .When(x => x.DietaryType.HasValue);
+
+        RuleFor(x => x.CuisineTypes)
+            .Must(c => c!.Count <= 20)
+            .WithMessage("Maximum 20 cuisine types allowed.")
+            .When(x => x.CuisineTypes is not null);
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateHours/UpdateRestaurantHoursCommand.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateHours/UpdateRestaurantHoursCommand.cs
@@ -1,0 +1,19 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdateHours;
+
+public sealed record UpdateRestaurantHoursCommand(
+    Guid RestaurantId,
+    TimeOnly? OpeningTime,
+    TimeOnly? ClosingTime,
+    bool? UseCustomSchedule,
+    List<WeeklyScheduleDayInput>? WeeklySchedule) : IRequest<Result>;
+
+public sealed record WeeklyScheduleDayInput(
+    DayOfWeek DayOfWeek,
+    List<ScheduleSlotInput> Slots);
+
+public sealed record ScheduleSlotInput(
+    TimeOnly OpensAt,
+    TimeOnly ClosesAt);

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateHours/UpdateRestaurantHoursCommandHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateHours/UpdateRestaurantHoursCommandHandler.cs
@@ -1,0 +1,57 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Application.Abstractions;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdateHours;
+
+internal sealed class UpdateRestaurantHoursCommandHandler
+    : IRequestHandler<UpdateRestaurantHoursCommand, Result>
+{
+    private readonly IRestaurantRepository _restaurantRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public UpdateRestaurantHoursCommandHandler(
+        IRestaurantRepository restaurantRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _restaurantRepository = restaurantRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result> Handle(
+        UpdateRestaurantHoursCommand request,
+        CancellationToken cancellationToken)
+    {
+        var restaurant = await _restaurantRepository.GetByIdWithScheduleAsync(request.RestaurantId, cancellationToken);
+        if (restaurant is null)
+            return Result.Failure(Error.NotFound("Restaurant", request.RestaurantId));
+
+        if (request.OpeningTime.HasValue && request.ClosingTime.HasValue)
+        {
+            var r = restaurant.SetBusinessHours(request.OpeningTime.Value, request.ClosingTime.Value);
+            if (r.IsFailure) return r;
+        }
+
+        if (request.UseCustomSchedule.HasValue)
+        {
+            var r = restaurant.SetUseCustomSchedule(request.UseCustomSchedule.Value);
+            if (r.IsFailure) return r;
+        }
+
+        if (request.WeeklySchedule is not null)
+        {
+            foreach (var day in request.WeeklySchedule)
+            {
+                var slots = (day.Slots ?? new())
+                    .Select(s => (s.OpensAt, s.ClosesAt))
+                    .ToList();
+
+                var r = restaurant.ReplaceScheduleForDay(day.DayOfWeek, slots);
+                if (r.IsFailure) return r;
+            }
+        }
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+        return Result.Success();
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateHours/UpdateRestaurantHoursCommandValidator.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateHours/UpdateRestaurantHoursCommandValidator.cs
@@ -1,0 +1,32 @@
+using FluentValidation;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdateHours;
+
+public sealed class UpdateRestaurantHoursCommandValidator
+    : AbstractValidator<UpdateRestaurantHoursCommand>
+{
+    public UpdateRestaurantHoursCommandValidator()
+    {
+        RuleFor(x => x.RestaurantId).NotEmpty();
+
+        When(x => x.OpeningTime.HasValue || x.ClosingTime.HasValue, () =>
+        {
+            RuleFor(x => x.OpeningTime).NotNull();
+            RuleFor(x => x.ClosingTime).NotNull();
+            RuleFor(x => x)
+                .Must(x => x.OpeningTime!.Value < x.ClosingTime!.Value)
+                .WithMessage("Opening time must be before closing time.")
+                .When(x => x.OpeningTime.HasValue && x.ClosingTime.HasValue);
+        });
+
+        RuleForEach(x => x.WeeklySchedule!).ChildRules(day =>
+        {
+            day.RuleFor(d => d.DayOfWeek).IsInEnum();
+            day.RuleFor(d => d.Slots).NotNull();
+            day.RuleFor(d => d.Slots!.Count)
+                .LessThanOrEqualTo(3)
+                .WithMessage("At most 3 slots per day.")
+                .When(d => d.Slots is not null);
+        }).When(x => x.WeeklySchedule is not null);
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateNotifications/UpdateRestaurantNotificationsCommand.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateNotifications/UpdateRestaurantNotificationsCommand.cs
@@ -1,0 +1,10 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdateNotifications;
+
+public sealed record UpdateRestaurantNotificationsCommand(
+    Guid RestaurantId,
+    bool? EmailAlerts,
+    bool? BrowserNotifications,
+    bool? OrderSound) : IRequest<Result>;

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateNotifications/UpdateRestaurantNotificationsCommandHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateNotifications/UpdateRestaurantNotificationsCommandHandler.cs
@@ -1,0 +1,42 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Application.Abstractions;
+using RallyAPI.Users.Domain.ValueObjects;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdateNotifications;
+
+internal sealed class UpdateRestaurantNotificationsCommandHandler
+    : IRequestHandler<UpdateRestaurantNotificationsCommand, Result>
+{
+    private readonly IRestaurantRepository _restaurantRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public UpdateRestaurantNotificationsCommandHandler(
+        IRestaurantRepository restaurantRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _restaurantRepository = restaurantRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result> Handle(
+        UpdateRestaurantNotificationsCommand request,
+        CancellationToken cancellationToken)
+    {
+        var restaurant = await _restaurantRepository.GetByIdAsync(request.RestaurantId, cancellationToken);
+        if (restaurant is null)
+            return Result.Failure(Error.NotFound("Restaurant", request.RestaurantId));
+
+        var current = restaurant.Notifications;
+        var next = NotificationPreferences.Create(
+            request.EmailAlerts ?? current.EmailAlerts,
+            request.BrowserNotifications ?? current.BrowserNotifications,
+            request.OrderSound ?? current.OrderSound);
+
+        var r = restaurant.SetNotificationPreferences(next);
+        if (r.IsFailure) return r;
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+        return Result.Success();
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateNotifications/UpdateRestaurantNotificationsCommandValidator.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateNotifications/UpdateRestaurantNotificationsCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdateNotifications;
+
+public sealed class UpdateRestaurantNotificationsCommandValidator
+    : AbstractValidator<UpdateRestaurantNotificationsCommand>
+{
+    public UpdateRestaurantNotificationsCommandValidator()
+    {
+        RuleFor(x => x.RestaurantId).NotEmpty();
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateOperations/UpdateRestaurantOperationsCommand.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateOperations/UpdateRestaurantOperationsCommand.cs
@@ -1,0 +1,12 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdateOperations;
+
+public sealed record UpdateRestaurantOperationsCommand(
+    Guid RestaurantId,
+    bool? AutoAcceptOrders,
+    int? AvgPrepTimeMins,
+    bool? IsAcceptingOrders,
+    decimal? MinOrderAmount,
+    bool? UseCustomSchedule) : IRequest<Result>;

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateOperations/UpdateRestaurantOperationsCommandHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateOperations/UpdateRestaurantOperationsCommandHandler.cs
@@ -1,0 +1,64 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Application.Abstractions;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdateOperations;
+
+internal sealed class UpdateRestaurantOperationsCommandHandler
+    : IRequestHandler<UpdateRestaurantOperationsCommand, Result>
+{
+    private readonly IRestaurantRepository _restaurantRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public UpdateRestaurantOperationsCommandHandler(
+        IRestaurantRepository restaurantRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _restaurantRepository = restaurantRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result> Handle(
+        UpdateRestaurantOperationsCommand request,
+        CancellationToken cancellationToken)
+    {
+        var restaurant = await _restaurantRepository.GetByIdAsync(request.RestaurantId, cancellationToken);
+        if (restaurant is null)
+            return Result.Failure(Error.NotFound("Restaurant", request.RestaurantId));
+
+        if (request.AutoAcceptOrders.HasValue)
+        {
+            var r = restaurant.SetAutoAcceptOrders(request.AutoAcceptOrders.Value);
+            if (r.IsFailure) return r;
+        }
+
+        if (request.AvgPrepTimeMins.HasValue)
+        {
+            var r = restaurant.SetPrepTime(request.AvgPrepTimeMins.Value);
+            if (r.IsFailure) return r;
+        }
+
+        if (request.MinOrderAmount.HasValue)
+        {
+            var r = restaurant.SetMinOrderAmount(request.MinOrderAmount.Value);
+            if (r.IsFailure) return r;
+        }
+
+        if (request.UseCustomSchedule.HasValue)
+        {
+            var r = restaurant.SetUseCustomSchedule(request.UseCustomSchedule.Value);
+            if (r.IsFailure) return r;
+        }
+
+        if (request.IsAcceptingOrders.HasValue)
+        {
+            var r = request.IsAcceptingOrders.Value
+                ? restaurant.StartAcceptingOrders()
+                : restaurant.StopAcceptingOrders();
+            if (r.IsFailure) return r;
+        }
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+        return Result.Success();
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateOperations/UpdateRestaurantOperationsCommandValidator.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdateOperations/UpdateRestaurantOperationsCommandValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdateOperations;
+
+public sealed class UpdateRestaurantOperationsCommandValidator
+    : AbstractValidator<UpdateRestaurantOperationsCommand>
+{
+    public UpdateRestaurantOperationsCommandValidator()
+    {
+        RuleFor(x => x.RestaurantId).NotEmpty();
+
+        RuleFor(x => x.AvgPrepTimeMins)
+            .InclusiveBetween(5, 120)
+            .When(x => x.AvgPrepTimeMins.HasValue);
+
+        RuleFor(x => x.MinOrderAmount)
+            .GreaterThanOrEqualTo(0)
+            .When(x => x.MinOrderAmount.HasValue);
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdatePassword/UpdateRestaurantPasswordCommand.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdatePassword/UpdateRestaurantPasswordCommand.cs
@@ -1,0 +1,9 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdatePassword;
+
+public sealed record UpdateRestaurantPasswordCommand(
+    Guid RestaurantId,
+    string CurrentPassword,
+    string NewPassword) : IRequest<Result>;

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdatePassword/UpdateRestaurantPasswordCommandHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdatePassword/UpdateRestaurantPasswordCommandHandler.cs
@@ -1,0 +1,42 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Application.Abstractions;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdatePassword;
+
+internal sealed class UpdateRestaurantPasswordCommandHandler
+    : IRequestHandler<UpdateRestaurantPasswordCommand, Result>
+{
+    private readonly IRestaurantRepository _restaurantRepository;
+    private readonly IPasswordHasher _passwordHasher;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public UpdateRestaurantPasswordCommandHandler(
+        IRestaurantRepository restaurantRepository,
+        IPasswordHasher passwordHasher,
+        IUnitOfWork unitOfWork)
+    {
+        _restaurantRepository = restaurantRepository;
+        _passwordHasher = passwordHasher;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result> Handle(
+        UpdateRestaurantPasswordCommand request,
+        CancellationToken cancellationToken)
+    {
+        var restaurant = await _restaurantRepository.GetByIdAsync(request.RestaurantId, cancellationToken);
+        if (restaurant is null)
+            return Result.Failure(Error.NotFound("Restaurant", request.RestaurantId));
+
+        if (!_passwordHasher.Verify(request.CurrentPassword, restaurant.PasswordHash))
+            return Result.Failure(Error.Validation("Current password is incorrect."));
+
+        var newHash = _passwordHasher.Hash(request.NewPassword);
+        var r = restaurant.UpdatePassword(newHash);
+        if (r.IsFailure) return r;
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+        return Result.Success();
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdatePassword/UpdateRestaurantPasswordCommandValidator.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UpdatePassword/UpdateRestaurantPasswordCommandValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+
+namespace RallyAPI.Users.Application.Restaurants.Commands.UpdatePassword;
+
+public sealed class UpdateRestaurantPasswordCommandValidator
+    : AbstractValidator<UpdateRestaurantPasswordCommand>
+{
+    public UpdateRestaurantPasswordCommandValidator()
+    {
+        RuleFor(x => x.RestaurantId).NotEmpty();
+
+        RuleFor(x => x.CurrentPassword)
+            .NotEmpty();
+
+        RuleFor(x => x.NewPassword)
+            .NotEmpty()
+            .MinimumLength(8).WithMessage("Password must be at least 8 characters.")
+            .MaximumLength(128);
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Queries/GetDetails/GetRestaurantDetailsQuery.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Queries/GetDetails/GetRestaurantDetailsQuery.cs
@@ -1,0 +1,65 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Domain.Enums;
+
+namespace RallyAPI.Users.Application.Restaurants.Queries.GetDetails;
+
+public sealed record GetRestaurantDetailsQuery(Guid RestaurantId)
+    : IRequest<Result<RestaurantDetailsResponse>>;
+
+public sealed record RestaurantDetailsResponse(
+    Guid Id,
+    RestaurantProfileSection Profile,
+    RestaurantDietarySection Dietary,
+    RestaurantOperationsSection Operations,
+    RestaurantHoursSection Hours,
+    RestaurantDeliverySection Delivery,
+    RestaurantNotificationsSection Notifications);
+
+public sealed record RestaurantProfileSection(
+    string Name,
+    string Phone,
+    string Email,
+    string? FssaiNumber,
+    string AddressLine,
+    decimal Latitude,
+    decimal Longitude,
+    string? Description,
+    string? LogoUrl);
+
+public sealed record RestaurantDietarySection(
+    DietaryType DietaryType,
+    bool IsPureVeg,
+    bool IsVeganFriendly,
+    bool HasJainOptions,
+    List<string> CuisineTypes);
+
+public sealed record RestaurantOperationsSection(
+    bool IsActive,
+    bool IsAcceptingOrders,
+    bool AutoAcceptOrders,
+    int AvgPrepTimeMins,
+    decimal MinOrderAmount,
+    decimal CommissionPercentage);
+
+public sealed record RestaurantHoursSection(
+    bool UseCustomSchedule,
+    TimeOnly OpeningTime,
+    TimeOnly ClosingTime,
+    IReadOnlyList<RestaurantScheduleDay> WeeklySchedule);
+
+public sealed record RestaurantScheduleDay(
+    DayOfWeek DayOfWeek,
+    IReadOnlyList<RestaurantScheduleSlotDto> Slots);
+
+public sealed record RestaurantScheduleSlotDto(
+    TimeOnly OpensAt,
+    TimeOnly ClosesAt);
+
+public sealed record RestaurantDeliverySection(
+    DeliveryMode DeliveryMode);
+
+public sealed record RestaurantNotificationsSection(
+    bool EmailAlerts,
+    bool BrowserNotifications,
+    bool OrderSound);

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Queries/GetDetails/GetRestaurantDetailsQueryHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Queries/GetDetails/GetRestaurantDetailsQueryHandler.cs
@@ -1,0 +1,80 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Application.Abstractions;
+
+namespace RallyAPI.Users.Application.Restaurants.Queries.GetDetails;
+
+internal sealed class GetRestaurantDetailsQueryHandler
+    : IRequestHandler<GetRestaurantDetailsQuery, Result<RestaurantDetailsResponse>>
+{
+    private readonly IRestaurantRepository _restaurantRepository;
+
+    public GetRestaurantDetailsQueryHandler(IRestaurantRepository restaurantRepository)
+    {
+        _restaurantRepository = restaurantRepository;
+    }
+
+    public async Task<Result<RestaurantDetailsResponse>> Handle(
+        GetRestaurantDetailsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var restaurant = await _restaurantRepository.GetByIdWithScheduleAsync(
+            request.RestaurantId,
+            cancellationToken);
+
+        if (restaurant is null)
+            return Result.Failure<RestaurantDetailsResponse>(
+                Error.NotFound("Restaurant", request.RestaurantId));
+
+        var weeklySchedule = Enum.GetValues<DayOfWeek>()
+            .Select(day =>
+            {
+                var slots = restaurant.ScheduleSlots
+                    .Where(s => s.DayOfWeek == day)
+                    .OrderBy(s => s.OpensAt)
+                    .Select(s => new RestaurantScheduleSlotDto(s.OpensAt, s.ClosesAt))
+                    .ToList();
+
+                return new RestaurantScheduleDay(day, slots);
+            })
+            .ToList();
+
+        var response = new RestaurantDetailsResponse(
+            restaurant.Id,
+            new RestaurantProfileSection(
+                restaurant.Name,
+                restaurant.Phone.GetFormatted(),
+                restaurant.Email.Value,
+                restaurant.FssaiNumber,
+                restaurant.AddressLine,
+                restaurant.Latitude,
+                restaurant.Longitude,
+                restaurant.Description,
+                restaurant.LogoUrl),
+            new RestaurantDietarySection(
+                restaurant.DietaryType,
+                restaurant.IsPureVeg,
+                restaurant.IsVeganFriendly,
+                restaurant.HasJainOptions,
+                restaurant.CuisineTypes.ToList()),
+            new RestaurantOperationsSection(
+                restaurant.IsActive,
+                restaurant.IsAcceptingOrders,
+                restaurant.AutoAcceptOrders,
+                restaurant.AvgPrepTimeMins,
+                restaurant.MinOrderAmount,
+                restaurant.CommissionPercentage),
+            new RestaurantHoursSection(
+                restaurant.UseCustomSchedule,
+                restaurant.OpeningTime,
+                restaurant.ClosingTime,
+                weeklySchedule),
+            new RestaurantDeliverySection(restaurant.DeliveryMode),
+            new RestaurantNotificationsSection(
+                restaurant.Notifications.EmailAlerts,
+                restaurant.Notifications.BrowserNotifications,
+                restaurant.Notifications.OrderSound));
+
+        return Result.Success(response);
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Domain/Entities/Restaurant.cs
+++ b/src/Modules/Users/RallyAPI.Users.Domain/Entities/Restaurant.cs
@@ -1,5 +1,6 @@
 ﻿using RallyAPI.SharedKernel.Domain;
 using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Domain.Enums;
 using RallyAPI.Users.Domain.ValueObjects;
 
 namespace RallyAPI.Users.Domain.Entities;
@@ -29,12 +30,31 @@ public sealed class Restaurant : AggregateRoot
     // Compliance
     public string? FssaiNumber { get; private set; }
 
+    // Description
+    public string? Description { get; private set; }
+
     // Restaurant attributes (cuisine/dietary)
     public List<string> CuisineTypes { get; private set; } = new();
     public bool IsPureVeg { get; private set; }
     public bool IsVeganFriendly { get; private set; }
     public bool HasJainOptions { get; private set; }
     public decimal MinOrderAmount { get; private set; }
+
+    // Dietary category (primary) + additive flags above
+    public DietaryType DietaryType { get; private set; } = DietaryType.Both;
+
+    // Delivery fulfilment preference
+    public DeliveryMode DeliveryMode { get; private set; } = DeliveryMode.Hivago;
+
+    // Use custom weekly schedule (slots) instead of legacy single OpeningTime/ClosingTime
+    public bool UseCustomSchedule { get; private set; }
+
+    // Notification preferences (owned value object)
+    public NotificationPreferences Notifications { get; private set; } = NotificationPreferences.Default();
+
+    // Weekly schedule — up to 3 slots per DayOfWeek
+    private readonly List<RestaurantScheduleSlot> _scheduleSlots = new();
+    public IReadOnlyCollection<RestaurantScheduleSlot> ScheduleSlots => _scheduleSlots.AsReadOnly();
 
     // EF Core
     private Restaurant() { }
@@ -272,6 +292,88 @@ public sealed class Restaurant : AggregateRoot
             return Result.Failure(Error.Validation("Commission percentage must be between 0 and 100."));
 
         CommissionPercentage = percentage;
+        MarkAsUpdated();
+        return Result.Success();
+    }
+
+    public Result SetDescription(string? description)
+    {
+        if (description is { Length: > 2000 })
+            return Result.Failure(Error.Validation("Description must be 2000 characters or fewer."));
+
+        Description = string.IsNullOrWhiteSpace(description) ? null : description.Trim();
+        MarkAsUpdated();
+        return Result.Success();
+    }
+
+    public Result SetEmail(Email email)
+    {
+        Email = email;
+        MarkAsUpdated();
+        return Result.Success();
+    }
+
+    public Result SetDietaryType(DietaryType dietaryType)
+    {
+        DietaryType = dietaryType;
+        IsPureVeg = dietaryType == DietaryType.PureVeg;
+        MarkAsUpdated();
+        return Result.Success();
+    }
+
+    public Result SetDeliveryMode(DeliveryMode mode)
+    {
+        DeliveryMode = mode;
+        MarkAsUpdated();
+        return Result.Success();
+    }
+
+    public Result SetUseCustomSchedule(bool useCustom)
+    {
+        UseCustomSchedule = useCustom;
+        MarkAsUpdated();
+        return Result.Success();
+    }
+
+    public Result SetNotificationPreferences(NotificationPreferences preferences)
+    {
+        if (preferences is null)
+            return Result.Failure(Error.Validation("Notification preferences are required."));
+
+        Notifications = preferences;
+        MarkAsUpdated();
+        return Result.Success();
+    }
+
+    public Result ReplaceScheduleForDay(DayOfWeek day, IReadOnlyList<(TimeOnly OpensAt, TimeOnly ClosesAt)> slots)
+    {
+        if (slots is null)
+            return Result.Failure(Error.Validation("Slots collection is required."));
+
+        if (slots.Count > 3)
+            return Result.Failure(Error.Validation($"{day}: at most 3 slots per day are allowed."));
+
+        var ordered = slots.OrderBy(s => s.OpensAt).ToList();
+
+        for (var i = 0; i < ordered.Count; i++)
+        {
+            if (ordered[i].OpensAt >= ordered[i].ClosesAt)
+                return Result.Failure(Error.Validation($"{day} slot {i + 1}: opens-at must be earlier than closes-at."));
+
+            if (i > 0 && ordered[i].OpensAt < ordered[i - 1].ClosesAt)
+                return Result.Failure(Error.Validation($"{day}: slots must not overlap."));
+        }
+
+        _scheduleSlots.RemoveAll(s => s.DayOfWeek == day);
+
+        foreach (var (opensAt, closesAt) in ordered)
+        {
+            var slotResult = RestaurantScheduleSlot.Create(Id, day, opensAt, closesAt);
+            if (slotResult.IsFailure)
+                return Result.Failure(slotResult.Error);
+            _scheduleSlots.Add(slotResult.Value);
+        }
+
         MarkAsUpdated();
         return Result.Success();
     }

--- a/src/Modules/Users/RallyAPI.Users.Domain/Entities/RestaurantScheduleSlot.cs
+++ b/src/Modules/Users/RallyAPI.Users.Domain/Entities/RestaurantScheduleSlot.cs
@@ -1,0 +1,38 @@
+using RallyAPI.SharedKernel.Domain;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Users.Domain.Entities;
+
+public sealed class RestaurantScheduleSlot : BaseEntity
+{
+    public Guid RestaurantId { get; private set; }
+    public DayOfWeek DayOfWeek { get; private set; }
+    public TimeOnly OpensAt { get; private set; }
+    public TimeOnly ClosesAt { get; private set; }
+
+    private RestaurantScheduleSlot() { }
+
+    private RestaurantScheduleSlot(Guid restaurantId, DayOfWeek dayOfWeek, TimeOnly opensAt, TimeOnly closesAt)
+    {
+        RestaurantId = restaurantId;
+        DayOfWeek = dayOfWeek;
+        OpensAt = opensAt;
+        ClosesAt = closesAt;
+    }
+
+    public static Result<RestaurantScheduleSlot> Create(
+        Guid restaurantId,
+        DayOfWeek dayOfWeek,
+        TimeOnly opensAt,
+        TimeOnly closesAt)
+    {
+        if (restaurantId == Guid.Empty)
+            return Result.Failure<RestaurantScheduleSlot>(Error.Validation("Restaurant ID is required."));
+
+        if (opensAt >= closesAt)
+            return Result.Failure<RestaurantScheduleSlot>(
+                Error.Validation($"{dayOfWeek}: opens-at must be earlier than closes-at."));
+
+        return new RestaurantScheduleSlot(restaurantId, dayOfWeek, opensAt, closesAt);
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Domain/Enums/DeliveryMode.cs
+++ b/src/Modules/Users/RallyAPI.Users.Domain/Enums/DeliveryMode.cs
@@ -1,0 +1,7 @@
+namespace RallyAPI.Users.Domain.Enums;
+
+public enum DeliveryMode
+{
+    Hivago = 0,
+    SelfDelivery = 1
+}

--- a/src/Modules/Users/RallyAPI.Users.Domain/Enums/DietaryType.cs
+++ b/src/Modules/Users/RallyAPI.Users.Domain/Enums/DietaryType.cs
@@ -1,0 +1,8 @@
+namespace RallyAPI.Users.Domain.Enums;
+
+public enum DietaryType
+{
+    PureVeg = 0,
+    PureNonVeg = 1,
+    Both = 2
+}

--- a/src/Modules/Users/RallyAPI.Users.Domain/ValueObjects/NotificationPreferences.cs
+++ b/src/Modules/Users/RallyAPI.Users.Domain/ValueObjects/NotificationPreferences.cs
@@ -1,0 +1,14 @@
+namespace RallyAPI.Users.Domain.ValueObjects;
+
+public sealed record NotificationPreferences
+{
+    public bool EmailAlerts { get; init; }
+    public bool BrowserNotifications { get; init; }
+    public bool OrderSound { get; init; }
+
+    public static NotificationPreferences Default() =>
+        new() { EmailAlerts = true, BrowserNotifications = true, OrderSound = true };
+
+    public static NotificationPreferences Create(bool emailAlerts, bool browserNotifications, bool orderSound) =>
+        new() { EmailAlerts = emailAlerts, BrowserNotifications = browserNotifications, OrderSound = orderSound };
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Restaurants/GetDetails.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Restaurants/GetDetails.cs
@@ -1,0 +1,35 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Restaurants.Queries.GetDetails;
+using System.Security.Claims;
+
+namespace RallyAPI.Users.Endpoints.Restaurants;
+
+public class GetDetails : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/restaurants/me/details", HandleAsync)
+            .WithName("GetRestaurantDetails")
+            .WithTags("Restaurants")
+            .WithSummary("Get full restaurant settings (profile, dietary, operations, hours, delivery, notifications)")
+            .RequireAuthorization("Restaurant");
+    }
+
+    private static async Task<IResult> HandleAsync(
+        ClaimsPrincipal user,
+        ISender sender,
+        CancellationToken cancellationToken)
+    {
+        var restaurantId = Guid.Parse(user.FindFirstValue("sub")!);
+
+        var result = await sender.Send(new GetRestaurantDetailsQuery(restaurantId), cancellationToken);
+
+        return result.IsFailure
+            ? result.Error.ToErrorResult()
+            : Results.Ok(result.Value);
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Restaurants/UpdateBasics.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Restaurants/UpdateBasics.cs
@@ -1,0 +1,57 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Restaurants.Commands.UpdateBasics;
+using System.Security.Claims;
+
+namespace RallyAPI.Users.Endpoints.Restaurants;
+
+public class UpdateBasics : IEndpoint
+{
+    public sealed record UpdateBasicsRequest(
+        string? Name,
+        string? Phone,
+        string? Email,
+        string? FssaiNumber,
+        string? AddressLine,
+        decimal? Latitude,
+        decimal? Longitude,
+        string? Description);
+
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPatch("/api/restaurants/me/profile", HandleAsync)
+            .WithName("UpdateRestaurantBasics")
+            .WithTags("Restaurants")
+            .WithSummary("Update restaurant basics: name, phone, email, FSSAI, address, description")
+            .RequireAuthorization("Restaurant");
+    }
+
+    private static async Task<IResult> HandleAsync(
+        [FromBody] UpdateBasicsRequest request,
+        ClaimsPrincipal user,
+        ISender sender,
+        CancellationToken ct)
+    {
+        var restaurantId = Guid.Parse(user.FindFirstValue("sub")!);
+
+        var command = new UpdateRestaurantBasicsCommand(
+            restaurantId,
+            request.Name,
+            request.Phone,
+            request.Email,
+            request.FssaiNumber,
+            request.AddressLine,
+            request.Latitude,
+            request.Longitude,
+            request.Description);
+
+        var result = await sender.Send(command, ct);
+        return result.IsFailure
+            ? result.Error.ToErrorResult()
+            : Results.Ok(new { message = "Profile updated successfully." });
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Restaurants/UpdateDelivery.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Restaurants/UpdateDelivery.cs
@@ -1,0 +1,41 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Restaurants.Commands.UpdateDelivery;
+using RallyAPI.Users.Domain.Enums;
+using System.Security.Claims;
+
+namespace RallyAPI.Users.Endpoints.Restaurants;
+
+public class UpdateDelivery : IEndpoint
+{
+    public sealed record UpdateDeliveryRequest(DeliveryMode DeliveryMode);
+
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPatch("/api/restaurants/me/delivery", HandleAsync)
+            .WithName("UpdateRestaurantDeliveryMode")
+            .WithTags("Restaurants")
+            .WithSummary("Switch between Hivago delivery and self-delivery")
+            .RequireAuthorization("Restaurant");
+    }
+
+    private static async Task<IResult> HandleAsync(
+        [FromBody] UpdateDeliveryRequest request,
+        ClaimsPrincipal user,
+        ISender sender,
+        CancellationToken ct)
+    {
+        var restaurantId = Guid.Parse(user.FindFirstValue("sub")!);
+
+        var command = new UpdateRestaurantDeliveryCommand(restaurantId, request.DeliveryMode);
+        var result = await sender.Send(command, ct);
+
+        return result.IsFailure
+            ? result.Error.ToErrorResult()
+            : Results.Ok(new { deliveryMode = request.DeliveryMode });
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Restaurants/UpdateDietary.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Restaurants/UpdateDietary.cs
@@ -1,0 +1,50 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Restaurants.Commands.UpdateDietary;
+using RallyAPI.Users.Domain.Enums;
+using System.Security.Claims;
+
+namespace RallyAPI.Users.Endpoints.Restaurants;
+
+public class UpdateDietary : IEndpoint
+{
+    public sealed record UpdateDietaryRequest(
+        DietaryType? DietaryType,
+        bool? IsVeganFriendly,
+        bool? HasJainOptions,
+        List<string>? CuisineTypes);
+
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPatch("/api/restaurants/me/dietary", HandleAsync)
+            .WithName("UpdateRestaurantDietary")
+            .WithTags("Restaurants")
+            .WithSummary("Update dietary type, vegan/Jain flags, and cuisine types")
+            .RequireAuthorization("Restaurant");
+    }
+
+    private static async Task<IResult> HandleAsync(
+        [FromBody] UpdateDietaryRequest request,
+        ClaimsPrincipal user,
+        ISender sender,
+        CancellationToken ct)
+    {
+        var restaurantId = Guid.Parse(user.FindFirstValue("sub")!);
+
+        var command = new UpdateRestaurantDietaryCommand(
+            restaurantId,
+            request.DietaryType,
+            request.IsVeganFriendly,
+            request.HasJainOptions,
+            request.CuisineTypes);
+
+        var result = await sender.Send(command, ct);
+        return result.IsFailure
+            ? result.Error.ToErrorResult()
+            : Results.Ok(new { message = "Dietary settings updated." });
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Restaurants/UpdateHours.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Restaurants/UpdateHours.cs
@@ -1,0 +1,49 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Restaurants.Commands.UpdateHours;
+using System.Security.Claims;
+
+namespace RallyAPI.Users.Endpoints.Restaurants;
+
+public class UpdateHours : IEndpoint
+{
+    public sealed record UpdateHoursRequest(
+        TimeOnly? OpeningTime,
+        TimeOnly? ClosingTime,
+        bool? UseCustomSchedule,
+        List<WeeklyScheduleDayInput>? WeeklySchedule);
+
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPatch("/api/restaurants/me/hours", HandleAsync)
+            .WithName("UpdateRestaurantHours")
+            .WithTags("Restaurants")
+            .WithSummary("Update opening/closing time and weekly schedule (up to 3 slots per day)")
+            .RequireAuthorization("Restaurant");
+    }
+
+    private static async Task<IResult> HandleAsync(
+        [FromBody] UpdateHoursRequest request,
+        ClaimsPrincipal user,
+        ISender sender,
+        CancellationToken ct)
+    {
+        var restaurantId = Guid.Parse(user.FindFirstValue("sub")!);
+
+        var command = new UpdateRestaurantHoursCommand(
+            restaurantId,
+            request.OpeningTime,
+            request.ClosingTime,
+            request.UseCustomSchedule,
+            request.WeeklySchedule);
+
+        var result = await sender.Send(command, ct);
+        return result.IsFailure
+            ? result.Error.ToErrorResult()
+            : Results.Ok(new { message = "Hours updated." });
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Restaurants/UpdateNotifications.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Restaurants/UpdateNotifications.cs
@@ -1,0 +1,47 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Restaurants.Commands.UpdateNotifications;
+using System.Security.Claims;
+
+namespace RallyAPI.Users.Endpoints.Restaurants;
+
+public class UpdateNotifications : IEndpoint
+{
+    public sealed record UpdateNotificationsRequest(
+        bool? EmailAlerts,
+        bool? BrowserNotifications,
+        bool? OrderSound);
+
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPatch("/api/restaurants/me/notifications", HandleAsync)
+            .WithName("UpdateRestaurantNotifications")
+            .WithTags("Restaurants")
+            .WithSummary("Toggle email alerts, browser notifications, order sound")
+            .RequireAuthorization("Restaurant");
+    }
+
+    private static async Task<IResult> HandleAsync(
+        [FromBody] UpdateNotificationsRequest request,
+        ClaimsPrincipal user,
+        ISender sender,
+        CancellationToken ct)
+    {
+        var restaurantId = Guid.Parse(user.FindFirstValue("sub")!);
+
+        var command = new UpdateRestaurantNotificationsCommand(
+            restaurantId,
+            request.EmailAlerts,
+            request.BrowserNotifications,
+            request.OrderSound);
+
+        var result = await sender.Send(command, ct);
+        return result.IsFailure
+            ? result.Error.ToErrorResult()
+            : Results.Ok(new { message = "Notification preferences updated." });
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Restaurants/UpdateOperations.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Restaurants/UpdateOperations.cs
@@ -1,0 +1,51 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Restaurants.Commands.UpdateOperations;
+using System.Security.Claims;
+
+namespace RallyAPI.Users.Endpoints.Restaurants;
+
+public class UpdateOperations : IEndpoint
+{
+    public sealed record UpdateOperationsRequest(
+        bool? AutoAcceptOrders,
+        int? AvgPrepTimeMins,
+        bool? IsAcceptingOrders,
+        decimal? MinOrderAmount,
+        bool? UseCustomSchedule);
+
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPatch("/api/restaurants/me/operations", HandleAsync)
+            .WithName("UpdateRestaurantOperations")
+            .WithTags("Restaurants")
+            .WithSummary("Toggle auto-accept, accepting orders, min order amount, prep time, custom schedule flag")
+            .RequireAuthorization("Restaurant");
+    }
+
+    private static async Task<IResult> HandleAsync(
+        [FromBody] UpdateOperationsRequest request,
+        ClaimsPrincipal user,
+        ISender sender,
+        CancellationToken ct)
+    {
+        var restaurantId = Guid.Parse(user.FindFirstValue("sub")!);
+
+        var command = new UpdateRestaurantOperationsCommand(
+            restaurantId,
+            request.AutoAcceptOrders,
+            request.AvgPrepTimeMins,
+            request.IsAcceptingOrders,
+            request.MinOrderAmount,
+            request.UseCustomSchedule);
+
+        var result = await sender.Send(command, ct);
+        return result.IsFailure
+            ? result.Error.ToErrorResult()
+            : Results.Ok(new { message = "Operations settings updated." });
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Restaurants/UpdatePassword.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Restaurants/UpdatePassword.cs
@@ -1,0 +1,43 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Restaurants.Commands.UpdatePassword;
+using System.Security.Claims;
+
+namespace RallyAPI.Users.Endpoints.Restaurants;
+
+public class UpdatePassword : IEndpoint
+{
+    public sealed record UpdatePasswordRequest(string CurrentPassword, string NewPassword);
+
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPatch("/api/restaurants/me/password", HandleAsync)
+            .WithName("UpdateRestaurantPassword")
+            .WithTags("Restaurants")
+            .WithSummary("Change account password (requires current password)")
+            .RequireAuthorization("Restaurant");
+    }
+
+    private static async Task<IResult> HandleAsync(
+        [FromBody] UpdatePasswordRequest request,
+        ClaimsPrincipal user,
+        ISender sender,
+        CancellationToken ct)
+    {
+        var restaurantId = Guid.Parse(user.FindFirstValue("sub")!);
+
+        var command = new UpdateRestaurantPasswordCommand(
+            restaurantId,
+            request.CurrentPassword,
+            request.NewPassword);
+
+        var result = await sender.Send(command, ct);
+        return result.IsFailure
+            ? result.Error.ToErrorResult()
+            : Results.Ok(new { message = "Password updated." });
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Configurations/RestaurantConfiguration.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Configurations/RestaurantConfiguration.cs
@@ -201,5 +201,59 @@ public class RestaurantConfiguration : IEntityTypeConfiguration<Restaurant>
             .HasPrecision(10, 2)
             .HasDefaultValue(0m)
             .IsRequired();
+
+        // Description
+        builder.Property(r => r.Description)
+            .HasColumnName("description")
+            .HasMaxLength(2000);
+
+        // Dietary type (enum stored as integer)
+        builder.Property(r => r.DietaryType)
+            .HasColumnName("dietary_type")
+            .HasConversion<int>()
+            .HasDefaultValue(Domain.Enums.DietaryType.Both)
+            .IsRequired();
+
+        // Delivery mode (enum stored as integer, default Hivago)
+        builder.Property(r => r.DeliveryMode)
+            .HasColumnName("delivery_mode")
+            .HasConversion<int>()
+            .HasDefaultValue(Domain.Enums.DeliveryMode.Hivago)
+            .IsRequired();
+
+        // Use custom weekly schedule flag
+        builder.Property(r => r.UseCustomSchedule)
+            .HasColumnName("use_custom_schedule")
+            .HasDefaultValue(false)
+            .IsRequired();
+
+        // Notification preferences — owned value object
+        builder.OwnsOne(r => r.Notifications, nav =>
+        {
+            nav.Property(n => n.EmailAlerts)
+                .HasColumnName("notify_email_alerts")
+                .HasDefaultValue(true)
+                .IsRequired();
+
+            nav.Property(n => n.BrowserNotifications)
+                .HasColumnName("notify_browser")
+                .HasDefaultValue(true)
+                .IsRequired();
+
+            nav.Property(n => n.OrderSound)
+                .HasColumnName("notify_order_sound")
+                .HasDefaultValue(true)
+                .IsRequired();
+        });
+
+        // Weekly schedule slots — one-to-many
+        builder.HasMany(r => r.ScheduleSlots)
+            .WithOne()
+            .HasForeignKey(s => s.RestaurantId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Metadata
+            .FindNavigation(nameof(Restaurant.ScheduleSlots))!
+            .SetPropertyAccessMode(PropertyAccessMode.Field);
     }
 }

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Configurations/RestaurantScheduleSlotConfiguration.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Configurations/RestaurantScheduleSlotConfiguration.cs
@@ -1,0 +1,54 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using RallyAPI.Users.Domain.Entities;
+
+namespace RallyAPI.Users.Infrastructure.Persistence.Configurations;
+
+public sealed class RestaurantScheduleSlotConfiguration : IEntityTypeConfiguration<RestaurantScheduleSlot>
+{
+    public void Configure(EntityTypeBuilder<RestaurantScheduleSlot> builder)
+    {
+        builder.ToTable("restaurant_schedule_slots");
+
+        builder.HasKey(s => s.Id);
+
+        builder.Property(s => s.Id)
+            .HasColumnName("id")
+            .ValueGeneratedNever();
+
+        builder.Property(s => s.RestaurantId)
+            .HasColumnName("restaurant_id")
+            .IsRequired();
+
+        builder.Property(s => s.DayOfWeek)
+            .HasColumnName("day_of_week")
+            .HasConversion<int>()
+            .IsRequired();
+
+        builder.Property(s => s.OpensAt)
+            .HasColumnName("opens_at")
+            .IsRequired();
+
+        builder.Property(s => s.ClosesAt)
+            .HasColumnName("closes_at")
+            .IsRequired();
+
+        builder.Property(s => s.CreatedAt)
+            .HasColumnName("created_at")
+            .IsRequired();
+
+        builder.Property(s => s.UpdatedAt)
+            .HasColumnName("updated_at")
+            .IsRequired();
+
+        builder.Property(s => s.DeletedAt)
+            .HasColumnName("deleted_at")
+            .IsRequired(false);
+
+        builder.HasIndex(s => new { s.RestaurantId, s.DayOfWeek })
+            .HasDatabaseName("idx_restaurant_schedule_slots_restaurant_day");
+
+        builder.Ignore(s => s.DomainEvents);
+        builder.HasQueryFilter(s => s.DeletedAt == null);
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Migrations/20260421082223_AddRestaurantSettingsAndSchedule.Designer.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Migrations/20260421082223_AddRestaurantSettingsAndSchedule.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RallyAPI.Users.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using RallyAPI.Users.Infrastructure.Persistence;
 namespace RallyAPI.Users.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(UsersDbContext))]
-    partial class UsersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260421082223_AddRestaurantSettingsAndSchedule")]
+    partial class AddRestaurantSettingsAndSchedule
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Migrations/20260421082223_AddRestaurantSettingsAndSchedule.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Migrations/20260421082223_AddRestaurantSettingsAndSchedule.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RallyAPI.Users.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRestaurantSettingsAndSchedule : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "delivery_mode",
+                schema: "users",
+                table: "restaurants",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "description",
+                schema: "users",
+                table: "restaurants",
+                type: "character varying(2000)",
+                maxLength: 2000,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "dietary_type",
+                schema: "users",
+                table: "restaurants",
+                type: "integer",
+                nullable: false,
+                defaultValue: 2);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "notify_browser",
+                schema: "users",
+                table: "restaurants",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "notify_email_alerts",
+                schema: "users",
+                table: "restaurants",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "notify_order_sound",
+                schema: "users",
+                table: "restaurants",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "use_custom_schedule",
+                schema: "users",
+                table: "restaurants",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateTable(
+                name: "restaurant_schedule_slots",
+                schema: "users",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    restaurant_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    day_of_week = table.Column<int>(type: "integer", nullable: false),
+                    opens_at = table.Column<TimeOnly>(type: "time without time zone", nullable: false),
+                    closes_at = table.Column<TimeOnly>(type: "time without time zone", nullable: false),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    deleted_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_restaurant_schedule_slots", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_restaurant_schedule_slots_restaurants_restaurant_id",
+                        column: x => x.restaurant_id,
+                        principalSchema: "users",
+                        principalTable: "restaurants",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "idx_restaurant_schedule_slots_restaurant_day",
+                schema: "users",
+                table: "restaurant_schedule_slots",
+                columns: new[] { "restaurant_id", "day_of_week" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "restaurant_schedule_slots",
+                schema: "users");
+
+            migrationBuilder.DropColumn(
+                name: "delivery_mode",
+                schema: "users",
+                table: "restaurants");
+
+            migrationBuilder.DropColumn(
+                name: "description",
+                schema: "users",
+                table: "restaurants");
+
+            migrationBuilder.DropColumn(
+                name: "dietary_type",
+                schema: "users",
+                table: "restaurants");
+
+            migrationBuilder.DropColumn(
+                name: "notify_browser",
+                schema: "users",
+                table: "restaurants");
+
+            migrationBuilder.DropColumn(
+                name: "notify_email_alerts",
+                schema: "users",
+                table: "restaurants");
+
+            migrationBuilder.DropColumn(
+                name: "notify_order_sound",
+                schema: "users",
+                table: "restaurants");
+
+            migrationBuilder.DropColumn(
+                name: "use_custom_schedule",
+                schema: "users",
+                table: "restaurants");
+        }
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Repositories/RestaurantRepository.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Repositories/RestaurantRepository.cs
@@ -20,6 +20,13 @@ public class RestaurantRepository : IRestaurantRepository
             .FirstOrDefaultAsync(r => r.Id == id, cancellationToken);
     }
 
+    public async Task<Restaurant?> GetByIdWithScheduleAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return await _context.Restaurants
+            .Include(r => r.ScheduleSlots)
+            .FirstOrDefaultAsync(r => r.Id == id, cancellationToken);
+    }
+
     public async Task<Restaurant?> GetByEmailAsync(Email email, CancellationToken cancellationToken = default)
     {
         return await _context.Restaurants


### PR DESCRIPTION
Adds GetDetails query and section-scoped PATCH endpoints (basics, dietary, operations, hours, delivery, notifications, password) backed by Restaurant entity updates, new RestaurantScheduleSlot, DeliveryMode/DietaryType enums, and NotificationPreferences value object. Includes migration AddRestaurantSettingsAndSchedule.