### PR TITLE
feat(orders): add restaurant dashboard stats endpoint

### DIFF
--- a/src/Modules/Orders/RallyAPI.Orders.Application/Queries/GetRestaurantStats/GetRestaurantStatsQuery.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/Queries/GetRestaurantStats/GetRestaurantStatsQuery.cs
@@ -1,0 +1,31 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Orders.Application.Queries.GetRestaurantStats;
+
+/// <summary>
+/// Snapshot stats for a single restaurant outlet, scoped by time range.
+/// Powers the restaurant dashboard summary card row.
+/// </summary>
+public sealed record GetRestaurantStatsQuery(
+    Guid RestaurantId,
+    StatsRange Range)
+    : IRequest<Result<RestaurantStatsResponse>>;
+
+public enum StatsRange
+{
+    Today = 0,
+    Last7Days = 1,
+    Last30Days = 2
+}
+
+public sealed record RestaurantStatsResponse(
+    string Range,
+    DateTime PeriodStartUtc,
+    int OrdersTotal,
+    int OrdersDelivered,
+    int OrdersCancelled,
+    int OrdersActive,
+    decimal GrossRevenue,
+    decimal AverageOrderValue,
+    IReadOnlyDictionary<string, int> ActiveByStatus);

--- a/src/Modules/Orders/RallyAPI.Orders.Application/Queries/GetRestaurantStats/GetRestaurantStatsQueryHandler.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/Queries/GetRestaurantStats/GetRestaurantStatsQueryHandler.cs
@@ -1,0 +1,43 @@
+using MediatR;
+using RallyAPI.SharedKernel.Abstractions.Orders;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Orders.Application.Queries.GetRestaurantStats;
+
+public sealed class GetRestaurantStatsQueryHandler
+    : IRequestHandler<GetRestaurantStatsQuery, Result<RestaurantStatsResponse>>
+{
+    private readonly IRestaurantStatsService _stats;
+
+    public GetRestaurantStatsQueryHandler(IRestaurantStatsService stats)
+    {
+        _stats = stats;
+    }
+
+    public async Task<Result<RestaurantStatsResponse>> Handle(
+        GetRestaurantStatsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        var fromUtc = request.Range switch
+        {
+            StatsRange.Today => now.Date,
+            StatsRange.Last7Days => now.AddDays(-7),
+            StatsRange.Last30Days => now.AddDays(-30),
+            _ => now.Date
+        };
+
+        var snapshot = await _stats.GetStatsAsync(request.RestaurantId, fromUtc, cancellationToken);
+
+        return Result.Success(new RestaurantStatsResponse(
+            request.Range.ToString(),
+            fromUtc,
+            snapshot.OrdersTotal,
+            snapshot.OrdersDelivered,
+            snapshot.OrdersCancelled,
+            snapshot.OrdersActive,
+            snapshot.GrossRevenue,
+            snapshot.AverageOrderValue,
+            snapshot.ActiveByStatus));
+    }
+}

--- a/src/Modules/Orders/RallyAPI.Orders.Endpoints/OrderEndpoints.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Endpoints/OrderEndpoints.cs
@@ -23,6 +23,7 @@ using RallyAPI.Orders.Application.Queries.GetOrderByNumber;
 using RallyAPI.Orders.Application.Queries.GetOrderNotes;
 using RallyAPI.Orders.Application.Queries.GetOrdersByCustomer;
 using RallyAPI.Orders.Application.Queries.GetOrdersByRestaurant;
+using RallyAPI.Orders.Application.Queries.GetRestaurantStats;
 using RallyAPI.Orders.Domain.Enums;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
@@ -86,6 +87,16 @@ public static class OrderEndpoints
             .WithSummary("Get orders for a restaurant")
             .RequireAuthorization("Restaurant")
             .Produces<PagedResult<OrderSummaryDto>>();
+
+        // Restaurant Dashboard Stats — outside the /api/orders group so it sits at /api/restaurants/me/stats
+        app.MapGet("/api/restaurants/me/stats", GetRestaurantStats)
+            .WithName("GetRestaurantDashboardStats")
+            .WithSummary("Snapshot stats for the logged-in restaurant outlet")
+            .WithTags("Restaurants")
+            .RequireAuthorization("Restaurant")
+            .Produces<RestaurantStatsResponse>()
+            .Produces<ProblemDetails>(StatusCodes.Status400BadRequest)
+            .Produces<ProblemDetails>(StatusCodes.Status401Unauthorized);
 
         // Get Active Orders (Admin)
         group.MapGet("/active", GetActiveOrders)
@@ -350,6 +361,36 @@ public static class OrderEndpoints
         };
 
         var result = await mediator.Send(query, cancellationToken);
+
+        return result.IsSuccess
+            ? Results.Ok(result.Value)
+            : result.Error.ToErrorResult();
+    }
+
+    private static async Task<IResult> GetRestaurantStats(
+        HttpContext httpContext,
+        IMediator mediator,
+        [FromQuery] string? range,
+        CancellationToken cancellationToken)
+    {
+        var restaurantIdClaim = httpContext.User.FindFirst("sub")?.Value;
+        if (!Guid.TryParse(restaurantIdClaim, out var restaurantId))
+            return Results.Unauthorized();
+
+        var parsedRange = range?.ToLowerInvariant() switch
+        {
+            "today" or null or "" => StatsRange.Today,
+            "7d" or "last7days" or "week" => StatsRange.Last7Days,
+            "30d" or "last30days" or "month" => StatsRange.Last30Days,
+            _ => (StatsRange?)null
+        };
+
+        if (parsedRange is null)
+            return Results.BadRequest(new { error = "range must be one of: today, 7d, 30d" });
+
+        var result = await mediator.Send(
+            new GetRestaurantStatsQuery(restaurantId, parsedRange.Value),
+            cancellationToken);
 
         return result.IsSuccess
             ? Results.Ok(result.Value)

--- a/src/Modules/Orders/RallyAPI.Orders.Infrastructure/DependencyInjection.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Infrastructure/DependencyInjection.cs
@@ -74,6 +74,7 @@ public static class DependencyInjection
 
         // Cross-module services (consumed by admin queries via SharedKernel abstractions)
         services.AddScoped<IOrderStatsService, OrderStatsService>();
+        services.AddScoped<IRestaurantStatsService, RestaurantStatsService>();
         services.AddScoped<IEscalatedOrderQueryService, EscalatedOrderQueryService>();
         services.AddScoped<ILiveOrderFeedService, LiveOrderFeedService>();
         services.AddScoped<IAdminAlertsService, AdminAlertsService>();

--- a/src/Modules/Orders/RallyAPI.Orders.Infrastructure/Services/RestaurantStatsService.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Infrastructure/Services/RestaurantStatsService.cs
@@ -1,0 +1,80 @@
+using Microsoft.EntityFrameworkCore;
+using RallyAPI.Orders.Domain.Enums;
+using RallyAPI.SharedKernel.Abstractions.Orders;
+
+namespace RallyAPI.Orders.Infrastructure.Services;
+
+public sealed class RestaurantStatsService : IRestaurantStatsService
+{
+    private static readonly OrderStatus[] ActiveStatuses =
+    [
+        OrderStatus.Paid,
+        OrderStatus.Confirmed,
+        OrderStatus.Preparing,
+        OrderStatus.ReadyForPickup,
+        OrderStatus.PickedUp
+    ];
+
+    private static readonly OrderStatus[] CancelledStatuses =
+    [
+        OrderStatus.Cancelled,
+        OrderStatus.Rejected,
+        OrderStatus.Failed
+    ];
+
+    private readonly OrdersDbContext _context;
+
+    public RestaurantStatsService(OrdersDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<RestaurantStatsSnapshot> GetStatsAsync(
+        Guid restaurantId,
+        DateTime fromUtc,
+        CancellationToken cancellationToken = default)
+    {
+        // Sequential — EF Core does not support concurrent ops on the same context.
+        var rangeQuery = _context.Orders
+            .Where(o => o.RestaurantId == restaurantId && o.CreatedAt >= fromUtc);
+
+        var ordersTotal = await rangeQuery.CountAsync(cancellationToken);
+
+        var ordersDelivered = await rangeQuery
+            .CountAsync(o => o.Status == OrderStatus.Delivered, cancellationToken);
+
+        var ordersCancelled = await rangeQuery
+            .CountAsync(o => CancelledStatuses.Contains(o.Status), cancellationToken);
+
+        var grossRevenueNullable = await rangeQuery
+            .Where(o => o.Status == OrderStatus.Delivered)
+            .SumAsync(o => (decimal?)o.Pricing.Total.Amount, cancellationToken);
+        var grossRevenue = grossRevenueNullable ?? 0m;
+
+        var averageOrderValue = ordersDelivered > 0
+            ? Math.Round(grossRevenue / ordersDelivered, 2)
+            : 0m;
+
+        var ordersActive = await _context.Orders
+            .CountAsync(
+                o => o.RestaurantId == restaurantId && ActiveStatuses.Contains(o.Status),
+                cancellationToken);
+
+        var activeGrouped = await _context.Orders
+            .Where(o => o.RestaurantId == restaurantId && ActiveStatuses.Contains(o.Status))
+            .GroupBy(o => o.Status)
+            .Select(g => new { Status = g.Key, Count = g.Count() })
+            .ToListAsync(cancellationToken);
+
+        var activeByStatus = activeGrouped.ToDictionary(x => x.Status.ToString(), x => x.Count);
+
+        return new RestaurantStatsSnapshot(
+            ordersTotal,
+            ordersDelivered,
+            ordersCancelled,
+            ordersActive,
+            grossRevenue,
+            averageOrderValue,
+            activeByStatus);
+    }
+}

--- a/src/RallyAPI.SharedKernel/Abstractions/Orders/IRestaurantStatsService.cs
+++ b/src/RallyAPI.SharedKernel/Abstractions/Orders/IRestaurantStatsService.cs
@@ -1,0 +1,28 @@
+namespace RallyAPI.SharedKernel.Abstractions.Orders;
+
+/// <summary>
+/// Cross-module service that returns operational stats for a single restaurant outlet.
+/// Powers the restaurant dashboard summary endpoint.
+/// Implemented in Orders.Infrastructure, consumed by Orders.Application.
+/// </summary>
+public interface IRestaurantStatsService
+{
+    /// <summary>
+    /// Returns a snapshot of orders for <paramref name="restaurantId"/> since <paramref name="fromUtc"/>.
+    /// Range counts (total / delivered / cancelled / revenue) use the time window;
+    /// the active snapshot is right-now regardless of the window.
+    /// </summary>
+    Task<RestaurantStatsSnapshot> GetStatsAsync(
+        Guid restaurantId,
+        DateTime fromUtc,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record RestaurantStatsSnapshot(
+    int OrdersTotal,
+    int OrdersDelivered,
+    int OrdersCancelled,
+    int OrdersActive,
+    decimal GrossRevenue,
+    decimal AverageOrderValue,
+    IReadOnlyDictionary<string, int> ActiveByStatus);


### PR DESCRIPTION
GET /api/restaurants/me/stats?range=today|7d|30d returns a windowed snapshot for the logged-in restaurant outlet: orders total/delivered/ cancelled, gross revenue, average order value, plus a right-now breakdown of in-flight orders by status. Scoped via the JWT sub claim and gated by the Restaurant role.

- IRestaurantStatsService (SharedKernel) + RestaurantStatsService (Orders.Infrastructure) for the EF queries
- GetRestaurantStatsQuery + handler in Orders.Application
- Endpoint wired in OrderEndpoints.cs