### PR TITLE
fix(orders): populate RestaurantPhone server-side and backfill on adm…

### DIFF
--- a/src/Modules/Orders/RallyAPI.Orders.Application/Commands/PlaceOrder/PlaceOrderCommandHandler.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/Commands/PlaceOrder/PlaceOrderCommandHandler.cs
@@ -97,13 +97,17 @@ public sealed class PlaceOrderCommandHandler : IRequestHandler<PlaceOrderCommand
                 return Result.Failure<OrderDto>(OrderErrors.RestaurantClosed);
             }
 
+            // Look up authoritative restaurant data once — used for pickup-acceptance check
+            // and to populate Order.RestaurantPhone server-side. The customer request body
+            // cannot be trusted to carry the restaurant's phone; admin/delivery downstream
+            // consumers need it set correctly here.
+            var restaurantDetails = await _restaurantQueryService.GetByIdAsync(
+                command.Request.RestaurantId, cancellationToken);
+
             // Step 3a: Block pickup orders against restaurants that don't accept pickup.
             // Authoritative server-side check — UI hint alone is not enough.
             if (command.Request.FulfillmentType == Domain.Enums.FulfillmentType.Pickup)
             {
-                var restaurantDetails = await _restaurantQueryService.GetByIdAsync(
-                    command.Request.RestaurantId, cancellationToken);
-
                 if (restaurantDetails is null || !restaurantDetails.AcceptsPickup)
                 {
                     _logger.LogWarning(
@@ -240,7 +244,7 @@ public sealed class PlaceOrderCommandHandler : IRequestHandler<PlaceOrderCommand
                 deliveryQuoteId: command.DeliveryQuoteId,
                 customerPhone: command.CustomerPhone,
                 customerEmail: command.CustomerEmail,
-                restaurantPhone: command.Request.RestaurantPhone,
+                restaurantPhone: restaurantDetails?.Phone ?? command.Request.RestaurantPhone,
                 specialInstructions: command.Request.SpecialInstructions);
 
             // Step 10: Add items

--- a/src/Modules/Orders/RallyAPI.Orders.Infrastructure/Services/AdminOrderQueryService.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Infrastructure/Services/AdminOrderQueryService.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore;
 using RallyAPI.Orders.Domain.Enums;
 using RallyAPI.SharedKernel.Abstractions.Orders;
+using RallyAPI.SharedKernel.Abstractions.Restaurants;
 
 namespace RallyAPI.Orders.Infrastructure.Services;
 
@@ -26,10 +27,14 @@ public sealed class AdminOrderQueryService : IAdminOrderQueryService
     ];
 
     private readonly OrdersDbContext _context;
+    private readonly IRestaurantQueryService _restaurantQueryService;
 
-    public AdminOrderQueryService(OrdersDbContext context)
+    public AdminOrderQueryService(
+        OrdersDbContext context,
+        IRestaurantQueryService restaurantQueryService)
     {
         _context = context;
+        _restaurantQueryService = restaurantQueryService;
     }
 
     public async Task<AdminOrdersPagedResult> SearchAsync(
@@ -83,6 +88,16 @@ public sealed class AdminOrderQueryService : IAdminOrderQueryService
         if (order is null)
             return null;
 
+        // Backfill the restaurant phone from the Users module if the order row is missing it.
+        // Legacy orders were created without server-side phone population, so this read-time
+        // lookup keeps the admin detail accurate without requiring a data migration.
+        var restaurantPhone = order.RestaurantPhone;
+        if (string.IsNullOrWhiteSpace(restaurantPhone))
+        {
+            var restaurant = await _restaurantQueryService.GetByIdAsync(order.RestaurantId, cancellationToken);
+            restaurantPhone = restaurant?.Phone;
+        }
+
         // Delay = how long the order has been in its current non-terminal state.
         // For the escalation modal, the most useful "delay" is age since payment for orders
         // still awaiting restaurant action.
@@ -112,7 +127,7 @@ public sealed class AdminOrderQueryService : IAdminOrderQueryService
             order.CustomerEmail,
             order.RestaurantId,
             order.RestaurantName,
-            order.RestaurantPhone,
+            restaurantPhone,
             order.DeliveryInfo?.RiderId,
             order.DeliveryInfo?.RiderName,
             order.DeliveryInfo?.RiderPhone,


### PR DESCRIPTION
…in detail

GET /api/admin/orders/{orderId} was returning a null restaurantPhone because Order.RestaurantPhone was being copied from the customer request body. The customer app has no need to carry the restaurant's phone, so the column was saved null and the admin detail surfaced the same.

PlaceOrderCommandHandler now resolves the restaurant via IRestaurantQueryService once (reusing the existing lookup that was scoped to pickup orders) and uses the restaurant's own phone as the source of truth, falling back to the request value only if the lookup misses.

AdminOrderQueryService.GetDetailAsync also performs a read-time lookup when order.RestaurantPhone is null so the admin view stays accurate for orders that were created before this fix without needing a data migration.