### PR TITLE
feat(delivery): add manual refresh endpoint to pull state from ProRou…

### DIFF
--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/RefreshDeliveryStatus/RefreshDeliveryStatusCommand.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/RefreshDeliveryStatus/RefreshDeliveryStatusCommand.cs
@@ -1,0 +1,27 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Delivery.Application.Commands.RefreshDeliveryStatus;
+
+/// <summary>
+/// Manually pulls current state from the 3PL provider (ProRouting) and
+/// reconciles both the DeliveryRequest and the Order. Used to recover orders
+/// where a webhook was lost or where bridge handlers were missing when
+/// transitions occurred.
+/// </summary>
+public sealed record RefreshDeliveryStatusCommand(
+    Guid OrderId,
+    Guid CallerId,
+    bool IsAdmin) : IRequest<Result<RefreshDeliveryStatusResult>>;
+
+public sealed record RefreshDeliveryStatusResult(
+    Guid DeliveryRequestId,
+    string DeliveryStatusBefore,
+    string DeliveryStatusAfter,
+    string? ProRoutingState,
+    string? ProRoutingError,
+    string? ExternalTaskId,
+    string? RiderName,
+    string? RiderPhone,
+    string? TrackingUrl,
+    int IntegrationEventsRepublished);

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/RefreshDeliveryStatus/RefreshDeliveryStatusCommandHandler.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/RefreshDeliveryStatus/RefreshDeliveryStatusCommandHandler.cs
@@ -1,0 +1,243 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using RallyAPI.Delivery.Domain.Abstractions;
+using RallyAPI.Delivery.Domain.Entities;
+using RallyAPI.Delivery.Domain.Enums;
+using RallyAPI.SharedKernel.Abstractions.Delivery;
+using RallyAPI.SharedKernel.IntegrationEvents.Delivery;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Delivery.Application.Commands.RefreshDeliveryStatus;
+
+internal sealed class RefreshDeliveryStatusCommandHandler
+    : IRequestHandler<RefreshDeliveryStatusCommand, Result<RefreshDeliveryStatusResult>>
+{
+    private readonly IDeliveryRequestRepository _repository;
+    private readonly IThirdPartyDeliveryProvider _provider;
+    private readonly IPublisher _publisher;
+    private readonly ILogger<RefreshDeliveryStatusCommandHandler> _logger;
+
+    public RefreshDeliveryStatusCommandHandler(
+        IDeliveryRequestRepository repository,
+        IThirdPartyDeliveryProvider provider,
+        IPublisher publisher,
+        ILogger<RefreshDeliveryStatusCommandHandler> logger)
+    {
+        _repository = repository;
+        _provider = provider;
+        _publisher = publisher;
+        _logger = logger;
+    }
+
+    public async Task<Result<RefreshDeliveryStatusResult>> Handle(
+        RefreshDeliveryStatusCommand request,
+        CancellationToken cancellationToken)
+    {
+        var delivery = await _repository.GetByOrderIdAsync(request.OrderId, cancellationToken);
+        if (delivery is null)
+            return Result.Failure<RefreshDeliveryStatusResult>(
+                Error.NotFound("DeliveryRequest", request.OrderId));
+
+        if (!request.IsAdmin)
+        {
+            if (delivery.RestaurantId != request.CallerId)
+            {
+                _logger.LogWarning(
+                    "Restaurant {CallerId} attempted to refresh delivery for order {OrderId} owned by {OwnerId}",
+                    request.CallerId, request.OrderId, delivery.RestaurantId);
+                return Result.Failure<RefreshDeliveryStatusResult>(
+                    Error.Validation("You are not authorized to refresh this order."));
+            }
+        }
+
+        var statusBefore = delivery.Status;
+
+        string? proroutingState = null;
+        string? proroutingError = null;
+
+        if (!string.IsNullOrEmpty(delivery.ExternalTaskId))
+        {
+            var statusResult = await _provider.GetTaskStatusAsync(
+                delivery.ExternalTaskId,
+                cancellationToken);
+
+            if (statusResult.IsSuccess)
+            {
+                proroutingState = statusResult.State;
+                ApplyStateTransition(delivery, statusResult, _logger);
+
+                if (delivery.Status != statusBefore)
+                {
+                    await _repository.UpdateAsync(delivery, cancellationToken);
+                }
+            }
+            else
+            {
+                proroutingError = statusResult.ErrorMessage;
+                _logger.LogWarning(
+                    "ProRouting status fetch failed for task {TaskId}: {Error}",
+                    delivery.ExternalTaskId, statusResult.ErrorMessage);
+            }
+        }
+
+        var republished = await ReconcileOrderFromDeliveryAsync(delivery, cancellationToken);
+
+        _logger.LogInformation(
+            "Refreshed delivery {DeliveryId} for order {OrderId}: {Before} -> {After} (republished {N} events)",
+            delivery.Id, request.OrderId, statusBefore, delivery.Status, republished);
+
+        return Result.Success(new RefreshDeliveryStatusResult(
+            delivery.Id,
+            statusBefore.ToString(),
+            delivery.Status.ToString(),
+            proroutingState,
+            proroutingError,
+            delivery.ExternalTaskId,
+            delivery.RiderName ?? delivery.ExternalRiderName,
+            delivery.RiderPhone ?? delivery.ExternalRiderPhone,
+            delivery.ExternalTrackingUrl,
+            republished));
+    }
+
+    private static void ApplyStateTransition(
+        DeliveryRequest delivery,
+        TaskStatusResult status,
+        ILogger logger)
+    {
+        var stateNormalized = status.State?.Trim().ToLowerInvariant() ?? string.Empty;
+
+        try
+        {
+            switch (stateNormalized)
+            {
+                case "agent-assigned":
+                case "agent_assigned":
+                    if (delivery.Status == DeliveryRequestStatus.Searching3PL
+                        && !string.IsNullOrEmpty(delivery.ExternalTaskId))
+                    {
+                        delivery.Assign3PLRider(
+                            delivery.ExternalTaskId,
+                            delivery.ExternalLspName ?? "ProRouting",
+                            status.RiderName,
+                            status.RiderPhone,
+                            status.TrackingUrl,
+                            delivery.QuotedPrice);
+                    }
+                    else
+                    {
+                        delivery.Update3PLRiderInfo(status.RiderName, status.RiderPhone, status.TrackingUrl);
+                    }
+                    break;
+
+                case "at-pickup":
+                case "at_pickup":
+                    if (delivery.Status is DeliveryRequestStatus.RiderAssigned
+                        or DeliveryRequestStatus.Assigned3PL)
+                    {
+                        delivery.MarkRiderEnRoutePickup();
+                    }
+                    if (delivery.Status == DeliveryRequestStatus.RiderEnRoutePickup)
+                    {
+                        delivery.MarkRiderArrivedPickup();
+                    }
+                    break;
+
+                case "picked-up":
+                case "picked_up":
+                case "order-picked-up":
+                    delivery.MarkPickedUp();
+                    break;
+
+                case "at-delivery":
+                case "at_delivery":
+                    if (delivery.Status == DeliveryRequestStatus.PickedUp)
+                        delivery.MarkRiderEnRouteDrop();
+                    if (delivery.Status == DeliveryRequestStatus.RiderEnRouteDrop)
+                        delivery.MarkRiderArrivedDrop();
+                    break;
+
+                case "delivered":
+                case "order-delivered":
+                    delivery.MarkDelivered();
+                    break;
+
+                default:
+                    logger.LogDebug(
+                        "Refresh: unhandled or non-actionable ProRouting state {State} for delivery {DeliveryId}",
+                        status.State, delivery.Id);
+                    break;
+            }
+        }
+        catch (InvalidOperationException ex)
+        {
+            logger.LogInformation(
+                "Refresh: ProRouting state {State} not applicable to delivery {DeliveryId} in status {Status}: {Reason}",
+                status.State, delivery.Id, delivery.Status, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Republishes the integration events implied by the current DeliveryRequest state.
+    /// This catches Orders that fell behind because bridge handlers were missing when
+    /// the original domain events fired. Orders-side handlers are idempotent (they
+    /// catch InvalidOperationException on no-op transitions).
+    /// </summary>
+    private async Task<int> ReconcileOrderFromDeliveryAsync(
+        DeliveryRequest delivery,
+        CancellationToken cancellationToken)
+    {
+        var republished = 0;
+
+        var hasRider = delivery.RiderId.HasValue
+            || !string.IsNullOrEmpty(delivery.RiderName)
+            || !string.IsNullOrEmpty(delivery.ExternalRiderName);
+
+        if (hasRider)
+        {
+            var fleetType = delivery.FleetType ?? FleetType.ThirdParty;
+            await _publisher.Publish(new DeliveryRiderAssignedIntegrationEvent(
+                delivery.Id,
+                delivery.OrderId,
+                delivery.OrderNumber,
+                fleetType == FleetType.OwnFleet,
+                delivery.RiderId,
+                delivery.RiderName ?? delivery.ExternalRiderName,
+                delivery.RiderPhone ?? delivery.ExternalRiderPhone,
+                delivery.ExternalTrackingUrl), cancellationToken);
+            republished++;
+        }
+
+        if (delivery.Status >= DeliveryRequestStatus.PickedUp
+            && delivery.Status != DeliveryRequestStatus.Cancelled
+            && delivery.Status != DeliveryRequestStatus.Failed)
+        {
+            await _publisher.Publish(new DeliveryPickedUpIntegrationEvent(
+                delivery.Id,
+                delivery.OrderId,
+                delivery.PickedUpAt ?? DateTime.UtcNow), cancellationToken);
+            republished++;
+        }
+
+        if (delivery.Status == DeliveryRequestStatus.Delivered)
+        {
+            await _publisher.Publish(new DeliveryCompletedIntegrationEvent(
+                delivery.Id,
+                delivery.OrderId,
+                delivery.DeliveredAt ?? DateTime.UtcNow), cancellationToken);
+            republished++;
+        }
+
+        if (delivery.Status == DeliveryRequestStatus.Failed)
+        {
+            await _publisher.Publish(new DeliveryFailedIntegrationEvent(
+                delivery.Id,
+                delivery.OrderId,
+                delivery.FailureReason?.ToString() ?? "Unknown",
+                delivery.FailureNotes,
+                delivery.FailedAt ?? DateTime.UtcNow), cancellationToken);
+            republished++;
+        }
+
+        return republished;
+    }
+}

--- a/src/Modules/Delivery/RallyAPI.Delivery.Endpoints/AdminDeliveryEndpoints.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Endpoints/AdminDeliveryEndpoints.cs
@@ -1,0 +1,48 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.Delivery.Application.Commands.RefreshDeliveryStatus;
+using RallyAPI.SharedKernel.Extensions;
+
+namespace RallyAPI.Delivery.Endpoints;
+
+public static class AdminDeliveryEndpoints
+{
+    public static IEndpointRouteBuilder MapAdminDeliveryEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/deliveries")
+            .WithTags("Delivery - Admin");
+
+        group.MapPost("/orders/{orderId:guid}/refresh-status", RefreshStatus)
+            .WithName("RefreshDeliveryStatus")
+            .WithSummary("Pull current state from ProRouting and reconcile the Order")
+            .RequireAuthorization("RestaurantOrAdmin")
+            .Produces<RefreshDeliveryStatusResult>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound);
+
+        return app;
+    }
+
+    private static async Task<IResult> RefreshStatus(
+        Guid orderId,
+        ISender sender,
+        HttpContext httpContext,
+        CancellationToken ct)
+    {
+        var userType = httpContext.User.FindFirst("user_type")?.Value ?? string.Empty;
+        var isAdmin = userType.Equals("admin", StringComparison.OrdinalIgnoreCase);
+
+        var subClaim = httpContext.User.FindFirst("sub")?.Value ?? string.Empty;
+        if (!Guid.TryParse(subClaim, out var callerId))
+            return Results.Unauthorized();
+
+        var command = new RefreshDeliveryStatusCommand(orderId, callerId, isAdmin);
+        var result = await sender.Send(command, ct);
+
+        return result.IsSuccess
+            ? Results.Ok(result.Value)
+            : result.Error.ToErrorResult();
+    }
+}

--- a/src/Modules/Delivery/RallyAPI.Delivery.Endpoints/DependencyInjection.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Endpoints/DependencyInjection.cs
@@ -25,6 +25,7 @@ public static class DependencyInjection
         app.MapRiderDeliveryEndpoints();
         app.MapTrackingEndpoints();
         app.MapWebhookEndpoints();
+        app.MapAdminDeliveryEndpoints();
 
         return app;
     }


### PR DESCRIPTION
…ting and reconcile Order

POST /api/deliveries/orders/{orderId}/refresh-status — admin or restaurant auth. Pulls the current task state from ProRouting via partner/order/status, walks the DeliveryRequest forward through the missed transitions (using the same switch logic as the webhook), and force-republishes the integration events implied by the current delivery state. The Orders-side handlers are idempotent, so this also recovers Orders that fell behind because the domain-event bridge handlers were missing when the original webhooks fired (the pre-fix stuck-order case).

Restaurants can only refresh their own orders; admins can refresh any.