### PR TITLE
feat(delivery): expose OTP codes + persist ProRouting cost breakdown

### DIFF
--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/DTOs/DeliveryCodesDto.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/DTOs/DeliveryCodesDto.cs
@@ -1,0 +1,21 @@
+namespace RallyAPI.Delivery.Application.DTOs;
+
+/// <summary>
+/// OTP codes used to verify the rider at pickup and the customer at drop.
+/// Role-filtered: customers never see the pickup code, restaurants never see
+/// the drop code. Admins receive both.
+/// </summary>
+public sealed record DeliveryCodesDto
+{
+    /// <summary>
+    /// 6-digit code shown to the restaurant. Restaurant reads it out to the
+    /// rider at pickup; the rider enters it in ProRouting to prove identity.
+    /// </summary>
+    public string? PickupCode { get; init; }
+
+    /// <summary>
+    /// 4-digit code shown to the customer. Customer reads it out to the rider
+    /// at drop; the rider enters it in ProRouting to mark delivered.
+    /// </summary>
+    public string? DropCode { get; init; }
+}

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Queries/GetDeliveryCodes/GetDeliveryCodesQuery.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Queries/GetDeliveryCodes/GetDeliveryCodesQuery.cs
@@ -1,0 +1,8 @@
+using MediatR;
+using RallyAPI.Delivery.Application.DTOs;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Delivery.Application.Queries.GetDeliveryCodes;
+
+public sealed record GetDeliveryCodesQuery(Guid OrderId, Guid CallerId, string CallerRole)
+    : IRequest<Result<DeliveryCodesDto>>;

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Queries/GetDeliveryCodes/GetDeliveryCodesQueryHandler.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Queries/GetDeliveryCodes/GetDeliveryCodesQueryHandler.cs
@@ -1,0 +1,60 @@
+using MediatR;
+using RallyAPI.Delivery.Application.DTOs;
+using RallyAPI.Delivery.Domain.Abstractions;
+using RallyAPI.Delivery.Domain.Entities;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Delivery.Application.Queries.GetDeliveryCodes;
+
+public sealed class GetDeliveryCodesQueryHandler
+    : IRequestHandler<GetDeliveryCodesQuery, Result<DeliveryCodesDto>>
+{
+    private readonly IDeliveryRequestRepository _repository;
+
+    public GetDeliveryCodesQueryHandler(IDeliveryRequestRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<Result<DeliveryCodesDto>> Handle(
+        GetDeliveryCodesQuery query,
+        CancellationToken cancellationToken)
+    {
+        var delivery = await _repository.GetByOrderIdAsync(query.OrderId, cancellationToken);
+
+        if (delivery is null)
+        {
+            return Result.Failure<DeliveryCodesDto>(
+                Error.NotFound($"No delivery request found for order {query.OrderId}"));
+        }
+
+        var dto = Authorize(delivery, query.CallerId, query.CallerRole);
+        if (dto is null)
+        {
+            // Treat unauthorized as NotFound so existence isn't leaked.
+            return Result.Failure<DeliveryCodesDto>(
+                Error.NotFound($"No delivery request found for order {query.OrderId}"));
+        }
+
+        return Result.Success(dto);
+    }
+
+    private static DeliveryCodesDto? Authorize(DeliveryRequest delivery, Guid callerId, string callerRole) =>
+        callerRole switch
+        {
+            "Admin" => new DeliveryCodesDto
+            {
+                PickupCode = delivery.PickupCode,
+                DropCode = delivery.DropCode
+            },
+            "Restaurant" when delivery.RestaurantId == callerId => new DeliveryCodesDto
+            {
+                PickupCode = delivery.PickupCode
+            },
+            "Customer" when delivery.CustomerId == callerId => new DeliveryCodesDto
+            {
+                DropCode = delivery.DropCode
+            },
+            _ => null
+        };
+}

--- a/src/Modules/Delivery/RallyAPI.Delivery.Domain/Entities/DeliveryRequest.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Domain/Entities/DeliveryRequest.cs
@@ -43,6 +43,14 @@ public sealed class DeliveryRequest : AggregateRoot
     public decimal? ActualPrice { get; private set; }
     public decimal? PriceDifference { get; private set; }
 
+    // 3PL cost breakdown — populated from provider callback on Agent-assigned.
+    // Used for monthly invoice reconciliation against the LSP statement.
+    public decimal? ProviderLspFee { get; private set; }
+    public decimal? ProviderPlatformFee { get; private set; }
+    public decimal? ProviderTotalWithTax { get; private set; }
+    public decimal? ProviderDistanceKm { get; private set; }
+    public string? ProviderNetworkOrderId { get; private set; }
+
     // Own Fleet Assignment
     public Guid? RiderId { get; private set; }
     public string? RiderName { get; private set; }
@@ -253,6 +261,27 @@ public sealed class DeliveryRequest : AggregateRoot
         ExternalRiderName = riderName ?? ExternalRiderName;
         ExternalRiderPhone = riderPhone ?? ExternalRiderPhone;
         ExternalTrackingUrl = trackingUrl ?? ExternalTrackingUrl;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Persist the cost breakdown reported by the 3PL provider. Called once
+    /// when the provider tells us what this delivery will cost (typically on
+    /// the Agent-assigned callback). Existing values are preserved if the
+    /// provider omits them on a later callback.
+    /// </summary>
+    public void RecordProviderCost(
+        decimal? lspFee,
+        decimal? platformFee,
+        decimal? totalWithTax,
+        decimal? distanceKm,
+        string? networkOrderId)
+    {
+        ProviderLspFee = lspFee ?? ProviderLspFee;
+        ProviderPlatformFee = platformFee ?? ProviderPlatformFee;
+        ProviderTotalWithTax = totalWithTax ?? ProviderTotalWithTax;
+        ProviderDistanceKm = distanceKm ?? ProviderDistanceKm;
+        ProviderNetworkOrderId = networkOrderId ?? ProviderNetworkOrderId;
         UpdatedAt = DateTime.UtcNow;
     }
 

--- a/src/Modules/Delivery/RallyAPI.Delivery.Endpoints/DeliveryEndpoints.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Endpoints/DeliveryEndpoints.cs
@@ -5,7 +5,9 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using RallyAPI.Delivery.Application.Commands.GetQuote;
 using RallyAPI.Delivery.Application.DTOs;
+using RallyAPI.Delivery.Application.Queries.GetDeliveryCodes;
 using RallyAPI.Delivery.Endpoints.Requests;
+using RallyAPI.SharedKernel.Abstractions;
 using RallyAPI.SharedKernel.Extensions;
 using RallyAPI.SharedKernel.Results;
 
@@ -25,6 +27,16 @@ public static class DeliveryEndpoints
             .WithSummary("Get delivery quote at checkout")
             .Produces<DeliveryQuoteDto>(StatusCodes.Status200OK)
             .Produces<ProblemDetails>(StatusCodes.Status400BadRequest);
+
+        // Get OTP codes for an order (role-filtered: customer sees DropCode,
+        // restaurant sees PickupCode, admin sees both)
+        group.MapGet("/orders/{orderId:guid}/codes", GetDeliveryCodes)
+            .WithName("GetDeliveryCodes")
+            .WithSummary("Get pickup/drop OTP codes for an order")
+            .RequireAuthorization()
+            .Produces<DeliveryCodesDto>(StatusCodes.Status200OK)
+            .Produces<ProblemDetails>(StatusCodes.Status404NotFound)
+            .Produces<ProblemDetails>(StatusCodes.Status401Unauthorized);
 
         return app;
     }
@@ -48,6 +60,29 @@ public static class DeliveryEndpoints
         };
 
         var result = await mediator.Send(command, ct);
+
+        return result.IsSuccess
+            ? Results.Ok(result.Value)
+            : result.Error.ToErrorResult();
+    }
+
+    private static async Task<IResult> GetDeliveryCodes(
+        Guid orderId,
+        IMediator mediator,
+        ICurrentUserService currentUser,
+        CancellationToken ct)
+    {
+        if (!currentUser.UserId.HasValue)
+            return Results.Unauthorized();
+
+        var role = currentUser.IsAdmin ? "Admin"
+            : currentUser.IsRestaurant ? "Restaurant"
+            : currentUser.IsRider ? "Rider"
+            : currentUser.IsCustomer ? "Customer"
+            : string.Empty;
+
+        var result = await mediator.Send(
+            new GetDeliveryCodesQuery(orderId, currentUser.UserId.Value, role), ct);
 
         return result.IsSuccess
             ? Results.Ok(result.Value)

--- a/src/Modules/Delivery/RallyAPI.Delivery.Endpoints/ProRoutingDiagnosticEndpoints.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Endpoints/ProRoutingDiagnosticEndpoints.cs
@@ -1,0 +1,209 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Options;
+using RallyAPI.Delivery.Application.Services;
+using RallyAPI.Integrations.ProRouting;
+using RallyAPI.SharedKernel.Abstractions.Delivery;
+
+namespace RallyAPI.Delivery.Endpoints;
+
+/// <summary>
+/// Dev-only diagnostic endpoints to verify ProRouting integration end-to-end
+/// without going through the full order/payment flow.
+///
+/// Register only when env is Development.
+/// </summary>
+public static class ProRoutingDiagnosticEndpoints
+{
+    public static IEndpointRouteBuilder MapProRoutingDiagnosticEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/diag/prorouting")
+            .WithTags("Diagnostics: ProRouting")
+            .WithOpenApi();
+
+        group.MapGet("/config", ShowConfig)
+            .WithName("DiagProRoutingConfig")
+            .WithSummary("Show ProRouting config (key redacted)");
+
+        group.MapPost("/create-task", CreateTask)
+            .WithName("DiagProRoutingCreateTask")
+            .WithSummary("Fire a real CreateTaskAsync call with sample payload");
+
+        group.MapGet("/status/{taskId}", GetStatus)
+            .WithName("DiagProRoutingTaskStatus")
+            .WithSummary("Poll ProRouting for current task state");
+
+        group.MapPost("/cancel/{taskId}", CancelTask)
+            .WithName("DiagProRoutingCancelTask")
+            .WithSummary("Cancel a ProRouting task (to clean up after a test)");
+
+        return app;
+    }
+
+    private static IResult ShowConfig(
+        IOptions<ProRoutingOptions> prOptions,
+        IOptions<DispatchOptions> dispatchOptions)
+    {
+        var pr = prOptions.Value;
+        var ds = dispatchOptions.Value;
+
+        var keyHint = string.IsNullOrWhiteSpace(pr.ApiKey)
+            ? "<MISSING>"
+            : pr.ApiKey.Length <= 8
+                ? "<short, likely placeholder>"
+                : $"{pr.ApiKey[..4]}…{pr.ApiKey[^4..]} (len={pr.ApiKey.Length})";
+
+        return Results.Ok(new
+        {
+            ProRouting = new
+            {
+                pr.BaseUrl,
+                ApiKeyHint = keyHint,
+                pr.TimeoutSeconds,
+                pr.DefaultOrderCategory,
+                pr.DefaultSearchCategory,
+                pr.Enabled
+            },
+            Dispatch = new
+            {
+                ds.WebhookUrl,
+                ds.AcceptanceTimeoutSeconds,
+                ds.SearchRadiusKm,
+                ds.MaxRidersToTry,
+                WebhookUrlLooksReal = !string.IsNullOrWhiteSpace(ds.WebhookUrl)
+                    && !ds.WebhookUrl.Contains("your-domain.com", StringComparison.OrdinalIgnoreCase)
+                    && !ds.WebhookUrl.Contains("localhost", StringComparison.OrdinalIgnoreCase)
+            }
+        });
+    }
+
+    private static async Task<IResult> CreateTask(
+        [FromBody] DiagCreateTaskRequest? overrides,
+        IThirdPartyDeliveryProvider provider,
+        IOptions<DispatchOptions> dispatchOptions,
+        CancellationToken ct)
+    {
+        var callbackUrl = !string.IsNullOrWhiteSpace(overrides?.CallbackUrl)
+            ? overrides!.CallbackUrl!
+            : dispatchOptions.Value.WebhookUrl;
+
+        var orderNumber = overrides?.OrderNumber ?? $"DIAG-{DateTime.UtcNow:yyyyMMddHHmmss}";
+
+        var req = new CreateTaskRequest
+        {
+            OrderId = Guid.NewGuid(),
+            OrderNumber = orderNumber,
+            DeliveryRequestId = Guid.NewGuid(),
+
+            // Pickup — Koramangala, Bangalore (sample restaurant)
+            PickupLatitude = overrides?.PickupLatitude ?? 12.9352,
+            PickupLongitude = overrides?.PickupLongitude ?? 77.6245,
+            PickupPincode = overrides?.PickupPincode ?? "560034",
+            PickupAddressLine1 = "Diagnostic Restaurant, 100 Feet Rd",
+            PickupCity = "Bengaluru",
+            PickupState = "Karnataka",
+            PickupContactName = "Diag Restaurant",
+            PickupContactPhone = "9999900001",
+            StoreId = "DIAG-STORE",
+
+            // Drop — Indiranagar, Bangalore (sample customer)
+            DropLatitude = overrides?.DropLatitude ?? 12.9784,
+            DropLongitude = overrides?.DropLongitude ?? 77.6408,
+            DropPincode = overrides?.DropPincode ?? "560038",
+            DropAddressLine1 = "Diagnostic Customer, 12th Main",
+            DropCity = "Bengaluru",
+            DropState = "Karnataka",
+            DropContactName = "Diag Customer",
+            DropContactPhone = "9999900002",
+
+            OrderAmount = overrides?.OrderAmount ?? 500m,
+            OrderCategory = overrides?.OrderCategory ?? "F&B",
+            PickupCode = "123456",
+            DropCode = "9999",
+            IsOrderReady = true,
+            SelectionMode = "fastest_agent",
+            CallbackUrl = callbackUrl,
+            OrderItems = new[]
+            {
+                new TaskOrderItem("Butter Chicken", 1, 280m),
+                new TaskOrderItem("Garlic Naan", 2, 60m)
+            }
+        };
+
+        var startedAt = DateTime.UtcNow;
+        var result = await provider.CreateTaskAsync(req, ct);
+        var elapsedMs = (DateTime.UtcNow - startedAt).TotalMilliseconds;
+
+        return Results.Ok(new
+        {
+            Sent = new
+            {
+                req.OrderNumber,
+                req.OrderId,
+                req.DeliveryRequestId,
+                Pickup = new { req.PickupLatitude, req.PickupLongitude, req.PickupPincode },
+                Drop = new { req.DropLatitude, req.DropLongitude, req.DropPincode },
+                req.CallbackUrl,
+                req.OrderAmount
+            },
+            ElapsedMs = (int)elapsedMs,
+            Result = new
+            {
+                result.IsSuccess,
+                result.TaskId,
+                result.ClientOrderId,
+                result.State,
+                result.ErrorMessage,
+                result.ProviderName
+            },
+            NextStep = result.IsSuccess
+                ? $"GET /api/diag/prorouting/status/{result.TaskId} to poll, or wait for webhook to {callbackUrl}"
+                : "Inspect ErrorMessage. Check serilog logs for the raw HTTP body returned by ProRouting."
+        });
+    }
+
+    private static async Task<IResult> GetStatus(
+        string taskId,
+        IThirdPartyDeliveryProvider provider,
+        CancellationToken ct)
+    {
+        var result = await provider.GetTaskStatusAsync(taskId, ct);
+        return Results.Ok(new
+        {
+            result.IsSuccess,
+            result.TaskId,
+            result.State,
+            result.RiderName,
+            result.RiderPhone,
+            result.TrackingUrl,
+            result.ErrorMessage,
+            result.UpdatedAt
+        });
+    }
+
+    private static async Task<IResult> CancelTask(
+        string taskId,
+        [FromQuery] string? reason,
+        IThirdPartyDeliveryProvider provider,
+        CancellationToken ct)
+    {
+        var result = await provider.CancelTaskAsync(taskId, reason ?? "Diagnostic cleanup", ct);
+        return Results.Ok(new { result.IsSuccess, result.ErrorMessage });
+    }
+}
+
+public sealed record DiagCreateTaskRequest
+{
+    public string? OrderNumber { get; init; }
+    public string? CallbackUrl { get; init; }
+    public double? PickupLatitude { get; init; }
+    public double? PickupLongitude { get; init; }
+    public string? PickupPincode { get; init; }
+    public double? DropLatitude { get; init; }
+    public double? DropLongitude { get; init; }
+    public string? DropPincode { get; init; }
+    public decimal? OrderAmount { get; init; }
+    public string? OrderCategory { get; init; }
+}

--- a/src/Modules/Delivery/RallyAPI.Delivery.Endpoints/WebhookEndpoints.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Endpoints/WebhookEndpoints.cs
@@ -142,10 +142,17 @@ public static class WebhookEndpoints
             {
                 case "agent-assigned":
                 case "agent_assigned":
+                    var trackingUrl = order.TrackingUrlAlt ?? order.TrackingUrl;
+                    delivery.RecordProviderCost(
+                        lspFee: order.Fees?.Lsp,
+                        platformFee: order.Fees?.Platform,
+                        totalWithTax: order.Fees?.TotalWithTax,
+                        distanceKm: order.Distance,
+                        networkOrderId: order.NetworkOrderId);
                     delivery.Update3PLRiderInfo(
                         order.Rider?.Name,
                         order.Rider?.Phone,
-                        order.TrackingUrl);
+                        trackingUrl);
                     if (delivery.Status == DeliveryRequestStatus.Searching3PL)
                     {
                         delivery.Assign3PLRider(
@@ -153,8 +160,8 @@ public static class WebhookEndpoints
                             order.LogisticsSeller ?? "ProRouting",
                             order.Rider?.Name,
                             order.Rider?.Phone,
-                            order.TrackingUrl,
-                            delivery.QuotedPrice);
+                            trackingUrl,
+                            order.Price ?? delivery.QuotedPrice);
                     }
                     break;
 
@@ -388,7 +395,18 @@ public static class WebhookEndpoints
                          ?? string.Empty;
 
         if (string.IsNullOrEmpty(expectedKey) || string.IsNullOrEmpty(providedKey))
+        {
+            // ProRouting preprod sends callbacks unsigned. Allow in Development so the round-trip
+            // can be tested locally via ngrok. Production envs still reject unsigned callbacks.
+            var envName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+            if (string.Equals(envName, "Development", StringComparison.OrdinalIgnoreCase))
+            {
+                var devEventId = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(rawBody)))[..32];
+                return (true, "accepted_dev_unsigned", devEventId);
+            }
+
             return (false, "rejected_missing_api_key", string.Empty);
+        }
 
         if (!CryptographicOperations.FixedTimeEquals(
                 Encoding.UTF8.GetBytes(providedKey),

--- a/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Migrations/20260514113931_AddProRoutingProviderCost.Designer.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Migrations/20260514113931_AddProRoutingProviderCost.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RallyAPI.Delivery.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using RallyAPI.Delivery.Infrastructure.Persistence;
 namespace RallyAPI.Delivery.Infrastructure.Migrations
 {
     [DbContext(typeof(DeliveryDbContext))]
-    partial class DeliveryDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260514113931_AddProRoutingProviderCost")]
+    partial class AddProRoutingProviderCost
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Migrations/20260514113931_AddProRoutingProviderCost.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Migrations/20260514113931_AddProRoutingProviderCost.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RallyAPI.Delivery.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProRoutingProviderCost : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "provider_distance_km",
+                schema: "delivery",
+                table: "delivery_requests",
+                type: "numeric(8,2)",
+                precision: 8,
+                scale: 2,
+                nullable: true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "provider_lsp_fee",
+                schema: "delivery",
+                table: "delivery_requests",
+                type: "numeric(10,2)",
+                precision: 10,
+                scale: 2,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "provider_network_order_id",
+                schema: "delivery",
+                table: "delivery_requests",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "provider_platform_fee",
+                schema: "delivery",
+                table: "delivery_requests",
+                type: "numeric(10,2)",
+                precision: 10,
+                scale: 2,
+                nullable: true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "provider_total_with_tax",
+                schema: "delivery",
+                table: "delivery_requests",
+                type: "numeric(10,2)",
+                precision: 10,
+                scale: 2,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "provider_distance_km",
+                schema: "delivery",
+                table: "delivery_requests");
+
+            migrationBuilder.DropColumn(
+                name: "provider_lsp_fee",
+                schema: "delivery",
+                table: "delivery_requests");
+
+            migrationBuilder.DropColumn(
+                name: "provider_network_order_id",
+                schema: "delivery",
+                table: "delivery_requests");
+
+            migrationBuilder.DropColumn(
+                name: "provider_platform_fee",
+                schema: "delivery",
+                table: "delivery_requests");
+
+            migrationBuilder.DropColumn(
+                name: "provider_total_with_tax",
+                schema: "delivery",
+                table: "delivery_requests");
+        }
+    }
+}

--- a/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Persistence/Configurations/DeliveryRequestConfiguration.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Persistence/Configurations/DeliveryRequestConfiguration.cs
@@ -86,6 +86,27 @@ public sealed class DeliveryRequestConfiguration : IEntityTypeConfiguration<Deli
             .HasColumnName("price_difference")
             .HasPrecision(10, 2);
 
+        // 3PL cost breakdown (from provider callback)
+        builder.Property(r => r.ProviderLspFee)
+            .HasColumnName("provider_lsp_fee")
+            .HasPrecision(10, 2);
+
+        builder.Property(r => r.ProviderPlatformFee)
+            .HasColumnName("provider_platform_fee")
+            .HasPrecision(10, 2);
+
+        builder.Property(r => r.ProviderTotalWithTax)
+            .HasColumnName("provider_total_with_tax")
+            .HasPrecision(10, 2);
+
+        builder.Property(r => r.ProviderDistanceKm)
+            .HasColumnName("provider_distance_km")
+            .HasPrecision(8, 2);
+
+        builder.Property(r => r.ProviderNetworkOrderId)
+            .HasColumnName("provider_network_order_id")
+            .HasMaxLength(100);
+
         // Own Fleet Assignment
         builder.Property(r => r.RiderId)
             .HasColumnName("rider_id");

--- a/src/Modules/Integrations/ProRouting/Models/ProRoutingCallbacks.cs
+++ b/src/Modules/Integrations/ProRouting/Models/ProRoutingCallbacks.cs
@@ -42,14 +42,45 @@ public sealed class ProRoutingStatusCallbackOrder
     [JsonPropertyName("logistics_seller")]
     public string? LogisticsSeller { get; set; }
 
+    /// <summary>
+    /// Provider's primary forward-leg price (LSP delivery charge before
+    /// platform fee). May be missing on early-state callbacks.
+    /// </summary>
+    [JsonPropertyName("price")]
+    public decimal? Price { get; set; }
+
+    [JsonPropertyName("fees")]
+    public ProRoutingCallbackFees? Fees { get; set; }
+
+    /// <summary>
+    /// Quoted route distance in km, reported back on the assignment callback.
+    /// </summary>
+    [JsonPropertyName("distance")]
+    public decimal? Distance { get; set; }
+
     [JsonPropertyName("rider")]
     public ProRoutingCallbackRider? Rider { get; set; }
 
     [JsonPropertyName("url")]
     public string? TrackingUrl { get; set; }
 
+    [JsonPropertyName("tracking_url")]
+    public string? TrackingUrlAlt { get; set; }
+
     [JsonPropertyName("cancel_reason")]
     public string? CancelReason { get; set; }
+}
+
+public sealed class ProRoutingCallbackFees
+{
+    [JsonPropertyName("lsp")]
+    public decimal? Lsp { get; set; }
+
+    [JsonPropertyName("platform")]
+    public decimal? Platform { get; set; }
+
+    [JsonPropertyName("total_with_tax")]
+    public decimal? TotalWithTax { get; set; }
 }
 
 /// <summary>

--- a/src/RallyAPI.Host/Program.cs
+++ b/src/RallyAPI.Host/Program.cs
@@ -350,6 +350,7 @@ if (app.Environment.IsDevelopment())
 {
     app.MapPurgeOrdersByRestaurant();
     app.MapSeedRestaurantOwner();
+    app.MapProRoutingDiagnosticEndpoints();
 }
 app.MapHub<NotificationHub>("/hubs/notifications");
 app.MapGet("/", () => "Rally API is running!");


### PR DESCRIPTION
OTP exposure
- New GET /api/delivery/orders/{orderId}/codes returns role-filtered codes: customer sees DropCode, restaurant sees PickupCode, admin sees both.
- Unauthorized callers receive 404 (not 403) so order existence isn't leaked.
- Codes themselves were already generated and sent to ProRouting at task creation; this only opens read access for the customer/restaurant UIs.

ProRouting cost tracking
- Persist provider price breakdown on Agent-assigned callback so the monthly invoice can be reconciled. New nullable columns on delivery_requests: provider_lsp_fee, provider_platform_fee, provider_total_with_tax, provider_distance_km, provider_network_order_id.
- Domain method RecordProviderCost preserves existing values when later callbacks omit cost fields.
- Webhook handler now uses provider price (when present) as the actual rather than always echoing our quoted price.

Other fixes carried in
- ProRoutingCallbacks model now also reads tracking_url (the key ProRouting actually sends; existing url key kept as fallback).
- Diagnostic phone numbers fixed to 10-digit Indian format (ProRouting rejects +91 prefixed values).
- WebhookEndpoints accepts unsigned callbacks only when ASPNETCORE_ENVIRONMENT is Development, so preprod testing through ngrok works without weakening production auth.
- Program.cs registers MapProRoutingDiagnosticEndpoints in Development.

Migration verified locally against rallydb; all 5 new columns present with nullable=true and correct precision.