### PR TITLE
fix(images): commit DB changes in restaurant logo and menu item image…

### DIFF
--- a/src/Modules/Catalog/RallyAPI.Catalog.Application/MenuItems/Commands/ConfirmMenuItemImageCommand.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Application/MenuItems/Commands/ConfirmMenuItemImageCommand.cs
@@ -37,13 +37,16 @@ public sealed class ConfirmMenuItemImageCommandHandler
 {
     private readonly IMenuItemRepository _menuItemRepository;
     private readonly IStorageService _storage;
+    private readonly IUnitOfWork _unitOfWork;
 
     public ConfirmMenuItemImageCommandHandler(
         IMenuItemRepository menuItemRepository,
-        IStorageService storage)
+        IStorageService storage,
+        IUnitOfWork unitOfWork)
     {
         _menuItemRepository = menuItemRepository;
         _storage = storage;
+        _unitOfWork = unitOfWork;
     }
 
     public async Task<Result<ConfirmMenuItemImageResponse>> Handle(
@@ -84,6 +87,7 @@ public sealed class ConfirmMenuItemImageCommandHandler
 
         // 6. Persist
         _menuItemRepository.Update(menuItem, ct);
+        await _unitOfWork.SaveChangesAsync(ct);
 
         return Result.Success(new ConfirmMenuItemImageResponse(
             menuItem.Id,

--- a/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UploadLogo/ConfirmRestaurantLogoCommand.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Restaurants/Commands/UploadLogo/ConfirmRestaurantLogoCommand.cs
@@ -31,13 +31,16 @@ public sealed class ConfirmRestaurantLogoCommandHandler
 {
     private readonly IRestaurantRepository _restaurantRepository;
     private readonly IStorageService _storage;
+    private readonly IUnitOfWork _unitOfWork;
 
     public ConfirmRestaurantLogoCommandHandler(
         IRestaurantRepository restaurantRepository,
-        IStorageService storage)
+        IStorageService storage,
+        IUnitOfWork unitOfWork)
     {
         _restaurantRepository = restaurantRepository;
         _storage = storage;
+        _unitOfWork = unitOfWork;
     }
 
     public async Task<Result<ConfirmRestaurantLogoResponse>> Handle(
@@ -71,6 +74,7 @@ public sealed class ConfirmRestaurantLogoCommandHandler
 
         // 6. Persist
         _restaurantRepository.Update(restaurant, ct);
+        await _unitOfWork.SaveChangesAsync(ct);
 
         return Result.Success(new ConfirmRestaurantLogoResponse(
             restaurant.Id,


### PR DESCRIPTION
… confirm handlers

Both ConfirmRestaurantLogoCommandHandler and ConfirmMenuItemImageCommandHandler called repository.Update() but never IUnitOfWork.SaveChangesAsync(). EF only flipped the change-tracker state to Modified, so the new LogoUrl / ImageUrl was returned to the client but never persisted. Next GET /api/restaurants/me/details or menu read returned the stale (empty) URL.

Inject IUnitOfWork and await SaveChangesAsync after Update, matching the existing pattern in ConfirmRiderKycDocumentCommandHandler.