### PR TITLE
feat(catalog): add search, price, prep-time, pickup, pagination filte…

### DIFF
--- a/src/Modules/Catalog/RallyAPI.Catalog.Application/Restaurants/Queries/GetRestaurants/GetRestaurantsQuery.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Application/Restaurants/Queries/GetRestaurants/GetRestaurantsQuery.cs
@@ -1,4 +1,4 @@
-﻿// File: src/Modules/Catalog/RallyAPI.Catalog.Application/Restaurants/Queries/GetRestaurants/GetRestaurantsQuery.cs
+// File: src/Modules/Catalog/RallyAPI.Catalog.Application/Restaurants/Queries/GetRestaurants/GetRestaurantsQuery.cs
 
 using MediatR;
 using RallyAPI.SharedKernel.Results;
@@ -9,13 +9,26 @@ public sealed record GetRestaurantsQuery(
     double? Latitude = null,
     double? Longitude = null,
     double? RadiusKm = null,
+    string? Search = null,
     string? Cuisines = null,
     bool? PureVeg = null,
     bool? VeganFriendly = null,
     bool? JainOptions = null,
     bool? OpenNow = null,
-    string? Sort = null
-) : IRequest<Result<List<RestaurantListResponse>>>;
+    int? MaxPrepTimeMins = null,
+    decimal? MinPrice = null,
+    decimal? MaxPrice = null,
+    bool? SupportsPickup = null,
+    string? Sort = null,
+    int Page = 1,
+    int PageSize = 20
+) : IRequest<Result<PagedRestaurantsResponse>>;
+
+public sealed record PagedRestaurantsResponse(
+    IReadOnlyList<RestaurantListResponse> Items,
+    int TotalCount,
+    int Page,
+    int PageSize);
 
 public sealed record RestaurantListResponse(
     Guid Id,

--- a/src/Modules/Catalog/RallyAPI.Catalog.Application/Restaurants/Queries/GetRestaurants/GetRestaurantsQueryHandler.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Application/Restaurants/Queries/GetRestaurants/GetRestaurantsQueryHandler.cs
@@ -1,4 +1,4 @@
-﻿// File: src/Modules/Catalog/RallyAPI.Catalog.Application/Restaurants/Queries/GetRestaurants/GetRestaurantsQueryHandler.cs
+// File: src/Modules/Catalog/RallyAPI.Catalog.Application/Restaurants/Queries/GetRestaurants/GetRestaurantsQueryHandler.cs
 
 using MediatR;
 using RallyAPI.SharedKernel.Abstractions.Restaurants;
@@ -7,7 +7,7 @@ using RallyAPI.SharedKernel.Results;
 namespace RallyAPI.Catalog.Application.Restaurants.Queries.GetRestaurants;
 
 internal sealed class GetRestaurantsQueryHandler
-    : IRequestHandler<GetRestaurantsQuery, Result<List<RestaurantListResponse>>>
+    : IRequestHandler<GetRestaurantsQuery, Result<PagedRestaurantsResponse>>
 {
     private readonly IRestaurantQueryService _restaurantQueryService;
 
@@ -16,75 +16,59 @@ internal sealed class GetRestaurantsQueryHandler
         _restaurantQueryService = restaurantQueryService;
     }
 
-    public async Task<Result<List<RestaurantListResponse>>> Handle(
+    public async Task<Result<PagedRestaurantsResponse>> Handle(
         GetRestaurantsQuery request,
         CancellationToken cancellationToken)
     {
-        var restaurants = await _restaurantQueryService.GetActiveRestaurantsAsync(
-            request.Latitude,
-            request.Longitude,
-            request.RadiusKm,
-            cancellationToken);
-
-        IEnumerable<RestaurantSummary> filtered = restaurants;
-
-        // Dietary filters
-        if (request.PureVeg == true)
-            filtered = filtered.Where(r => r.IsPureVeg);
-
-        if (request.VeganFriendly == true)
-            filtered = filtered.Where(r => r.IsVeganFriendly);
-
-        if (request.JainOptions == true)
-            filtered = filtered.Where(r => r.HasJainOptions);
-
-        // Cuisine filter (comma-separated, match any)
-        if (!string.IsNullOrWhiteSpace(request.Cuisines))
-        {
-            var cuisineList = request.Cuisines
+        var cuisines = string.IsNullOrWhiteSpace(request.Cuisines)
+            ? null
+            : request.Cuisines
                 .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .ToList();
 
-            filtered = filtered.Where(r =>
-                r.CuisineTypes.Any(c => cuisineList.Contains(c, StringComparer.OrdinalIgnoreCase)));
-        }
-
-        // Open now filter
-        if (request.OpenNow == true)
-            filtered = filtered.Where(r => r.IsAcceptingOrders);
-
-        // Sorting
-        var sorted = request.Sort?.ToLowerInvariant() switch
+        var filter = new RestaurantListFilter
         {
-            "distance" => filtered.OrderBy(r => r.DistanceKm ?? double.MaxValue),
-            "cost_asc" => filtered.OrderBy(r => r.MinOrderAmount),
-            "cost_desc" => filtered.OrderByDescending(r => r.MinOrderAmount),
-            "prep_time" => filtered.OrderBy(r => r.AvgPrepTimeMins),
-            _ => request.Latitude.HasValue
-                ? filtered.OrderBy(r => r.DistanceKm ?? double.MaxValue)
-                : filtered.OrderBy(r => r.Name)
+            Latitude = request.Latitude,
+            Longitude = request.Longitude,
+            RadiusKm = request.RadiusKm,
+            Search = request.Search,
+            Cuisines = cuisines,
+            PureVeg = request.PureVeg,
+            VeganFriendly = request.VeganFriendly,
+            JainOptions = request.JainOptions,
+            OpenNow = request.OpenNow,
+            MaxPrepTimeMins = request.MaxPrepTimeMins,
+            MinPrice = request.MinPrice,
+            MaxPrice = request.MaxPrice,
+            SupportsPickup = request.SupportsPickup,
+            Sort = request.Sort,
+            Page = request.Page,
+            PageSize = request.PageSize
         };
 
-        var response = sorted.Select(r => new RestaurantListResponse(
-            r.Id,
-            r.Name,
-            r.AddressLine,
-            r.Latitude,
-            r.Longitude,
-            r.IsAcceptingOrders,
-            r.AcceptsPickup,
-            r.AvgPrepTimeMins,
-            r.OpeningTime.ToString("HH:mm"),
-            r.ClosingTime.ToString("HH:mm"),
-            r.CuisineTypes,
-            r.IsPureVeg,
-            r.IsVeganFriendly,
-            r.HasJainOptions,
-            r.MinOrderAmount,
-            r.LogoUrl,
-            r.DistanceKm
-        )).ToList();
+        var paged = await _restaurantQueryService.BrowseAsync(filter, cancellationToken);
 
-        return response;
+        var items = paged.Items
+            .Select(r => new RestaurantListResponse(
+                r.Id,
+                r.Name,
+                r.AddressLine,
+                r.Latitude,
+                r.Longitude,
+                r.IsAcceptingOrders,
+                r.AcceptsPickup,
+                r.AvgPrepTimeMins,
+                r.OpeningTime.ToString("HH:mm"),
+                r.ClosingTime.ToString("HH:mm"),
+                r.CuisineTypes,
+                r.IsPureVeg,
+                r.IsVeganFriendly,
+                r.HasJainOptions,
+                r.MinOrderAmount,
+                r.LogoUrl,
+                r.DistanceKm))
+            .ToList();
+
+        return new PagedRestaurantsResponse(items, paged.TotalCount, paged.Page, paged.PageSize);
     }
 }

--- a/src/Modules/Catalog/RallyAPI.Catalog.Endpoints/Restaurants/GetRestaurants.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Endpoints/Restaurants/GetRestaurants.cs
@@ -1,4 +1,4 @@
-﻿// File: src/Modules/Catalog/RallyAPI.Catalog.Endpoints/Restaurants/GetRestaurants.cs
+// File: src/Modules/Catalog/RallyAPI.Catalog.Endpoints/Restaurants/GetRestaurants.cs
 
 using MediatR;
 using Microsoft.AspNetCore.Builder;
@@ -15,7 +15,7 @@ public class GetRestaurants : IEndpoint
     {
         app.MapGet("/api/catalog/restaurants", HandleAsync)
             .WithTags("Customer Catalog")
-            .WithSummary("List active restaurants with optional location, cuisine, and dietary filters")
+            .WithSummary("Browse restaurants. Supports location, cuisine, dietary, price range, prep-time, pickup, sort, and pagination.")
             .AllowAnonymous();
     }
 
@@ -23,16 +23,50 @@ public class GetRestaurants : IEndpoint
         double? lat,
         double? lng,
         double? radiusKm,
+        string? search,
         string? cuisines,
         bool? pureVeg,
         bool? veganFriendly,
         bool? jainOptions,
         bool? openNow,
+        int? maxPrepTimeMins,
+        decimal? minPrice,
+        decimal? maxPrice,
+        bool? supportsPickup,
         string? sort,
+        int? page,
+        int? pageSize,
         ISender sender,
         CancellationToken ct)
     {
-        var query = new GetRestaurantsQuery(lat, lng, radiusKm, cuisines, pureVeg, veganFriendly, jainOptions, openNow, sort);
+        // Clamp pagination at the boundary so handlers / services don't need to guard.
+        var safePage = page is null or < 1 ? 1 : page.Value;
+        var safePageSize = pageSize switch
+        {
+            null => 20,
+            < 1 => 20,
+            > 100 => 100,
+            _ => pageSize.Value
+        };
+
+        var query = new GetRestaurantsQuery(
+            lat,
+            lng,
+            radiusKm,
+            search,
+            cuisines,
+            pureVeg,
+            veganFriendly,
+            jainOptions,
+            openNow,
+            maxPrepTimeMins,
+            minPrice,
+            maxPrice,
+            supportsPickup,
+            sort,
+            safePage,
+            safePageSize);
+
         var result = await sender.Send(query, ct);
 
         return result.IsSuccess

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Services/RestaurantQueryService.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Services/RestaurantQueryService.cs
@@ -29,38 +29,7 @@ internal sealed class RestaurantQueryService : IRestaurantQueryService
 
         var restaurants = await query.ToListAsync(ct);
 
-        var summaries = restaurants.Select(r =>
-        {
-            double? distanceKm = null;
-
-            if (latitude.HasValue && longitude.HasValue)
-            {
-                distanceKm = HaversineDistance(
-                    latitude.Value, longitude.Value,
-                    (double)r.Latitude, (double)r.Longitude);
-            }
-
-            return new RestaurantSummary
-            {
-                Id = r.Id,
-                Name = r.Name,
-                AddressLine = r.AddressLine,
-                Latitude = (double)r.Latitude,
-                Longitude = (double)r.Longitude,
-                IsAcceptingOrders = r.IsAcceptingOrders,
-                AvgPrepTimeMins = r.AvgPrepTimeMins,
-                OpeningTime = r.OpeningTime,
-                ClosingTime = r.ClosingTime,
-                CuisineTypes = r.CuisineTypes,
-                IsPureVeg = r.IsPureVeg,
-                IsVeganFriendly = r.IsVeganFriendly,
-                HasJainOptions = r.HasJainOptions,
-                MinOrderAmount = r.MinOrderAmount,
-                LogoUrl = r.LogoUrl,
-                AcceptsPickup = r.AcceptsPickup,
-                DistanceKm = distanceKm.HasValue ? Math.Round(distanceKm.Value, 2) : null
-            };
-        }).ToList();
+        var summaries = restaurants.Select(r => ToSummary(r, latitude, longitude)).ToList();
 
         // Filter by radius if location provided
         if (latitude.HasValue && longitude.HasValue && radiusKm.HasValue)
@@ -76,6 +45,157 @@ internal sealed class RestaurantQueryService : IRestaurantQueryService
             : summaries.OrderBy(r => r.Name).ToList();
 
         return summaries;
+    }
+
+    public async Task<PagedRestaurantList> BrowseAsync(
+        RestaurantListFilter filter,
+        CancellationToken ct = default)
+    {
+        // Defend the service even if endpoint layer forgets to clamp.
+        var page = filter.Page < 1 ? 1 : filter.Page;
+        var pageSize = filter.PageSize switch
+        {
+            < 1 => 20,
+            > 100 => 100,
+            _ => filter.PageSize
+        };
+
+        var query = _context.Restaurants
+            .AsNoTracking()
+            .Where(r => r.IsActive && r.DeletedAt == null);
+
+        // SQL-side filters (cheap scalar comparisons)
+        if (filter.PureVeg == true)
+            query = query.Where(r => r.IsPureVeg);
+
+        if (filter.VeganFriendly == true)
+            query = query.Where(r => r.IsVeganFriendly);
+
+        if (filter.JainOptions == true)
+            query = query.Where(r => r.HasJainOptions);
+
+        if (filter.OpenNow == true)
+            query = query.Where(r => r.IsAcceptingOrders);
+
+        if (filter.SupportsPickup.HasValue)
+            query = query.Where(r => r.AcceptsPickup == filter.SupportsPickup.Value);
+
+        if (filter.MaxPrepTimeMins.HasValue)
+            query = query.Where(r => r.AvgPrepTimeMins <= filter.MaxPrepTimeMins.Value);
+
+        if (filter.MinPrice.HasValue)
+            query = query.Where(r => r.MinOrderAmount >= filter.MinPrice.Value);
+
+        if (filter.MaxPrice.HasValue)
+            query = query.Where(r => r.MinOrderAmount <= filter.MaxPrice.Value);
+
+        // Name keyword — ILIKE is the Npgsql case-insensitive operator. Cuisine keyword
+        // would need to touch the jsonb column, which doesn't translate cleanly, so we
+        // handle it in-memory after materialization.
+        if (!string.IsNullOrWhiteSpace(filter.Search))
+        {
+            var pattern = $"%{filter.Search.Trim()}%";
+            query = query.Where(r => EF.Functions.ILike(r.Name, pattern));
+        }
+
+        var rows = await query.ToListAsync(ct);
+
+        IEnumerable<RestaurantSummary> result = rows.Select(r => ToSummary(r, filter.Latitude, filter.Longitude));
+
+        // In-memory filters: cuisine list (jsonb) + Haversine radius
+        if (filter.Cuisines is { Count: > 0 })
+        {
+            var wanted = filter.Cuisines;
+            result = result.Where(r =>
+                r.CuisineTypes.Any(c => wanted.Contains(c, StringComparer.OrdinalIgnoreCase)));
+        }
+
+        if (filter.Latitude.HasValue && filter.Longitude.HasValue && filter.RadiusKm.HasValue)
+        {
+            var radius = filter.RadiusKm.Value;
+            result = result.Where(r => r.DistanceKm.HasValue && r.DistanceKm.Value <= radius);
+        }
+
+        // Sort
+        result = (filter.Sort?.ToLowerInvariant()) switch
+        {
+            "distance" => result.OrderBy(r => r.DistanceKm ?? double.MaxValue),
+            "cost_asc" => result.OrderBy(r => r.MinOrderAmount),
+            "cost_desc" => result.OrderByDescending(r => r.MinOrderAmount),
+            "prep_time" => result.OrderBy(r => r.AvgPrepTimeMins),
+            "newest" => result.OrderByDescending(r => r.CreatedAt),
+            "relevance" => SortByRelevance(result, filter.Search),
+            _ => filter.Latitude.HasValue
+                ? result.OrderBy(r => r.DistanceKm ?? double.MaxValue)
+                : result.OrderBy(r => r.Name)
+        };
+
+        var materialized = result.ToList();
+        var total = materialized.Count;
+
+        var paged = materialized
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToList();
+
+        return new PagedRestaurantList(paged, total, page, pageSize);
+    }
+
+    private static IOrderedEnumerable<RestaurantSummary> SortByRelevance(
+        IEnumerable<RestaurantSummary> items,
+        string? search)
+    {
+        if (string.IsNullOrWhiteSpace(search))
+            return items.OrderBy(r => r.Name);
+
+        var term = search.Trim();
+        return items
+            .OrderByDescending(r => Score(r, term))
+            .ThenBy(r => r.Name);
+
+        static int Score(RestaurantSummary r, string term)
+        {
+            if (r.Name.StartsWith(term, StringComparison.OrdinalIgnoreCase)) return 3;
+            if (r.Name.Contains(term, StringComparison.OrdinalIgnoreCase)) return 2;
+            if (r.CuisineTypes.Any(c => c.Contains(term, StringComparison.OrdinalIgnoreCase))) return 1;
+            return 0;
+        }
+    }
+
+    private static RestaurantSummary ToSummary(
+        Users.Domain.Entities.Restaurant r,
+        double? lat,
+        double? lng)
+    {
+        double? distanceKm = null;
+        if (lat.HasValue && lng.HasValue)
+        {
+            distanceKm = HaversineDistance(
+                lat.Value, lng.Value,
+                (double)r.Latitude, (double)r.Longitude);
+        }
+
+        return new RestaurantSummary
+        {
+            Id = r.Id,
+            Name = r.Name,
+            AddressLine = r.AddressLine,
+            Latitude = (double)r.Latitude,
+            Longitude = (double)r.Longitude,
+            IsAcceptingOrders = r.IsAcceptingOrders,
+            AvgPrepTimeMins = r.AvgPrepTimeMins,
+            OpeningTime = r.OpeningTime,
+            ClosingTime = r.ClosingTime,
+            CuisineTypes = r.CuisineTypes,
+            IsPureVeg = r.IsPureVeg,
+            IsVeganFriendly = r.IsVeganFriendly,
+            HasJainOptions = r.HasJainOptions,
+            MinOrderAmount = r.MinOrderAmount,
+            LogoUrl = r.LogoUrl,
+            AcceptsPickup = r.AcceptsPickup,
+            CreatedAt = r.CreatedAt,
+            DistanceKm = distanceKm.HasValue ? Math.Round(distanceKm.Value, 2) : null
+        };
     }
 
     public async Task<RestaurantDetails?> GetByIdAsync(

--- a/src/RallyAPI.SharedKernel/Abstractions/Restaurants/IRestaurantQueryService.cs
+++ b/src/RallyAPI.SharedKernel/Abstractions/Restaurants/IRestaurantQueryService.cs
@@ -17,6 +17,14 @@ public interface IRestaurantQueryService
         CancellationToken ct = default);
 
     /// <summary>
+    /// Customer browse endpoint with the full filter / sort / paginate set.
+    /// Cheap filters are pushed into SQL; distance / cuisine-list / radius are applied in-memory.
+    /// </summary>
+    Task<PagedRestaurantList> BrowseAsync(
+        RestaurantListFilter filter,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Gets a single restaurant's details by ID.
     /// </summary>
     Task<RestaurantDetails?> GetByIdAsync(

--- a/src/RallyAPI.SharedKernel/Abstractions/Restaurants/RestaurantListFilter.cs
+++ b/src/RallyAPI.SharedKernel/Abstractions/Restaurants/RestaurantListFilter.cs
@@ -1,0 +1,45 @@
+// File: src/RallyAPI.SharedKernel/Abstractions/Restaurants/RestaurantListFilter.cs
+
+namespace RallyAPI.SharedKernel.Abstractions.Restaurants;
+
+/// <summary>
+/// Filter / sort / page parameters for the customer-facing restaurant browse list.
+/// </summary>
+public sealed record RestaurantListFilter
+{
+    public double? Latitude { get; init; }
+    public double? Longitude { get; init; }
+    public double? RadiusKm { get; init; }
+
+    /// <summary>Free-text keyword matched against restaurant name and cuisines (case-insensitive).</summary>
+    public string? Search { get; init; }
+
+    /// <summary>Restaurant matches if any of its cuisines overlap this list (case-insensitive).</summary>
+    public IReadOnlyList<string>? Cuisines { get; init; }
+
+    public bool? PureVeg { get; init; }
+    public bool? VeganFriendly { get; init; }
+    public bool? JainOptions { get; init; }
+    public bool? OpenNow { get; init; }
+
+    /// <summary>Only include restaurants whose AvgPrepTimeMins ≤ this value.</summary>
+    public int? MaxPrepTimeMins { get; init; }
+
+    public decimal? MinPrice { get; init; }
+    public decimal? MaxPrice { get; init; }
+
+    /// <summary>True = only pickup-enabled. False = only delivery-only. Null = both.</summary>
+    public bool? SupportsPickup { get; init; }
+
+    /// <summary>One of: distance, cost_asc, cost_desc, prep_time, newest, relevance.</summary>
+    public string? Sort { get; init; }
+
+    public int Page { get; init; } = 1;
+    public int PageSize { get; init; } = 20;
+}
+
+public sealed record PagedRestaurantList(
+    IReadOnlyList<RestaurantSummary> Items,
+    int TotalCount,
+    int Page,
+    int PageSize);

--- a/src/RallyAPI.SharedKernel/Abstractions/Restaurants/RestaurantSummary.cs
+++ b/src/RallyAPI.SharedKernel/Abstractions/Restaurants/RestaurantSummary.cs
@@ -33,4 +33,7 @@ public sealed record RestaurantSummary
     /// Distance from the queried location in km. Null if no location was provided.
     /// </summary>
     public double? DistanceKm { get; init; }
+
+    /// <summary>When the restaurant was created. Used for "newest" sort.</summary>
+    public DateTime CreatedAt { get; init; }
 }


### PR DESCRIPTION
…rs to restaurant browse

GET /api/catalog/restaurants now accepts: search, maxPrepTimeMins, minPrice, maxPrice, supportsPickup, page, pageSize, plus sort=newest and sort=relevance. Response is now a paged envelope { items, totalCount, page, pageSize } — breaking change for callers (was a plain array).

Cheap scalar filters are pushed into SQL via a new BrowseAsync method on IRestaurantQueryService; cuisine-list (jsonb) and Haversine radius stay in-memory. No schema changes — AcceptsPickup already existed.