### PR TITLE
feat(menu): add DELETE /api/restaurant/items/{itemId} endpoint

### DIFF
--- a/src/Modules/Catalog/RallyAPI.Catalog.Application/MenuItems/Commands/DeleteMenuItem/DeleteMenuItemCommand.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Application/MenuItems/Commands/DeleteMenuItem/DeleteMenuItemCommand.cs
@@ -1,0 +1,8 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Catalog.Application.MenuItems.Commands.DeleteMenuItem;
+
+public sealed record DeleteMenuItemCommand(
+    Guid MenuItemId,
+    Guid RestaurantId) : IRequest<Result>;

--- a/src/Modules/Catalog/RallyAPI.Catalog.Application/MenuItems/Commands/DeleteMenuItem/DeleteMenuItemCommandHandler.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Application/MenuItems/Commands/DeleteMenuItem/DeleteMenuItemCommandHandler.cs
@@ -1,0 +1,39 @@
+using MediatR;
+using RallyAPI.Catalog.Application.Abstractions;
+using RallyAPI.Catalog.Domain.MenuItems;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Catalog.Application.MenuItems.Commands.DeleteMenuItem;
+
+internal sealed class DeleteMenuItemCommandHandler
+    : IRequestHandler<DeleteMenuItemCommand, Result>
+{
+    private readonly IMenuItemRepository _menuItemRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public DeleteMenuItemCommandHandler(
+        IMenuItemRepository menuItemRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _menuItemRepository = menuItemRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result> Handle(
+        DeleteMenuItemCommand request,
+        CancellationToken cancellationToken)
+    {
+        var menuItem = await _menuItemRepository.GetByIdAsync(request.MenuItemId, cancellationToken);
+
+        if (menuItem is null)
+            return Result.Failure(MenuItemErrors.NotFound);
+
+        if (menuItem.RestaurantId != request.RestaurantId)
+            return Result.Failure(MenuItemErrors.Unauthorized);
+
+        _menuItemRepository.Delete(menuItem);
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/src/Modules/Catalog/RallyAPI.Catalog.Endpoints/MenuItems/DeleteMenuItem.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Endpoints/MenuItems/DeleteMenuItem.cs
@@ -1,0 +1,36 @@
+using System.Security.Claims;
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.Catalog.Application.MenuItems.Commands.DeleteMenuItem;
+using RallyAPI.SharedKernel.Extensions;
+
+namespace RallyAPI.Catalog.Endpoints.MenuItems;
+
+public class DeleteMenuItem : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapDelete("/api/restaurant/items/{itemId:guid}", HandleAsync)
+            .WithTags("Restaurant Menu Items")
+            .WithSummary("Delete a menu item")
+            .RequireAuthorization("Restaurant");
+    }
+
+    private static async Task<IResult> HandleAsync(
+        Guid itemId,
+        ClaimsPrincipal user,
+        ISender sender,
+        CancellationToken ct)
+    {
+        var restaurantId = Guid.Parse(user.FindFirstValue("sub")!);
+
+        var command = new DeleteMenuItemCommand(itemId, restaurantId);
+        var result = await sender.Send(command, ct);
+
+        return result.IsSuccess
+            ? Results.NoContent()
+            : result.Error.ToErrorResult();
+    }
+}


### PR DESCRIPTION
Adds a new endpoint allowing restaurant owners to delete their own menu items. Command handler verifies RestaurantId ownership before deletion. Follows the existing DeleteOption / DeleteMenu CQRS pattern.