### PR TITLE
fix(delivery): bridge delivery domain events to cross-module integrat…

### DIFF
--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/EventHandlers/DeliveryCompletedEventBridge.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/EventHandlers/DeliveryCompletedEventBridge.cs
@@ -1,0 +1,38 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using RallyAPI.Delivery.Domain.Events;
+using RallyAPI.SharedKernel.IntegrationEvents.Delivery;
+
+namespace RallyAPI.Delivery.Application.EventHandlers;
+
+/// <summary>
+/// Bridge: DeliveryCompletedEvent (domain) -> DeliveryCompletedIntegrationEvent (cross-module).
+/// Lets the Orders module mark the order as Delivered.
+/// </summary>
+public sealed class DeliveryCompletedEventBridge : INotificationHandler<DeliveryCompletedEvent>
+{
+    private readonly IPublisher _publisher;
+    private readonly ILogger<DeliveryCompletedEventBridge> _logger;
+
+    public DeliveryCompletedEventBridge(
+        IPublisher publisher,
+        ILogger<DeliveryCompletedEventBridge> logger)
+    {
+        _publisher = publisher;
+        _logger = logger;
+    }
+
+    public async Task Handle(DeliveryCompletedEvent notification, CancellationToken cancellationToken)
+    {
+        var integrationEvent = new DeliveryCompletedIntegrationEvent(
+            notification.DeliveryRequestId,
+            notification.OrderId,
+            notification.DeliveredAt);
+
+        await _publisher.Publish(integrationEvent, cancellationToken);
+
+        _logger.LogInformation(
+            "Published DeliveryCompletedIntegrationEvent for Order {OrderId}",
+            notification.OrderId);
+    }
+}

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/EventHandlers/DeliveryFailedEventBridge.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/EventHandlers/DeliveryFailedEventBridge.cs
@@ -1,0 +1,40 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using RallyAPI.Delivery.Domain.Events;
+using RallyAPI.SharedKernel.IntegrationEvents.Delivery;
+
+namespace RallyAPI.Delivery.Application.EventHandlers;
+
+/// <summary>
+/// Bridge: DeliveryFailedEvent (domain) -> DeliveryFailedIntegrationEvent (cross-module).
+/// Lets the Orders module react to delivery failure (refund flow, customer notification, etc.).
+/// </summary>
+public sealed class DeliveryFailedEventBridge : INotificationHandler<DeliveryFailedEvent>
+{
+    private readonly IPublisher _publisher;
+    private readonly ILogger<DeliveryFailedEventBridge> _logger;
+
+    public DeliveryFailedEventBridge(
+        IPublisher publisher,
+        ILogger<DeliveryFailedEventBridge> logger)
+    {
+        _publisher = publisher;
+        _logger = logger;
+    }
+
+    public async Task Handle(DeliveryFailedEvent notification, CancellationToken cancellationToken)
+    {
+        var integrationEvent = new DeliveryFailedIntegrationEvent(
+            notification.DeliveryRequestId,
+            notification.OrderId,
+            notification.Reason.ToString(),
+            notification.Notes,
+            notification.FailedAt);
+
+        await _publisher.Publish(integrationEvent, cancellationToken);
+
+        _logger.LogInformation(
+            "Published DeliveryFailedIntegrationEvent for Order {OrderId} (reason: {Reason})",
+            notification.OrderId, notification.Reason);
+    }
+}

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/EventHandlers/DeliveryPickedUpEventBridge.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/EventHandlers/DeliveryPickedUpEventBridge.cs
@@ -1,0 +1,38 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using RallyAPI.Delivery.Domain.Events;
+using RallyAPI.SharedKernel.IntegrationEvents.Delivery;
+
+namespace RallyAPI.Delivery.Application.EventHandlers;
+
+/// <summary>
+/// Bridge: DeliveryPickedUpEvent (domain) -> DeliveryPickedUpIntegrationEvent (cross-module).
+/// Lets the Orders module advance status to PickedUp.
+/// </summary>
+public sealed class DeliveryPickedUpEventBridge : INotificationHandler<DeliveryPickedUpEvent>
+{
+    private readonly IPublisher _publisher;
+    private readonly ILogger<DeliveryPickedUpEventBridge> _logger;
+
+    public DeliveryPickedUpEventBridge(
+        IPublisher publisher,
+        ILogger<DeliveryPickedUpEventBridge> logger)
+    {
+        _publisher = publisher;
+        _logger = logger;
+    }
+
+    public async Task Handle(DeliveryPickedUpEvent notification, CancellationToken cancellationToken)
+    {
+        var integrationEvent = new DeliveryPickedUpIntegrationEvent(
+            notification.DeliveryRequestId,
+            notification.OrderId,
+            notification.PickedUpAt);
+
+        await _publisher.Publish(integrationEvent, cancellationToken);
+
+        _logger.LogInformation(
+            "Published DeliveryPickedUpIntegrationEvent for Order {OrderId}",
+            notification.OrderId);
+    }
+}

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/EventHandlers/DeliveryRiderAssignedEventBridge.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/EventHandlers/DeliveryRiderAssignedEventBridge.cs
@@ -1,0 +1,44 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using RallyAPI.Delivery.Domain.Enums;
+using RallyAPI.Delivery.Domain.Events;
+using RallyAPI.SharedKernel.IntegrationEvents.Delivery;
+
+namespace RallyAPI.Delivery.Application.EventHandlers;
+
+/// <summary>
+/// Bridge: DeliveryRiderAssignedEvent (domain) -> DeliveryRiderAssignedIntegrationEvent (cross-module).
+/// Lets the Orders module attach rider info to the order.
+/// </summary>
+public sealed class DeliveryRiderAssignedEventBridge : INotificationHandler<DeliveryRiderAssignedEvent>
+{
+    private readonly IPublisher _publisher;
+    private readonly ILogger<DeliveryRiderAssignedEventBridge> _logger;
+
+    public DeliveryRiderAssignedEventBridge(
+        IPublisher publisher,
+        ILogger<DeliveryRiderAssignedEventBridge> logger)
+    {
+        _publisher = publisher;
+        _logger = logger;
+    }
+
+    public async Task Handle(DeliveryRiderAssignedEvent notification, CancellationToken cancellationToken)
+    {
+        var integrationEvent = new DeliveryRiderAssignedIntegrationEvent(
+            notification.DeliveryRequestId,
+            notification.OrderId,
+            notification.OrderNumber,
+            notification.FleetType == FleetType.OwnFleet,
+            notification.RiderId,
+            notification.RiderName,
+            notification.RiderPhone,
+            notification.TrackingUrl);
+
+        await _publisher.Publish(integrationEvent, cancellationToken);
+
+        _logger.LogInformation(
+            "Published DeliveryRiderAssignedIntegrationEvent for Order {OrderId}",
+            notification.OrderId);
+    }
+}


### PR DESCRIPTION
…ion events

Order status never advanced when ProRouting (or an own-fleet rider) reported picked-up/delivered/failed/rider-assigned. The Delivery module correctly dispatched its domain events via DomainEventInterceptor but had no INotificationHandler bridges to publish the matching DeliveryXxxIntegrationEvent in SharedKernel — so the Orders module's DeliveryXxxEventHandler instances were dormant. Adds the four missing bridge handlers (Completed, PickedUp, Failed, RiderAssigned) following the same pattern Orders uses for OrderConfirmedEvent. No infra changes; handlers auto-register via the existing MediatR assembly scan.