### PR TITLE
fix(admins): wire latitude/longitude through admin edit restaurant en…

### DIFF
--- a/src/Modules/Users/RallyAPI.Users.Application/Admins/Commands/EditRestaurant/EditRestaurantCommand.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Admins/Commands/EditRestaurant/EditRestaurantCommand.cs
@@ -17,4 +17,6 @@ public sealed record EditRestaurantCommand(
     bool? HasJainOptions,
     decimal? MinOrderAmount,
     string? FssaiNumber,
-    bool? AcceptsPickup) : IRequest<Result>;
+    bool? AcceptsPickup,
+    decimal? Latitude,
+    decimal? Longitude) : IRequest<Result>;

--- a/src/Modules/Users/RallyAPI.Users.Application/Admins/Commands/EditRestaurant/EditRestaurantCommandHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Admins/Commands/EditRestaurant/EditRestaurantCommandHandler.cs
@@ -83,6 +83,15 @@ internal sealed class EditRestaurantCommandHandler
         if (request.AcceptsPickup.HasValue)
             restaurant.SetAcceptsPickup(request.AcceptsPickup.Value);
 
+        if (request.Latitude.HasValue && request.Longitude.HasValue)
+        {
+            var locationResult = restaurant.UpdateLocation(
+                request.Latitude.Value,
+                request.Longitude.Value);
+            if (locationResult.IsFailure)
+                return locationResult;
+        }
+
         _restaurantRepository.Update(restaurant, cancellationToken);
         await _unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/src/Modules/Users/RallyAPI.Users.Application/Admins/Commands/EditRestaurant/EditRestaurantCommandValidator.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Admins/Commands/EditRestaurant/EditRestaurantCommandValidator.cs
@@ -37,5 +37,13 @@ public sealed class EditRestaurantCommandValidator : AbstractValidator<EditResta
         RuleFor(x => x.FssaiNumber)
             .MaximumLength(50).WithMessage("FSSAI number must not exceed 50 characters.")
             .When(x => x.FssaiNumber is not null);
+
+        RuleFor(x => x.Longitude)
+            .NotNull().WithMessage("Longitude is required when Latitude is provided.")
+            .When(x => x.Latitude.HasValue);
+
+        RuleFor(x => x.Latitude)
+            .NotNull().WithMessage("Latitude is required when Longitude is provided.")
+            .When(x => x.Longitude.HasValue);
     }
 }

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Admins/EditRestaurant.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Admins/EditRestaurant.cs
@@ -38,7 +38,9 @@ public class EditRestaurant : IEndpoint
             request.HasJainOptions,
             request.MinOrderAmount,
             request.FssaiNumber,
-            request.AcceptsPickup);
+            request.AcceptsPickup,
+            request.Latitude,
+            request.Longitude);
 
         var result = await sender.Send(command, cancellationToken);
 
@@ -61,4 +63,6 @@ public record EditRestaurantRequest(
     bool? HasJainOptions,
     decimal? MinOrderAmount,
     string? FssaiNumber,
-    bool? AcceptsPickup);
+    bool? AcceptsPickup,
+    decimal? Latitude,
+    decimal? Longitude);


### PR DESCRIPTION
…dpoint

PUT /api/admins/restaurants/{restaurantId} was silently dropping lat/long sent by the admin panel — the request DTO, command, and handler never referenced the fields, so System.Text.Json discarded them during binding and the endpoint returned 204 without updating coordinates. Plumbs both fields through all three layers and calls Restaurant.UpdateLocation (which already validates India bounds). Validator now rejects partial updates where only one of lat/long is provided.