### PR TITLE
feat(restaurants): owner scheduled time off + order-time enforcement

### DIFF
--- a/src/Modules/Orders/RallyAPI.Orders.Application/Commands/PlaceOrder/PlaceOrderCommandHandler.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/Commands/PlaceOrder/PlaceOrderCommandHandler.cs
@@ -25,6 +25,7 @@ public sealed class PlaceOrderCommandHandler : IRequestHandler<PlaceOrderCommand
     private readonly IOrderNumberGenerator _orderNumberGenerator;
     private readonly IOrderValidationService _validationService;
     private readonly IRestaurantQueryService _restaurantQueryService;
+    private readonly IRestaurantAvailabilityChecker _availabilityChecker;
     private readonly ICartRepository _cartRepository;
     private readonly ICartCacheService _cartCache;
     private readonly IUnitOfWork _unitOfWork;
@@ -37,6 +38,7 @@ public sealed class PlaceOrderCommandHandler : IRequestHandler<PlaceOrderCommand
         IOrderNumberGenerator orderNumberGenerator,
         IOrderValidationService validationService,
         IRestaurantQueryService restaurantQueryService,
+        IRestaurantAvailabilityChecker availabilityChecker,
         ICartRepository cartRepository,
         ICartCacheService cartCache,
         IUnitOfWork unitOfWork,
@@ -46,6 +48,7 @@ public sealed class PlaceOrderCommandHandler : IRequestHandler<PlaceOrderCommand
         _orderNumberGenerator = orderNumberGenerator;
         _validationService = validationService;
         _restaurantQueryService = restaurantQueryService;
+        _availabilityChecker = availabilityChecker;
         _cartRepository = cartRepository;
         _cartCache = cartCache;
         _unitOfWork = unitOfWork;
@@ -79,6 +82,19 @@ public sealed class PlaceOrderCommandHandler : IRequestHandler<PlaceOrderCommand
             {
                 _logger.LogWarning("Restaurant validation failed: {Error}", restaurantValidation.Error);
                 return Result.Failure<OrderDto>(restaurantValidation.Error);
+            }
+
+            // Step 3.5: Block orders if the restaurant is in a scheduled time-off window.
+            // Closure overrides IsAcceptingOrders — the owner explicitly scheduled this.
+            var isClosed = await _availabilityChecker.IsClosedForScheduledTimeOffAsync(
+                command.Request.RestaurantId, momentUtc: null, cancellationToken);
+
+            if (isClosed)
+            {
+                _logger.LogWarning(
+                    "Order rejected — Restaurant {RestaurantId} is on scheduled time off",
+                    command.Request.RestaurantId);
+                return Result.Failure<OrderDto>(OrderErrors.RestaurantClosed);
             }
 
             // Step 3a: Block pickup orders against restaurants that don't accept pickup.

--- a/src/Modules/Users/RallyAPI.Users.Application/Abstractions/IRestaurantTimeOffRepository.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Abstractions/IRestaurantTimeOffRepository.cs
@@ -1,0 +1,38 @@
+using RallyAPI.Users.Domain.Entities;
+
+namespace RallyAPI.Users.Application.Abstractions;
+
+public interface IRestaurantTimeOffRepository
+{
+    Task<RestaurantTimeOff?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<RestaurantTimeOff>> GetForRestaurantAsync(
+        Guid restaurantId,
+        bool includeCancelled,
+        bool includePast,
+        DateTime nowUtc,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns true if any non-cancelled time off for <paramref name="restaurantId"/> overlaps
+    /// the half-open window [startsAt, endsAt). Used to enforce non-overlap at scheduling time.
+    /// </summary>
+    Task<bool> HasOverlapAsync(
+        Guid restaurantId,
+        DateTime startsAtUtc,
+        DateTime endsAtUtc,
+        Guid? excludeId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns true if there is an active (non-cancelled) time off covering <paramref name="momentUtc"/>.
+    /// Hot path: called on every PlaceOrder.
+    /// </summary>
+    Task<bool> IsClosedAtAsync(
+        Guid restaurantId,
+        DateTime momentUtc,
+        CancellationToken cancellationToken = default);
+
+    Task AddAsync(RestaurantTimeOff entity, CancellationToken cancellationToken = default);
+    void Update(RestaurantTimeOff entity);
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/CancelTimeOff/CancelTimeOffCommand.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/CancelTimeOff/CancelTimeOffCommand.cs
@@ -1,0 +1,9 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Users.Application.Owners.Commands.CancelTimeOff;
+
+public sealed record CancelTimeOffCommand(
+    Guid OwnerId,
+    Guid RestaurantId,
+    Guid TimeOffId) : IRequest<Result>;

--- a/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/CancelTimeOff/CancelTimeOffCommandHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/CancelTimeOff/CancelTimeOffCommandHandler.cs
@@ -1,0 +1,43 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Application.Abstractions;
+
+namespace RallyAPI.Users.Application.Owners.Commands.CancelTimeOff;
+
+internal sealed class CancelTimeOffCommandHandler : IRequestHandler<CancelTimeOffCommand, Result>
+{
+    private readonly IRestaurantRepository _restaurantRepository;
+    private readonly IRestaurantTimeOffRepository _timeOffRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public CancelTimeOffCommandHandler(
+        IRestaurantRepository restaurantRepository,
+        IRestaurantTimeOffRepository timeOffRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _restaurantRepository = restaurantRepository;
+        _timeOffRepository = timeOffRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result> Handle(CancelTimeOffCommand request, CancellationToken cancellationToken)
+    {
+        var restaurant = await _restaurantRepository.GetByIdAsync(request.RestaurantId, cancellationToken);
+        if (restaurant is null)
+            return Result.Failure(Error.NotFound("Restaurant", request.RestaurantId));
+
+        if (restaurant.OwnerId != request.OwnerId)
+            return Result.Failure(Error.Forbidden("You do not have access to this outlet."));
+
+        var timeOff = await _timeOffRepository.GetByIdAsync(request.TimeOffId, cancellationToken);
+        if (timeOff is null || timeOff.RestaurantId != request.RestaurantId)
+            return Result.Failure(Error.NotFound("TimeOff", request.TimeOffId));
+
+        var cancelResult = timeOff.Cancel(DateTime.UtcNow);
+        if (cancelResult.IsFailure)
+            return cancelResult;
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+        return Result.Success();
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/QuickPauseOutlet/QuickPauseOutletCommand.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/QuickPauseOutlet/QuickPauseOutletCommand.cs
@@ -1,0 +1,15 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Application.Owners.Commands.ScheduleTimeOff;
+
+namespace RallyAPI.Users.Application.Owners.Commands.QuickPauseOutlet;
+
+/// <summary>
+/// Pause the outlet for <paramref name="DurationMinutes"/> starting now. Convenience wrapper
+/// around <see cref="ScheduleTimeOffCommand"/> — backing storage is identical.
+/// </summary>
+public sealed record QuickPauseOutletCommand(
+    Guid OwnerId,
+    Guid RestaurantId,
+    int DurationMinutes,
+    string? Reason) : IRequest<Result<ScheduleTimeOffResponse>>;

--- a/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/QuickPauseOutlet/QuickPauseOutletCommandHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/QuickPauseOutlet/QuickPauseOutletCommandHandler.cs
@@ -1,0 +1,71 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Application.Abstractions;
+using RallyAPI.Users.Application.Owners.Commands.ScheduleTimeOff;
+using RallyAPI.Users.Domain.Entities;
+
+namespace RallyAPI.Users.Application.Owners.Commands.QuickPauseOutlet;
+
+internal sealed class QuickPauseOutletCommandHandler
+    : IRequestHandler<QuickPauseOutletCommand, Result<ScheduleTimeOffResponse>>
+{
+    private readonly IRestaurantRepository _restaurantRepository;
+    private readonly IRestaurantTimeOffRepository _timeOffRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public QuickPauseOutletCommandHandler(
+        IRestaurantRepository restaurantRepository,
+        IRestaurantTimeOffRepository timeOffRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _restaurantRepository = restaurantRepository;
+        _timeOffRepository = timeOffRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result<ScheduleTimeOffResponse>> Handle(
+        QuickPauseOutletCommand request,
+        CancellationToken cancellationToken)
+    {
+        var restaurant = await _restaurantRepository.GetByIdAsync(request.RestaurantId, cancellationToken);
+        if (restaurant is null)
+            return Result.Failure<ScheduleTimeOffResponse>(Error.NotFound("Restaurant", request.RestaurantId));
+
+        if (restaurant.OwnerId != request.OwnerId)
+            return Result.Failure<ScheduleTimeOffResponse>(
+                Error.Forbidden("You do not have access to this outlet."));
+
+        var nowUtc = DateTime.UtcNow;
+        var startsAtUtc = nowUtc;
+        var endsAtUtc = nowUtc.AddMinutes(request.DurationMinutes);
+
+        if (await _timeOffRepository.HasOverlapAsync(
+                request.RestaurantId, startsAtUtc, endsAtUtc, excludeId: null, cancellationToken))
+        {
+            return Result.Failure<ScheduleTimeOffResponse>(
+                Error.Conflict("Another scheduled time off overlaps this window. Cancel it first to pause again."));
+        }
+
+        var createResult = RestaurantTimeOff.Create(
+            request.RestaurantId,
+            startsAtUtc,
+            endsAtUtc,
+            request.Reason,
+            request.OwnerId,
+            nowUtc);
+
+        if (createResult.IsFailure)
+            return Result.Failure<ScheduleTimeOffResponse>(createResult.Error);
+
+        var timeOff = createResult.Value;
+        await _timeOffRepository.AddAsync(timeOff, cancellationToken);
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return new ScheduleTimeOffResponse(
+            timeOff.Id,
+            timeOff.RestaurantId,
+            timeOff.StartsAt,
+            timeOff.EndsAt,
+            timeOff.Reason);
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/QuickPauseOutlet/QuickPauseOutletCommandValidator.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/QuickPauseOutlet/QuickPauseOutletCommandValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+
+namespace RallyAPI.Users.Application.Owners.Commands.QuickPauseOutlet;
+
+public sealed class QuickPauseOutletCommandValidator : AbstractValidator<QuickPauseOutletCommand>
+{
+    public QuickPauseOutletCommandValidator()
+    {
+        RuleFor(x => x.OwnerId).NotEmpty();
+        RuleFor(x => x.RestaurantId).NotEmpty();
+        RuleFor(x => x.DurationMinutes)
+            .InclusiveBetween(1, 1440)
+            .WithMessage("Pause duration must be between 1 minute and 24 hours.");
+        RuleFor(x => x.Reason)
+            .MaximumLength(200)
+            .When(x => !string.IsNullOrWhiteSpace(x.Reason));
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/ScheduleTimeOff/ScheduleTimeOffCommand.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/ScheduleTimeOff/ScheduleTimeOffCommand.cs
@@ -1,0 +1,18 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Users.Application.Owners.Commands.ScheduleTimeOff;
+
+public sealed record ScheduleTimeOffCommand(
+    Guid OwnerId,
+    Guid RestaurantId,
+    DateTime StartsAtUtc,
+    DateTime EndsAtUtc,
+    string? Reason) : IRequest<Result<ScheduleTimeOffResponse>>;
+
+public sealed record ScheduleTimeOffResponse(
+    Guid Id,
+    Guid RestaurantId,
+    DateTime StartsAtUtc,
+    DateTime EndsAtUtc,
+    string? Reason);

--- a/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/ScheduleTimeOff/ScheduleTimeOffCommandHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/ScheduleTimeOff/ScheduleTimeOffCommandHandler.cs
@@ -1,0 +1,70 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Application.Abstractions;
+using RallyAPI.Users.Domain.Entities;
+
+namespace RallyAPI.Users.Application.Owners.Commands.ScheduleTimeOff;
+
+internal sealed class ScheduleTimeOffCommandHandler
+    : IRequestHandler<ScheduleTimeOffCommand, Result<ScheduleTimeOffResponse>>
+{
+    private readonly IRestaurantRepository _restaurantRepository;
+    private readonly IRestaurantTimeOffRepository _timeOffRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public ScheduleTimeOffCommandHandler(
+        IRestaurantRepository restaurantRepository,
+        IRestaurantTimeOffRepository timeOffRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _restaurantRepository = restaurantRepository;
+        _timeOffRepository = timeOffRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result<ScheduleTimeOffResponse>> Handle(
+        ScheduleTimeOffCommand request,
+        CancellationToken cancellationToken)
+    {
+        var restaurant = await _restaurantRepository.GetByIdAsync(request.RestaurantId, cancellationToken);
+        if (restaurant is null)
+            return Result.Failure<ScheduleTimeOffResponse>(Error.NotFound("Restaurant", request.RestaurantId));
+
+        if (restaurant.OwnerId != request.OwnerId)
+            return Result.Failure<ScheduleTimeOffResponse>(
+                Error.Forbidden("You do not have access to this outlet."));
+
+        var startsAtUtc = DateTime.SpecifyKind(request.StartsAtUtc.ToUniversalTime(), DateTimeKind.Utc);
+        var endsAtUtc = DateTime.SpecifyKind(request.EndsAtUtc.ToUniversalTime(), DateTimeKind.Utc);
+        var nowUtc = DateTime.UtcNow;
+
+        if (await _timeOffRepository.HasOverlapAsync(
+                request.RestaurantId, startsAtUtc, endsAtUtc, excludeId: null, cancellationToken))
+        {
+            return Result.Failure<ScheduleTimeOffResponse>(
+                Error.Conflict("Another scheduled time off overlaps this window."));
+        }
+
+        var createResult = RestaurantTimeOff.Create(
+            request.RestaurantId,
+            startsAtUtc,
+            endsAtUtc,
+            request.Reason,
+            request.OwnerId,
+            nowUtc);
+
+        if (createResult.IsFailure)
+            return Result.Failure<ScheduleTimeOffResponse>(createResult.Error);
+
+        var timeOff = createResult.Value;
+        await _timeOffRepository.AddAsync(timeOff, cancellationToken);
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return new ScheduleTimeOffResponse(
+            timeOff.Id,
+            timeOff.RestaurantId,
+            timeOff.StartsAt,
+            timeOff.EndsAt,
+            timeOff.Reason);
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/ScheduleTimeOff/ScheduleTimeOffCommandValidator.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/ScheduleTimeOff/ScheduleTimeOffCommandValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+
+namespace RallyAPI.Users.Application.Owners.Commands.ScheduleTimeOff;
+
+public sealed class ScheduleTimeOffCommandValidator : AbstractValidator<ScheduleTimeOffCommand>
+{
+    public ScheduleTimeOffCommandValidator()
+    {
+        RuleFor(x => x.OwnerId).NotEmpty();
+        RuleFor(x => x.RestaurantId).NotEmpty();
+        RuleFor(x => x.StartsAtUtc).NotEmpty();
+        RuleFor(x => x.EndsAtUtc).NotEmpty();
+        RuleFor(x => x.EndsAtUtc)
+            .GreaterThan(x => x.StartsAtUtc)
+            .WithMessage("End time must be after start time.");
+        RuleFor(x => x.Reason)
+            .MaximumLength(200)
+            .When(x => !string.IsNullOrWhiteSpace(x.Reason));
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Owners/Queries/GetTimeOffs/GetTimeOffsQuery.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Owners/Queries/GetTimeOffs/GetTimeOffsQuery.cs
@@ -1,0 +1,20 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Users.Application.Owners.Queries.GetTimeOffs;
+
+public sealed record GetTimeOffsQuery(
+    Guid OwnerId,
+    Guid RestaurantId,
+    bool IncludeCancelled,
+    bool IncludePast) : IRequest<Result<IReadOnlyList<TimeOffResponse>>>;
+
+public sealed record TimeOffResponse(
+    Guid Id,
+    Guid RestaurantId,
+    DateTime StartsAtUtc,
+    DateTime EndsAtUtc,
+    string? Reason,
+    DateTime? CancelledAtUtc,
+    DateTime CreatedAtUtc,
+    bool IsActive);

--- a/src/Modules/Users/RallyAPI.Users.Application/Owners/Queries/GetTimeOffs/GetTimeOffsQueryHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Owners/Queries/GetTimeOffs/GetTimeOffsQueryHandler.cs
@@ -1,0 +1,56 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Application.Abstractions;
+
+namespace RallyAPI.Users.Application.Owners.Queries.GetTimeOffs;
+
+internal sealed class GetTimeOffsQueryHandler
+    : IRequestHandler<GetTimeOffsQuery, Result<IReadOnlyList<TimeOffResponse>>>
+{
+    private readonly IRestaurantRepository _restaurantRepository;
+    private readonly IRestaurantTimeOffRepository _timeOffRepository;
+
+    public GetTimeOffsQueryHandler(
+        IRestaurantRepository restaurantRepository,
+        IRestaurantTimeOffRepository timeOffRepository)
+    {
+        _restaurantRepository = restaurantRepository;
+        _timeOffRepository = timeOffRepository;
+    }
+
+    public async Task<Result<IReadOnlyList<TimeOffResponse>>> Handle(
+        GetTimeOffsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var restaurant = await _restaurantRepository.GetByIdAsync(request.RestaurantId, cancellationToken);
+        if (restaurant is null)
+            return Result.Failure<IReadOnlyList<TimeOffResponse>>(
+                Error.NotFound("Restaurant", request.RestaurantId));
+
+        if (restaurant.OwnerId != request.OwnerId)
+            return Result.Failure<IReadOnlyList<TimeOffResponse>>(
+                Error.Forbidden("You do not have access to this outlet."));
+
+        var nowUtc = DateTime.UtcNow;
+        var items = await _timeOffRepository.GetForRestaurantAsync(
+            request.RestaurantId,
+            request.IncludeCancelled,
+            request.IncludePast,
+            nowUtc,
+            cancellationToken);
+
+        var response = items
+            .Select(t => new TimeOffResponse(
+                t.Id,
+                t.RestaurantId,
+                t.StartsAt,
+                t.EndsAt,
+                t.Reason,
+                t.CancelledAt,
+                t.CreatedAt,
+                t.IsActiveAt(nowUtc)))
+            .ToList();
+
+        return Result.Success<IReadOnlyList<TimeOffResponse>>(response);
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Domain/Entities/RestaurantTimeOff.cs
+++ b/src/Modules/Users/RallyAPI.Users.Domain/Entities/RestaurantTimeOff.cs
@@ -1,0 +1,89 @@
+using RallyAPI.SharedKernel.Domain;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Users.Domain.Entities;
+
+/// <summary>
+/// One-off scheduled closure window for a restaurant (holiday, training, kitchen pause, etc.).
+/// Overrides <c>IsAcceptingOrders</c> during the window — order placement is blocked even if
+/// the outlet is marked online. Cancelled closures are soft-deleted via <see cref="CancelledAt"/>
+/// rather than removed, so history is preserved for audit.
+/// </summary>
+public sealed class RestaurantTimeOff : BaseEntity
+{
+    public Guid RestaurantId { get; private set; }
+    public DateTime StartsAt { get; private set; }
+    public DateTime EndsAt { get; private set; }
+    public string? Reason { get; private set; }
+    public Guid CreatedByOwnerId { get; private set; }
+    public DateTime? CancelledAt { get; private set; }
+
+    private const int MaxReasonLength = 200;
+    private static readonly TimeSpan MaxDuration = TimeSpan.FromDays(90);
+
+    private RestaurantTimeOff() { }
+
+    private RestaurantTimeOff(
+        Guid restaurantId,
+        DateTime startsAtUtc,
+        DateTime endsAtUtc,
+        string? reason,
+        Guid createdByOwnerId)
+    {
+        RestaurantId = restaurantId;
+        StartsAt = startsAtUtc;
+        EndsAt = endsAtUtc;
+        Reason = reason;
+        CreatedByOwnerId = createdByOwnerId;
+    }
+
+    public static Result<RestaurantTimeOff> Create(
+        Guid restaurantId,
+        DateTime startsAtUtc,
+        DateTime endsAtUtc,
+        string? reason,
+        Guid createdByOwnerId,
+        DateTime nowUtc)
+    {
+        if (restaurantId == Guid.Empty)
+            return Result.Failure<RestaurantTimeOff>(Error.Validation("Restaurant ID is required."));
+
+        if (createdByOwnerId == Guid.Empty)
+            return Result.Failure<RestaurantTimeOff>(Error.Validation("Owner ID is required."));
+
+        if (startsAtUtc >= endsAtUtc)
+            return Result.Failure<RestaurantTimeOff>(
+                Error.Validation("Start time must be earlier than end time."));
+
+        if (endsAtUtc <= nowUtc)
+            return Result.Failure<RestaurantTimeOff>(
+                Error.Validation("End time must be in the future."));
+
+        if (endsAtUtc - startsAtUtc > MaxDuration)
+            return Result.Failure<RestaurantTimeOff>(
+                Error.Validation($"Time off cannot exceed {MaxDuration.TotalDays:0} days."));
+
+        var trimmedReason = string.IsNullOrWhiteSpace(reason) ? null : reason.Trim();
+        if (trimmedReason is { Length: > MaxReasonLength })
+            return Result.Failure<RestaurantTimeOff>(
+                Error.Validation($"Reason must be {MaxReasonLength} characters or fewer."));
+
+        return new RestaurantTimeOff(restaurantId, startsAtUtc, endsAtUtc, trimmedReason, createdByOwnerId);
+    }
+
+    public Result Cancel(DateTime nowUtc)
+    {
+        if (CancelledAt is not null)
+            return Result.Failure(Error.Validation("Time off is already cancelled."));
+
+        if (EndsAt <= nowUtc)
+            return Result.Failure(Error.Validation("Cannot cancel a time off that has already ended."));
+
+        CancelledAt = nowUtc;
+        MarkAsUpdated();
+        return Result.Success();
+    }
+
+    public bool IsActiveAt(DateTime momentUtc)
+        => CancelledAt is null && momentUtc >= StartsAt && momentUtc < EndsAt;
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Owners/CancelTimeOff.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Owners/CancelTimeOff.cs
@@ -1,0 +1,38 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Owners.Commands.CancelTimeOff;
+using System.Security.Claims;
+
+namespace RallyAPI.Users.Endpoints.Owners;
+
+public class CancelTimeOff : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapDelete("/api/owners/me/outlets/{restaurantId:guid}/time-off/{timeOffId:guid}", HandleAsync)
+            .WithName("CancelOutletTimeOff")
+            .WithTags("Owners")
+            .WithSummary("Owner cancels a scheduled time off (soft — preserves history)")
+            .RequireAuthorization("Owner");
+    }
+
+    private static async Task<IResult> HandleAsync(
+        Guid restaurantId,
+        Guid timeOffId,
+        ClaimsPrincipal user,
+        ISender sender,
+        CancellationToken cancellationToken)
+    {
+        var ownerId = Guid.Parse(user.FindFirstValue("sub")!);
+
+        var command = new CancelTimeOffCommand(ownerId, restaurantId, timeOffId);
+        var result = await sender.Send(command, cancellationToken);
+
+        return result.IsFailure
+            ? result.Error.ToErrorResult()
+            : Results.NoContent();
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Owners/GetTimeOffs.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Owners/GetTimeOffs.cs
@@ -1,0 +1,44 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Owners.Queries.GetTimeOffs;
+using System.Security.Claims;
+
+namespace RallyAPI.Users.Endpoints.Owners;
+
+public class GetTimeOffs : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/owners/me/outlets/{restaurantId:guid}/time-off", HandleAsync)
+            .WithName("GetOutletTimeOffs")
+            .WithTags("Owners")
+            .WithSummary("List scheduled time offs for an outlet (default: upcoming + active only)")
+            .RequireAuthorization("Owner");
+    }
+
+    private static async Task<IResult> HandleAsync(
+        Guid restaurantId,
+        bool? includeCancelled,
+        bool? includePast,
+        ClaimsPrincipal user,
+        ISender sender,
+        CancellationToken cancellationToken)
+    {
+        var ownerId = Guid.Parse(user.FindFirstValue("sub")!);
+
+        var query = new GetTimeOffsQuery(
+            ownerId,
+            restaurantId,
+            includeCancelled ?? false,
+            includePast ?? false);
+
+        var result = await sender.Send(query, cancellationToken);
+
+        return result.IsFailure
+            ? result.Error.ToErrorResult()
+            : Results.Ok(result.Value);
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Owners/QuickPauseOutlet.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Owners/QuickPauseOutlet.cs
@@ -1,0 +1,40 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Owners.Commands.QuickPauseOutlet;
+using System.Security.Claims;
+
+namespace RallyAPI.Users.Endpoints.Owners;
+
+public class QuickPauseOutlet : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/owners/me/outlets/{restaurantId:guid}/time-off/quick-pause", HandleAsync)
+            .WithName("QuickPauseOutlet")
+            .WithTags("Owners")
+            .WithSummary("Owner pauses an outlet for N minutes starting now (1–1440 min)")
+            .RequireAuthorization("Owner");
+    }
+
+    public record QuickPauseRequest(int DurationMinutes, string? Reason);
+
+    private static async Task<IResult> HandleAsync(
+        Guid restaurantId,
+        QuickPauseRequest request,
+        ClaimsPrincipal user,
+        ISender sender,
+        CancellationToken cancellationToken)
+    {
+        var ownerId = Guid.Parse(user.FindFirstValue("sub")!);
+
+        var command = new QuickPauseOutletCommand(ownerId, restaurantId, request.DurationMinutes, request.Reason);
+        var result = await sender.Send(command, cancellationToken);
+
+        return result.IsFailure
+            ? result.Error.ToErrorResult()
+            : Results.Created($"/api/owners/me/outlets/{restaurantId}/time-off/{result.Value.Id}", result.Value);
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Owners/ScheduleTimeOff.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Owners/ScheduleTimeOff.cs
@@ -1,0 +1,46 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Owners.Commands.ScheduleTimeOff;
+using System.Security.Claims;
+
+namespace RallyAPI.Users.Endpoints.Owners;
+
+public class ScheduleTimeOff : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/owners/me/outlets/{restaurantId:guid}/time-off", HandleAsync)
+            .WithName("ScheduleOutletTimeOff")
+            .WithTags("Owners")
+            .WithSummary("Owner schedules a closure window for an outlet (e.g. Diwali, training)")
+            .RequireAuthorization("Owner");
+    }
+
+    public record ScheduleTimeOffRequest(DateTime StartsAtUtc, DateTime EndsAtUtc, string? Reason);
+
+    private static async Task<IResult> HandleAsync(
+        Guid restaurantId,
+        ScheduleTimeOffRequest request,
+        ClaimsPrincipal user,
+        ISender sender,
+        CancellationToken cancellationToken)
+    {
+        var ownerId = Guid.Parse(user.FindFirstValue("sub")!);
+
+        var command = new ScheduleTimeOffCommand(
+            ownerId,
+            restaurantId,
+            request.StartsAtUtc,
+            request.EndsAtUtc,
+            request.Reason);
+
+        var result = await sender.Send(command, cancellationToken);
+
+        return result.IsFailure
+            ? result.Error.ToErrorResult()
+            : Results.Created($"/api/owners/me/outlets/{restaurantId}/time-off/{result.Value.Id}", result.Value);
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/DependencyInjection.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/DependencyInjection.cs
@@ -70,7 +70,10 @@ public static class DependencyInjection
         services.AddScoped<IRestaurantCodeGenerator, RestaurantCodeGenerator>();
         services.AddScoped<IRiderPayoutLedgerRepository, RiderPayoutLedgerRepository>();
         services.AddScoped<IRiderPayoutQueryService, RiderPayoutQueryService>();
+        services.AddScoped<IRestaurantTimeOffRepository, RestaurantTimeOffRepository>();
 
+        // Cross-module availability probe — consumed by Orders.PlaceOrder
+        services.AddScoped<IRestaurantAvailabilityChecker, RestaurantAvailabilityChecker>();
 
         // Rider services for cross-module communication
         services.AddScoped<IRiderQueryService, RiderQueryService>();

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Configurations/RestaurantTimeOffConfiguration.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Configurations/RestaurantTimeOffConfiguration.cs
@@ -1,0 +1,74 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using RallyAPI.Users.Domain.Entities;
+
+namespace RallyAPI.Users.Infrastructure.Persistence.Configurations;
+
+public sealed class RestaurantTimeOffConfiguration : IEntityTypeConfiguration<RestaurantTimeOff>
+{
+    public void Configure(EntityTypeBuilder<RestaurantTimeOff> builder)
+    {
+        builder.ToTable("restaurant_time_offs");
+
+        builder.HasKey(t => t.Id);
+
+        builder.Property(t => t.Id)
+            .HasColumnName("id")
+            .ValueGeneratedNever();
+
+        builder.Property(t => t.RestaurantId)
+            .HasColumnName("restaurant_id")
+            .IsRequired();
+
+        builder.Property(t => t.StartsAt)
+            .HasColumnName("starts_at")
+            .IsRequired();
+
+        builder.Property(t => t.EndsAt)
+            .HasColumnName("ends_at")
+            .IsRequired();
+
+        builder.Property(t => t.Reason)
+            .HasColumnName("reason")
+            .HasMaxLength(200)
+            .IsRequired(false);
+
+        builder.Property(t => t.CreatedByOwnerId)
+            .HasColumnName("created_by_owner_id")
+            .IsRequired();
+
+        builder.Property(t => t.CancelledAt)
+            .HasColumnName("cancelled_at")
+            .IsRequired(false);
+
+        builder.Property(t => t.CreatedAt)
+            .HasColumnName("created_at")
+            .IsRequired();
+
+        builder.Property(t => t.UpdatedAt)
+            .HasColumnName("updated_at")
+            .IsRequired();
+
+        builder.Property(t => t.DeletedAt)
+            .HasColumnName("deleted_at")
+            .IsRequired(false);
+
+        // FK to restaurants
+        builder.HasOne<Restaurant>()
+            .WithMany()
+            .HasForeignKey(t => t.RestaurantId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Hot path: "is this outlet currently closed?" — restaurant_id + ends_at filtered by cancelled
+        builder.HasIndex(t => new { t.RestaurantId, t.EndsAt })
+            .HasDatabaseName("ix_restaurant_time_offs_restaurant_ends_at");
+
+        // For owner listing — restaurant_id + starts_at
+        builder.HasIndex(t => new { t.RestaurantId, t.StartsAt })
+            .HasDatabaseName("ix_restaurant_time_offs_restaurant_starts_at");
+
+        builder.HasQueryFilter(t => t.DeletedAt == null);
+
+        builder.Ignore(t => t.DomainEvents);
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Migrations/20260515085403_AddRestaurantTimeOff.Designer.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Migrations/20260515085403_AddRestaurantTimeOff.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RallyAPI.Users.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using RallyAPI.Users.Infrastructure.Persistence;
 namespace RallyAPI.Users.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(UsersDbContext))]
-    partial class UsersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260515085403_AddRestaurantTimeOff")]
+    partial class AddRestaurantTimeOff
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Migrations/20260515085403_AddRestaurantTimeOff.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Migrations/20260515085403_AddRestaurantTimeOff.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RallyAPI.Users.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRestaurantTimeOff : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "restaurant_time_offs",
+                schema: "users",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    restaurant_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    starts_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ends_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    reason = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    created_by_owner_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    cancelled_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    deleted_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_restaurant_time_offs", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_restaurant_time_offs_restaurants_restaurant_id",
+                        column: x => x.restaurant_id,
+                        principalSchema: "users",
+                        principalTable: "restaurants",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_restaurant_time_offs_restaurant_ends_at",
+                schema: "users",
+                table: "restaurant_time_offs",
+                columns: new[] { "restaurant_id", "ends_at" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_restaurant_time_offs_restaurant_starts_at",
+                schema: "users",
+                table: "restaurant_time_offs",
+                columns: new[] { "restaurant_id", "starts_at" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "restaurant_time_offs",
+                schema: "users");
+        }
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Repositories/RestaurantTimeOffRepository.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Repositories/RestaurantTimeOffRepository.cs
@@ -1,0 +1,78 @@
+using Microsoft.EntityFrameworkCore;
+using RallyAPI.Users.Application.Abstractions;
+using RallyAPI.Users.Domain.Entities;
+
+namespace RallyAPI.Users.Infrastructure.Persistence.Repositories;
+
+public sealed class RestaurantTimeOffRepository : IRestaurantTimeOffRepository
+{
+    private readonly UsersDbContext _context;
+
+    public RestaurantTimeOffRepository(UsersDbContext context)
+    {
+        _context = context;
+    }
+
+    public Task<RestaurantTimeOff?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+        => _context.RestaurantTimeOffs.FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+
+    public async Task<IReadOnlyList<RestaurantTimeOff>> GetForRestaurantAsync(
+        Guid restaurantId,
+        bool includeCancelled,
+        bool includePast,
+        DateTime nowUtc,
+        CancellationToken cancellationToken = default)
+    {
+        var query = _context.RestaurantTimeOffs
+            .AsNoTracking()
+            .Where(t => t.RestaurantId == restaurantId);
+
+        if (!includeCancelled)
+            query = query.Where(t => t.CancelledAt == null);
+
+        if (!includePast)
+            query = query.Where(t => t.EndsAt > nowUtc);
+
+        return await query
+            .OrderBy(t => t.StartsAt)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<bool> HasOverlapAsync(
+        Guid restaurantId,
+        DateTime startsAtUtc,
+        DateTime endsAtUtc,
+        Guid? excludeId,
+        CancellationToken cancellationToken = default)
+    {
+        var query = _context.RestaurantTimeOffs
+            .AsNoTracking()
+            .Where(t => t.RestaurantId == restaurantId
+                        && t.CancelledAt == null
+                        && t.StartsAt < endsAtUtc
+                        && t.EndsAt > startsAtUtc);
+
+        if (excludeId.HasValue)
+            query = query.Where(t => t.Id != excludeId.Value);
+
+        return await query.AnyAsync(cancellationToken);
+    }
+
+    public Task<bool> IsClosedAtAsync(
+        Guid restaurantId,
+        DateTime momentUtc,
+        CancellationToken cancellationToken = default)
+        => _context.RestaurantTimeOffs
+            .AsNoTracking()
+            .AnyAsync(t => t.RestaurantId == restaurantId
+                           && t.CancelledAt == null
+                           && t.StartsAt <= momentUtc
+                           && t.EndsAt > momentUtc,
+                cancellationToken);
+
+    public async Task AddAsync(RestaurantTimeOff entity, CancellationToken cancellationToken = default)
+        => await _context.RestaurantTimeOffs.AddAsync(entity, cancellationToken);
+
+    public void Update(RestaurantTimeOff entity)
+        => _context.RestaurantTimeOffs.Update(entity);
+}

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/UsersDbContext.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/UsersDbContext.cs
@@ -26,6 +26,7 @@ namespace RallyAPI.Users.Infrastructure.Persistence
         public DbSet<RiderPayoutLedger> RiderPayoutLedger => Set<RiderPayoutLedger>();
 
         public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
+        public DbSet<RestaurantTimeOff> RestaurantTimeOffs => Set<RestaurantTimeOff>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Services/RestaurantAvailabilityChecker.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Services/RestaurantAvailabilityChecker.cs
@@ -1,0 +1,23 @@
+using RallyAPI.SharedKernel.Abstractions.Restaurants;
+using RallyAPI.Users.Application.Abstractions;
+
+namespace RallyAPI.Users.Infrastructure.Services;
+
+internal sealed class RestaurantAvailabilityChecker : IRestaurantAvailabilityChecker
+{
+    private readonly IRestaurantTimeOffRepository _timeOffRepository;
+
+    public RestaurantAvailabilityChecker(IRestaurantTimeOffRepository timeOffRepository)
+    {
+        _timeOffRepository = timeOffRepository;
+    }
+
+    public Task<bool> IsClosedForScheduledTimeOffAsync(
+        Guid restaurantId,
+        DateTime? momentUtc = null,
+        CancellationToken cancellationToken = default)
+        => _timeOffRepository.IsClosedAtAsync(
+            restaurantId,
+            momentUtc ?? DateTime.UtcNow,
+            cancellationToken);
+}

--- a/src/RallyAPI.SharedKernel/Abstractions/Restaurants/IRestaurantAvailabilityChecker.cs
+++ b/src/RallyAPI.SharedKernel/Abstractions/Restaurants/IRestaurantAvailabilityChecker.cs
@@ -1,0 +1,19 @@
+namespace RallyAPI.SharedKernel.Abstractions.Restaurants;
+
+/// <summary>
+/// Cross-module probe for whether a restaurant is currently available to take orders.
+/// Implemented in Users.Infrastructure; consumed by Orders.Application (PlaceOrder) and
+/// anywhere else that needs an authoritative "is this outlet open right now" answer that
+/// takes scheduled time off into account.
+/// </summary>
+public interface IRestaurantAvailabilityChecker
+{
+    /// <summary>
+    /// Returns true if the restaurant has an active (non-cancelled) scheduled time off
+    /// covering <paramref name="momentUtc"/> (defaults to <c>DateTime.UtcNow</c>).
+    /// </summary>
+    Task<bool> IsClosedForScheduledTimeOffAsync(
+        Guid restaurantId,
+        DateTime? momentUtc = null,
+        CancellationToken cancellationToken = default);
+}


### PR DESCRIPTION
Adds a one-off closure mechanism for restaurants. Owner schedules a window (StartsAt → EndsAt) and during that window the outlet is treated as closed:
- Customers cannot place orders (PlaceOrder rejects with Order.RestaurantClosed)
- After EndsAt the outlet auto-reopens (no manual toggle needed)
- Closure overrides IsAcceptingOrders — explicit schedule wins over the flag

New Owner endpoints (all scoped to owned outlets, ownership enforced by matching Restaurant.OwnerId against the JWT sub):

  POST   /api/owners/me/outlets/{id}/time-off
  POST   /api/owners/me/outlets/{id}/time-off/quick-pause
  GET    /api/owners/me/outlets/{id}/time-off?includeCancelled&includePast
  DELETE /api/owners/me/outlets/{id}/time-off/{timeOffId}

Cross-module enforcement via new SharedKernel.IRestaurantAvailabilityChecker, implemented in Users.Infrastructure and consumed by Orders.PlaceOrder.

Domain rules: max duration 90 days, reason ≤ 200 chars, no overlap with another non-cancelled time off on the same outlet, cancel is soft (CancelledAt) to preserve audit history.

New table: users.restaurant_time_offs (auto-generated migration, schema- qualified, two indexes for hot-path "is currently closed" lookups).