### PR TITLE
feat(orders): notify customer on cancel/reject + raise auto-cancel ti…

### DIFF
--- a/src/Modules/Orders/RallyAPI.Orders.Infrastructure/BackgroundServices/AutoCancelOptions.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Infrastructure/BackgroundServices/AutoCancelOptions.cs
@@ -14,15 +14,15 @@ public sealed class AutoCancelOptions
     public int CheckIntervalSeconds { get; set; } = 30;
 
     /// <summary>
-    /// Stage 1: Minutes after order creation before escalating to admin. Default: 1
+    /// Stage 1: Minutes after order creation before escalating to admin. Default: 5
     /// </summary>
-    public int EscalationMinutes { get; set; } = 1;
+    public int EscalationMinutes { get; set; } = 5;
 
     /// <summary>
-    /// Stage 2: Minutes after order creation before hard auto-cancel. Default: 3
+    /// Stage 2: Minutes after order creation before hard auto-cancel. Default: 10
     /// Must be greater than EscalationMinutes.
     /// </summary>
-    public int HardCancelMinutes { get; set; } = 3;
+    public int HardCancelMinutes { get; set; } = 10;
 
     /// <summary>
     /// Minutes after Pending order creation before auto-cancelling unpaid orders. Default: 15

--- a/src/RallyAPI.Host/Notifications/OrderStatusSignalRHandler.cs
+++ b/src/RallyAPI.Host/Notifications/OrderStatusSignalRHandler.cs
@@ -3,13 +3,15 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 using RallyAPI.Host.Hubs;
 using RallyAPI.Orders.Domain.Abstractions;
+using RallyAPI.Orders.Domain.Enums;
 using RallyAPI.Orders.Domain.Events;
 
 namespace RallyAPI.Host.Notifications;
 
 /// <summary>
 /// Pushes order status changes to the customer's SignalR group.
-/// Handles all 5 lifecycle events: Confirmed, RiderAssigned, PickedUp, Delivered, Failed.
+/// Handles every terminal-or-near-terminal lifecycle event so the customer
+/// app never gets stuck on a stale "Order Placed" view.
 /// Lives in Host to avoid a circular dependency on IHubContext{NotificationHub}.
 /// </summary>
 public sealed class OrderStatusSignalRHandler :
@@ -17,7 +19,9 @@ public sealed class OrderStatusSignalRHandler :
     INotificationHandler<RiderAssignedEvent>,
     INotificationHandler<OrderPickedUpEvent>,
     INotificationHandler<OrderDeliveredEvent>,
-    INotificationHandler<OrderFailedEvent>
+    INotificationHandler<OrderFailedEvent>,
+    INotificationHandler<OrderCancelledEvent>,
+    INotificationHandler<OrderRejectedEvent>
 {
     private readonly IHubContext<NotificationHub> _hub;
     private readonly IOrderRepository _orders;
@@ -101,6 +105,55 @@ public sealed class OrderStatusSignalRHandler :
             message     = "There was a delivery issue with your order"
         }, ct);
     }
+
+    public async Task Handle(OrderCancelledEvent notification, CancellationToken ct)
+    {
+        var order = await _orders.GetByIdAsync(notification.OrderId, ct);
+        if (order is null) { LogMissing(notification.OrderId); return; }
+
+        await PushToCustomer(order.CustomerId, new
+        {
+            orderId       = order.Id,
+            orderNumber   = order.OrderNumber.Value,
+            status        = "Cancelled",
+            reason        = notification.Reason.ToString(),
+            initiator     = notification.Reason.GetInitiator(),
+            isRefundable  = notification.Reason.IsRefundable(),
+            message       = BuildCancelMessage(notification.Reason)
+        }, ct);
+    }
+
+    public async Task Handle(OrderRejectedEvent notification, CancellationToken ct)
+    {
+        await PushToCustomer(notification.CustomerId, new
+        {
+            orderId      = notification.OrderId,
+            orderNumber  = notification.OrderNumber,
+            status       = "Rejected",
+            reason       = notification.Reason,
+            initiator    = "Restaurant",
+            isRefundable = true,
+            message      = string.IsNullOrWhiteSpace(notification.Reason)
+                ? "The restaurant could not accept your order. A refund will be issued."
+                : $"The restaurant could not accept your order: {notification.Reason}. A refund will be issued."
+        }, ct);
+    }
+
+    private static string BuildCancelMessage(CancellationReason reason) => reason switch
+    {
+        CancellationReason.CustomerRequested    => "Your order was cancelled at your request.",
+        CancellationReason.RestaurantUnavailable => "The restaurant could not confirm your order in time. A refund will be issued.",
+        CancellationReason.ItemsOutOfStock      => "Some items are out of stock. A refund will be issued.",
+        CancellationReason.RestaurantClosed     => "The restaurant is closed. A refund will be issued.",
+        CancellationReason.NoRidersAvailable    => "We could not find a delivery partner. A refund will be issued.",
+        CancellationReason.PaymentFailed        => "Your payment could not be processed.",
+        CancellationReason.PaymentTimeout       => "Payment was not completed in time, so the order was cancelled.",
+        CancellationReason.DeliveryAddressIssue => "There was an issue with the delivery address. A refund will be issued.",
+        CancellationReason.Timeout              => "The order timed out before it could be fulfilled. A refund will be issued.",
+        CancellationReason.SystemError          => "A system error cancelled your order. A refund will be issued.",
+        CancellationReason.FraudSuspected       => "Your order was cancelled.",
+        _                                        => "Your order was cancelled."
+    };
 
     private Task PushToCustomer(Guid customerId, object payload, CancellationToken ct) =>
         _hub.Clients.Group($"customer_{customerId}").SendAsync("OrderStatusUpdate", payload, ct);

--- a/src/RallyAPI.Host/appsettings.json
+++ b/src/RallyAPI.Host/appsettings.json
@@ -101,8 +101,9 @@
 
   "AutoCancel": {
     "CheckIntervalSeconds": 30,
-    "EscalationMinutes": 1,
-    "HardCancelMinutes": 3
+    "EscalationMinutes": 5,
+    "HardCancelMinutes": 10,
+    "PaymentTimeoutMinutes": 15
   },
   "PerKmPricing": {
     "BaseDistanceKm": 3.0,


### PR DESCRIPTION
…meouts

Customer never received a real-time push when their order was auto-cancelled or rejected by the restaurant — OrderStatusSignalRHandler listened to Confirmed/RiderAssigned/PickedUp/Delivered/Failed but silently dropped OrderCancelledEvent and OrderRejectedEvent. Result: the app stayed on "Order Placed" until the user manually refreshed.

Changes:
- OrderStatusSignalRHandler now implements both missing handlers and pushes status="Cancelled"/"Rejected" with a human-readable reason, initiator (Customer/Restaurant/System), and refundability flag so the UI can render the right banner without extra round-trips.
- BuildCancelMessage maps every CancellationReason to a customer-safe string, so the UI can fall back to `message` if it doesn't want to switch on the enum itself.

Auto-cancel defaults raised to launch-realistic values:
- EscalationMinutes: 1 → 5  (admin gets pinged after 5 min, not 1)
- HardCancelMinutes: 3 → 10 (restaurant has 10 min total to accept)
- PaymentTimeoutMinutes stays at 15. Both AutoCancelOptions defaults and appsettings.json updated.