### PR TITLE
feat(restaurants): add owner endpoints to toggle outlet availability

### DIFF
--- a/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/SetAllOutletsAvailability/SetAllOutletsAvailabilityCommand.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/SetAllOutletsAvailability/SetAllOutletsAvailabilityCommand.cs
@@ -1,0 +1,12 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Users.Application.Owners.Commands.SetAllOutletsAvailability;
+
+public sealed record SetAllOutletsAvailabilityCommand(
+    Guid OwnerId,
+    bool IsAcceptingOrders) : IRequest<Result<SetAllOutletsAvailabilityResponse>>;
+
+public sealed record SetAllOutletsAvailabilityResponse(
+    int UpdatedCount,
+    int SkippedCount);

--- a/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/SetAllOutletsAvailability/SetAllOutletsAvailabilityCommandHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/SetAllOutletsAvailability/SetAllOutletsAvailabilityCommandHandler.cs
@@ -1,0 +1,54 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Application.Abstractions;
+
+namespace RallyAPI.Users.Application.Owners.Commands.SetAllOutletsAvailability;
+
+internal sealed class SetAllOutletsAvailabilityCommandHandler
+    : IRequestHandler<SetAllOutletsAvailabilityCommand, Result<SetAllOutletsAvailabilityResponse>>
+{
+    private readonly IRestaurantRepository _restaurantRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public SetAllOutletsAvailabilityCommandHandler(
+        IRestaurantRepository restaurantRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _restaurantRepository = restaurantRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result<SetAllOutletsAvailabilityResponse>> Handle(
+        SetAllOutletsAvailabilityCommand request,
+        CancellationToken cancellationToken)
+    {
+        var outlets = await _restaurantRepository.GetByOwnerIdAsync(
+            request.OwnerId,
+            cancellationToken);
+
+        var updated = 0;
+        var skipped = 0;
+
+        foreach (var outlet in outlets)
+        {
+            var toggle = request.IsAcceptingOrders
+                ? outlet.StartAcceptingOrders()
+                : outlet.StopAcceptingOrders();
+
+            if (toggle.IsSuccess)
+            {
+                _restaurantRepository.Update(outlet, cancellationToken);
+                updated++;
+            }
+            else
+            {
+                skipped++;
+            }
+        }
+
+        if (updated > 0)
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return new SetAllOutletsAvailabilityResponse(updated, skipped);
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/SetOutletAvailability/SetOutletAvailabilityCommand.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/SetOutletAvailability/SetOutletAvailabilityCommand.cs
@@ -1,0 +1,9 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Users.Application.Owners.Commands.SetOutletAvailability;
+
+public sealed record SetOutletAvailabilityCommand(
+    Guid OwnerId,
+    Guid RestaurantId,
+    bool IsAcceptingOrders) : IRequest<Result>;

--- a/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/SetOutletAvailability/SetOutletAvailabilityCommandHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/SetOutletAvailability/SetOutletAvailabilityCommandHandler.cs
@@ -1,0 +1,46 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Application.Abstractions;
+
+namespace RallyAPI.Users.Application.Owners.Commands.SetOutletAvailability;
+
+internal sealed class SetOutletAvailabilityCommandHandler
+    : IRequestHandler<SetOutletAvailabilityCommand, Result>
+{
+    private readonly IRestaurantRepository _restaurantRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public SetOutletAvailabilityCommandHandler(
+        IRestaurantRepository restaurantRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _restaurantRepository = restaurantRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result> Handle(
+        SetOutletAvailabilityCommand request,
+        CancellationToken cancellationToken)
+    {
+        var restaurant = await _restaurantRepository.GetByIdAsync(
+            request.RestaurantId,
+            cancellationToken);
+
+        if (restaurant is null)
+            return Result.Failure(Error.NotFound("Restaurant", request.RestaurantId));
+
+        if (restaurant.OwnerId != request.OwnerId)
+            return Result.Failure(Error.Forbidden("You do not have access to this outlet."));
+
+        var result = request.IsAcceptingOrders
+            ? restaurant.StartAcceptingOrders()
+            : restaurant.StopAcceptingOrders();
+
+        if (result.IsFailure)
+            return result;
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Owners/SetAllOutletsAvailability.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Owners/SetAllOutletsAvailability.cs
@@ -1,0 +1,39 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Owners.Commands.SetAllOutletsAvailability;
+using System.Security.Claims;
+
+namespace RallyAPI.Users.Endpoints.Owners;
+
+public class SetAllOutletsAvailability : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPut("/api/owners/me/outlets/availability", HandleAsync)
+            .WithName("SetOwnerAllOutletsAvailability")
+            .WithTags("Owners")
+            .WithSummary("Owner toggles all owned outlets online/offline. Inactive outlets are skipped when going online.")
+            .RequireAuthorization("Owner");
+    }
+
+    public record SetAllOutletsAvailabilityRequest(bool IsAcceptingOrders);
+
+    private static async Task<IResult> HandleAsync(
+        SetAllOutletsAvailabilityRequest request,
+        ClaimsPrincipal user,
+        ISender sender,
+        CancellationToken cancellationToken)
+    {
+        var ownerId = Guid.Parse(user.FindFirstValue("sub")!);
+
+        var command = new SetAllOutletsAvailabilityCommand(ownerId, request.IsAcceptingOrders);
+        var result = await sender.Send(command, cancellationToken);
+
+        return result.IsFailure
+            ? result.Error.ToErrorResult()
+            : Results.Ok(result.Value);
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Owners/SetOutletAvailability.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Owners/SetOutletAvailability.cs
@@ -1,0 +1,40 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Owners.Commands.SetOutletAvailability;
+using System.Security.Claims;
+
+namespace RallyAPI.Users.Endpoints.Owners;
+
+public class SetOutletAvailability : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPut("/api/owners/me/outlets/{restaurantId:guid}/availability", HandleAsync)
+            .WithName("SetOwnerOutletAvailability")
+            .WithTags("Owners")
+            .WithSummary("Owner toggles a specific outlet online/offline")
+            .RequireAuthorization("Owner");
+    }
+
+    public record SetOutletAvailabilityRequest(bool IsAcceptingOrders);
+
+    private static async Task<IResult> HandleAsync(
+        Guid restaurantId,
+        SetOutletAvailabilityRequest request,
+        ClaimsPrincipal user,
+        ISender sender,
+        CancellationToken cancellationToken)
+    {
+        var ownerId = Guid.Parse(user.FindFirstValue("sub")!);
+
+        var command = new SetOutletAvailabilityCommand(ownerId, restaurantId, request.IsAcceptingOrders);
+        var result = await sender.Send(command, cancellationToken);
+
+        return result.IsFailure
+            ? result.Error.ToErrorResult()
+            : Results.Ok(new { restaurantId, isAcceptingOrders = request.IsAcceptingOrders });
+    }
+}


### PR DESCRIPTION
Adds two Owner-scoped endpoints so multi-outlet owners can take outlets online/offline without switching restaurant context:

- PUT /api/owners/me/outlets/{restaurantId}/availability (single outlet)
- PUT /api/owners/me/outlets/availability (all owned outlets, skip-and-continue)

Ownership enforced by matching Restaurant.OwnerId to the JWT sub claim. Bulk handler skips outlets where the domain rejects the toggle (e.g. admin-deactivated outlet going online) and reports updatedCount / skippedCount.