### PR TITLE
feat(admin): add SignalR auto-update channels for admin panel

### DIFF
--- a/src/Modules/Users/RallyAPI.Users.Application/Riders/Commands/UploadKyc/ConfirmRiderKycDocumentCommand.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Riders/Commands/UploadKyc/ConfirmRiderKycDocumentCommand.cs
@@ -33,13 +33,16 @@ public sealed class ConfirmRiderKycDocumentCommandHandler
 {
     private readonly IRiderRepository _riderRepository;
     private readonly IStorageService _storage;
+    private readonly IUnitOfWork _unitOfWork;
 
     public ConfirmRiderKycDocumentCommandHandler(
         IRiderRepository riderRepository,
-        IStorageService storage)
+        IStorageService storage,
+        IUnitOfWork unitOfWork)
     {
         _riderRepository = riderRepository;
         _storage = storage;
+        _unitOfWork = unitOfWork;
     }
 
     public async Task<Result<ConfirmRiderKycDocumentResponse>> Handle(
@@ -79,6 +82,7 @@ public sealed class ConfirmRiderKycDocumentCommandHandler
 
         // 6. Save rider — EF Core cascade saves the KycDocuments collection
         _riderRepository.Update(rider, ct);
+        await _unitOfWork.SaveChangesAsync(ct);
 
         return Result.Success(new ConfirmRiderKycDocumentResponse(
             document.Id,

--- a/src/Modules/Users/RallyAPI.Users.Domain/Entities/Rider.cs
+++ b/src/Modules/Users/RallyAPI.Users.Domain/Entities/Rider.cs
@@ -90,15 +90,25 @@ public sealed class Rider : AggregateRoot
         if (KycStatus != KycStatus.Verified)
             return Result.Failure(Error.Validation("KYC must be verified to go online."));
 
+        var wasOnline = IsOnline;
         IsOnline = true;
         MarkAsUpdated();
+
+        if (!wasOnline)
+            AddDomainEvent(new RiderWentOnlineEvent(Id, Name));
+
         return Result.Success();
     }
 
     public Result GoOffline()
     {
+        var wasOnline = IsOnline;
         IsOnline = false;
         MarkAsUpdated();
+
+        if (wasOnline)
+            AddDomainEvent(new RiderWentOfflineEvent(Id, Name));
+
         return Result.Success();
     }
 
@@ -268,6 +278,8 @@ public sealed class Rider : AggregateRoot
         var document = RiderKycDocument.Create(Id, documentType, fileKey, publicUrl);
         _kycDocuments.Add(document);
         UpdatedAt = DateTime.UtcNow;
+
+        AddDomainEvent(new RiderKycSubmittedEvent(Id, Name, documentType));
 
         return document;
     }

--- a/src/Modules/Users/RallyAPI.Users.Domain/Events/RiderKycSubmittedEvent.cs
+++ b/src/Modules/Users/RallyAPI.Users.Domain/Events/RiderKycSubmittedEvent.cs
@@ -1,0 +1,18 @@
+using RallyAPI.SharedKernel.Domain;
+using RallyAPI.Users.Domain.Entities;
+
+namespace RallyAPI.Users.Domain.Events;
+
+public sealed class RiderKycSubmittedEvent : BaseDomainEvent
+{
+    public Guid RiderId { get; }
+    public string Name { get; }
+    public RiderKycDocumentType DocumentType { get; }
+
+    public RiderKycSubmittedEvent(Guid riderId, string name, RiderKycDocumentType documentType)
+    {
+        RiderId = riderId;
+        Name = name;
+        DocumentType = documentType;
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Domain/Events/RiderWentOfflineEvent.cs
+++ b/src/Modules/Users/RallyAPI.Users.Domain/Events/RiderWentOfflineEvent.cs
@@ -1,0 +1,15 @@
+using RallyAPI.SharedKernel.Domain;
+
+namespace RallyAPI.Users.Domain.Events;
+
+public sealed class RiderWentOfflineEvent : BaseDomainEvent
+{
+    public Guid RiderId { get; }
+    public string Name { get; }
+
+    public RiderWentOfflineEvent(Guid riderId, string name)
+    {
+        RiderId = riderId;
+        Name = name;
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Domain/Events/RiderWentOnlineEvent.cs
+++ b/src/Modules/Users/RallyAPI.Users.Domain/Events/RiderWentOnlineEvent.cs
@@ -1,0 +1,15 @@
+using RallyAPI.SharedKernel.Domain;
+
+namespace RallyAPI.Users.Domain.Events;
+
+public sealed class RiderWentOnlineEvent : BaseDomainEvent
+{
+    public Guid RiderId { get; }
+    public string Name { get; }
+
+    public RiderWentOnlineEvent(Guid riderId, string name)
+    {
+        RiderId = riderId;
+        Name = name;
+    }
+}

--- a/src/RallyAPI.Host/Notifications/AdminOrderFeedHandler.cs
+++ b/src/RallyAPI.Host/Notifications/AdminOrderFeedHandler.cs
@@ -1,0 +1,186 @@
+using MediatR;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using RallyAPI.Host.Hubs;
+using RallyAPI.Orders.Domain.Abstractions;
+using RallyAPI.Orders.Domain.Events;
+
+namespace RallyAPI.Host.Notifications;
+
+/// <summary>
+/// Pushes order lifecycle events to the admin SignalR group as a unified
+/// "AdminOrderFeed" channel. Drives both the live orders feed and the
+/// dashboard counters (activeOrders, todayOrders) in the admin panel.
+///
+/// OrderEscalatedToAdminEvent is intentionally NOT handled here — it is
+/// pushed separately as "OrderEscalated" by EscalationSignalRHandler so the
+/// admin UI can surface it as a distinct alert.
+/// </summary>
+public sealed class AdminOrderFeedHandler :
+    INotificationHandler<OrderConfirmedEvent>,
+    INotificationHandler<RiderAssignedEvent>,
+    INotificationHandler<OrderPickedUpEvent>,
+    INotificationHandler<OrderDeliveredEvent>,
+    INotificationHandler<OrderFailedEvent>,
+    INotificationHandler<OrderCancelledEvent>,
+    INotificationHandler<OrderRejectedEvent>
+{
+    private readonly IHubContext<NotificationHub> _hub;
+    private readonly IOrderRepository _orders;
+    private readonly ILogger<AdminOrderFeedHandler> _logger;
+
+    public AdminOrderFeedHandler(
+        IHubContext<NotificationHub> hub,
+        IOrderRepository orders,
+        ILogger<AdminOrderFeedHandler> logger)
+    {
+        _hub = hub;
+        _orders = orders;
+        _logger = logger;
+    }
+
+    public async Task Handle(OrderConfirmedEvent notification, CancellationToken ct)
+    {
+        var order = await _orders.GetByIdAsync(notification.OrderId, ct);
+        if (order is null) { LogMissing(notification.OrderId); return; }
+
+        await Push("OrderPlaced", new
+        {
+            orderId        = order.Id,
+            orderNumber    = order.OrderNumber.Value,
+            restaurantId   = order.RestaurantId,
+            restaurantName = order.RestaurantName,
+            customerId     = order.CustomerId,
+            customerName   = order.CustomerName,
+            status         = order.Status.ToString(),
+            totalAmount    = order.Pricing.Total.Amount,
+            occurredAt     = notification.OccurredAt
+        }, ct);
+    }
+
+    public async Task Handle(RiderAssignedEvent notification, CancellationToken ct)
+    {
+        var order = await _orders.GetByIdAsync(notification.OrderId, ct);
+        if (order is null) { LogMissing(notification.OrderId); return; }
+
+        await Push("RiderAssigned", new
+        {
+            orderId        = order.Id,
+            orderNumber    = order.OrderNumber.Value,
+            restaurantId   = order.RestaurantId,
+            restaurantName = order.RestaurantName,
+            riderId        = order.DeliveryInfo?.RiderId,
+            riderName      = order.DeliveryInfo?.RiderName,
+            status         = order.Status.ToString(),
+            totalAmount    = order.Pricing.Total.Amount,
+            occurredAt     = notification.OccurredAt
+        }, ct);
+    }
+
+    public async Task Handle(OrderPickedUpEvent notification, CancellationToken ct)
+    {
+        var order = await _orders.GetByIdAsync(notification.OrderId, ct);
+        if (order is null) { LogMissing(notification.OrderId); return; }
+
+        await Push("PickedUp", new
+        {
+            orderId        = order.Id,
+            orderNumber    = order.OrderNumber.Value,
+            restaurantId   = order.RestaurantId,
+            restaurantName = order.RestaurantName,
+            riderId        = notification.RiderId,
+            status         = order.Status.ToString(),
+            totalAmount    = order.Pricing.Total.Amount,
+            occurredAt     = notification.OccurredAt
+        }, ct);
+    }
+
+    public async Task Handle(OrderDeliveredEvent notification, CancellationToken ct)
+    {
+        var order = await _orders.GetByIdAsync(notification.OrderId, ct);
+        if (order is null) { LogMissing(notification.OrderId); return; }
+
+        await Push("Delivered", new
+        {
+            orderId        = order.Id,
+            orderNumber    = order.OrderNumber.Value,
+            restaurantId   = order.RestaurantId,
+            restaurantName = order.RestaurantName,
+            riderId        = notification.RiderId,
+            status         = order.Status.ToString(),
+            totalAmount    = order.Pricing.Total.Amount,
+            occurredAt     = notification.OccurredAt
+        }, ct);
+    }
+
+    public async Task Handle(OrderFailedEvent notification, CancellationToken ct)
+    {
+        var order = await _orders.GetByIdAsync(notification.OrderId, ct);
+        if (order is null) { LogMissing(notification.OrderId); return; }
+
+        await Push("Failed", new
+        {
+            orderId        = order.Id,
+            orderNumber    = order.OrderNumber.Value,
+            restaurantId   = order.RestaurantId,
+            restaurantName = order.RestaurantName,
+            status         = order.Status.ToString(),
+            totalAmount    = order.Pricing.Total.Amount,
+            reason         = notification.Reason,
+            occurredAt     = notification.OccurredAt
+        }, ct);
+    }
+
+    public async Task Handle(OrderCancelledEvent notification, CancellationToken ct)
+    {
+        var order = await _orders.GetByIdAsync(notification.OrderId, ct);
+        if (order is null) { LogMissing(notification.OrderId); return; }
+
+        await Push("Cancelled", new
+        {
+            orderId        = order.Id,
+            orderNumber    = order.OrderNumber.Value,
+            restaurantId   = order.RestaurantId,
+            restaurantName = order.RestaurantName,
+            status         = order.Status.ToString(),
+            totalAmount    = order.Pricing.Total.Amount,
+            reason         = notification.Reason.ToString(),
+            cancelledBy    = notification.CancelledBy,
+            occurredAt     = notification.OccurredAt
+        }, ct);
+    }
+
+    public async Task Handle(OrderRejectedEvent notification, CancellationToken ct)
+    {
+        var order = await _orders.GetByIdAsync(notification.OrderId, ct);
+        if (order is null) { LogMissing(notification.OrderId); return; }
+
+        await Push("Rejected", new
+        {
+            orderId        = order.Id,
+            orderNumber    = order.OrderNumber.Value,
+            restaurantId   = order.RestaurantId,
+            restaurantName = order.RestaurantName,
+            status         = order.Status.ToString(),
+            totalAmount    = order.Pricing.Total.Amount,
+            reason         = notification.Reason,
+            occurredAt     = notification.OccurredAt
+        }, ct);
+    }
+
+    private Task Push(string eventName, object payload, CancellationToken ct)
+    {
+        var envelope = new
+        {
+            @event   = eventName,
+            payload
+        };
+
+        return _hub.Clients.Group("admin").SendAsync("AdminOrderFeed", envelope, ct);
+    }
+
+    private void LogMissing(Guid orderId) =>
+        _logger.LogWarning(
+            "AdminOrderFeedHandler: order {OrderId} not found, skipping push",
+            orderId);
+}

--- a/src/RallyAPI.Host/Notifications/AdminRiderFeedHandler.cs
+++ b/src/RallyAPI.Host/Notifications/AdminRiderFeedHandler.cs
@@ -1,0 +1,72 @@
+using MediatR;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using RallyAPI.Host.Hubs;
+using RallyAPI.Users.Domain.Events;
+
+namespace RallyAPI.Host.Notifications;
+
+/// <summary>
+/// Pushes rider lifecycle events to the admin SignalR group as a unified
+/// "AdminRiderFeed" channel. Drives the dashboard counters
+/// (onlineRiders, pendingKyc) in the admin panel.
+///
+/// KycSubmitted carries showToast=true so the admin panel surfaces a toast
+/// even when the operator is on a different page — they should not miss a
+/// new KYC submission.
+/// </summary>
+public sealed class AdminRiderFeedHandler :
+    INotificationHandler<RiderWentOnlineEvent>,
+    INotificationHandler<RiderWentOfflineEvent>,
+    INotificationHandler<RiderKycSubmittedEvent>
+{
+    private readonly IHubContext<NotificationHub> _hub;
+    private readonly ILogger<AdminRiderFeedHandler> _logger;
+
+    public AdminRiderFeedHandler(
+        IHubContext<NotificationHub> hub,
+        ILogger<AdminRiderFeedHandler> logger)
+    {
+        _hub = hub;
+        _logger = logger;
+    }
+
+    public Task Handle(RiderWentOnlineEvent notification, CancellationToken ct) =>
+        Push("RiderOnline", new
+        {
+            riderId    = notification.RiderId,
+            name       = notification.Name,
+            showToast  = false,
+            occurredAt = notification.OccurredAt
+        }, ct);
+
+    public Task Handle(RiderWentOfflineEvent notification, CancellationToken ct) =>
+        Push("RiderOffline", new
+        {
+            riderId    = notification.RiderId,
+            name       = notification.Name,
+            showToast  = false,
+            occurredAt = notification.OccurredAt
+        }, ct);
+
+    public Task Handle(RiderKycSubmittedEvent notification, CancellationToken ct) =>
+        Push("KycSubmitted", new
+        {
+            riderId      = notification.RiderId,
+            name         = notification.Name,
+            documentType = notification.DocumentType.ToString(),
+            showToast    = true,
+            occurredAt   = notification.OccurredAt
+        }, ct);
+
+    private Task Push(string eventName, object payload, CancellationToken ct)
+    {
+        var envelope = new
+        {
+            @event = eventName,
+            payload
+        };
+
+        return _hub.Clients.Group("admin").SendAsync("AdminRiderFeed", envelope, ct);
+    }
+}


### PR DESCRIPTION
Wire two new realtime channels on the existing /hubs/notifications hub so the admin panel can drop polling and react live, mirroring what the restaurant dashboard already does.

AdminOrderFeed (single channel, sub-events in payload.event):
- OrderPlaced     <- OrderConfirmedEvent
- RiderAssigned   <- RiderAssignedEvent
- PickedUp        <- OrderPickedUpEvent
- Delivered       <- OrderDeliveredEvent
- Failed          <- OrderFailedEvent
- Cancelled       <- OrderCancelledEvent
- Rejected        <- OrderRejectedEvent
Drives the live orders feed and the activeOrders / todayOrders
counters on /api/admin/dashboard/stats. OrderEscalated stays on its
own channel as before.

AdminRiderFeed (single channel, sub-events in payload.event):
- RiderOnline     <- new RiderWentOnlineEvent  (showToast=false)
- RiderOffline    <- new RiderWentOfflineEvent (showToast=false)
- KycSubmitted    <- new RiderKycSubmittedEvent (showToast=true)
Drives onlineRiders and pendingKyc counters. KycSubmitted carries
showToast=true so admins do not miss a new submission while on a
different page.

Domain
- Three new domain events on Rider aggregate; emitted only on actual state transitions (no-op GoOnline/GoOffline does not fire).

Application
- Fixed pre-existing missing SaveChangesAsync in ConfirmRiderKycDocumentCommandHandler. Without it the KYC document was not actually persisted (and the new domain event would never reach the interceptor).

Build green (0 errors). All 110 unit tests pass.
Smoke test deferred — local Redis was not running; build + DI registration via assembly scan confirm wiring.