### PR TITLE
fix(delivery): force UTC on quote ExpiresAt to satisfy timestamptz

### DIFF
--- a/src/Modules/Delivery/RallyAPI.Delivery.Domain/Entities/DeliveryQuote.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Domain/Entities/DeliveryQuote.cs
@@ -86,7 +86,7 @@ public sealed class DeliveryQuote : BaseEntity
             FleetType = FleetType.OwnFleet,
             ProviderName = "Rally",
             CreatedAt = DateTime.UtcNow,
-            ExpiresAt = expiresAt,
+            ExpiresAt = NormalizeToUtc(expiresAt),
             BreakdownJson = breakdownJson
         };
     }
@@ -124,9 +124,20 @@ public sealed class DeliveryQuote : BaseEntity
             ProviderName = providerName,
             ProviderQuoteId = providerQuoteId,
             CreatedAt = DateTime.UtcNow,
-            ExpiresAt = expiresAt
+            ExpiresAt = NormalizeToUtc(expiresAt)
         };
     }
+
+    /// <summary>
+    /// Postgres `timestamp with time zone` rejects DateTime.Kind=Unspecified or Local.
+    /// Coerce any caller's value to UTC so we never crash on save.
+    /// </summary>
+    private static DateTime NormalizeToUtc(DateTime value) => value.Kind switch
+    {
+        DateTimeKind.Utc => value,
+        DateTimeKind.Local => value.ToUniversalTime(),
+        _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+    };
 
     public void MarkAsUsed(Guid orderId)
     {

--- a/src/Modules/Integrations/ProRouting/ProRoutingTaskService.cs
+++ b/src/Modules/Integrations/ProRouting/ProRoutingTaskService.cs
@@ -139,11 +139,18 @@ public sealed class ProRoutingTaskService : IThirdPartyDeliveryProvider, IIgmPro
                 })
                 .ToList();
 
-            // Parse validity
+            // Parse validity. ProRouting returns timestamps without a TZ suffix, so DateTime.TryParse
+            // produces Kind=Unspecified which Postgres rejects on `timestamp with time zone` columns.
+            // Force UTC: assume universal, then convert to UTC kind.
             DateTime validUntil = DateTime.UtcNow.AddMinutes(5);
-            if (!string.IsNullOrEmpty(quotesResponse.ValidUntil))
+            if (!string.IsNullOrEmpty(quotesResponse.ValidUntil)
+                && DateTime.TryParse(
+                    quotesResponse.ValidUntil,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal,
+                    out var parsed))
             {
-                DateTime.TryParse(quotesResponse.ValidUntil, out validUntil);
+                validUntil = parsed;
             }
 
             _logger.LogInformation(


### PR DESCRIPTION
Root cause of 500s on /api/delivery/quote with no own riders: ProRouting returns valid_until as a TZ-less string. DateTime.TryParse yielded Kind=Unspecified, which Npgsql rejects when writing to a `timestamp with time zone` column, so every 3PL quote crashed at save.

Two-layer fix:
- ProRoutingTaskService: parse with AssumeUniversal | AdjustToUniversal so the result is always Kind=Utc.
- DeliveryQuote.CreateOwnFleet/CreateThirdParty: defensively coerce any incoming DateTime to UTC via NormalizeToUtc helper, so a future caller passing Local or Unspecified can't reintroduce this.