### PR TITLE
fix(delivery): call ProRouting partner/order/update to push OTPs and …

### DIFF
--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/DTOs/DeliveryCodesDto.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/DTOs/DeliveryCodesDto.cs
@@ -8,7 +8,7 @@ namespace RallyAPI.Delivery.Application.DTOs;
 public sealed record DeliveryCodesDto
 {
     /// <summary>
-    /// 6-digit code shown to the restaurant. Restaurant reads it out to the
+    /// 4-digit code shown to the restaurant. Restaurant reads it out to the
     /// rider at pickup; the rider enters it in ProRouting to prove identity.
     /// </summary>
     public string? PickupCode { get; init; }

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Services/RiderDispatchOrchestrator.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Services/RiderDispatchOrchestrator.cs
@@ -222,8 +222,39 @@ public sealed class RiderDispatchOrchestrator
         }
 
         _logger.LogInformation(
-            "3PL task created for delivery {DeliveryId}: {TaskId}. Waiting {Timeout}s for assignment.",
-            deliveryRequest.Id, createResult.TaskId, _options.AcceptanceTimeoutSeconds);
+            "3PL task created for delivery {DeliveryId}: {TaskId}. Pushing OTPs via update...",
+            deliveryRequest.Id, createResult.TaskId);
+
+        // ProRouting requires partner/order/update to push the OTPs AND transition the
+        // task from UnFulfilled -> Searching-for-Agent. Without this call the task stalls
+        // at UnFulfilled and the rider gets ProRouting's auto-generated OTPs instead of
+        // ours, causing a pickup-code mismatch at the restaurant.
+        var updateResult = await _thirdPartyProvider.UpdateOrderAsync(
+            new UpdateOrderRequest
+            {
+                ExternalTaskId = createResult.TaskId!,
+                PickupCode = deliveryRequest.PickupCode ?? string.Empty,
+                DropCode = deliveryRequest.DropCode,
+                OrderReady = true
+            }, ct);
+
+        if (!updateResult.IsSuccess)
+        {
+            _logger.LogError(
+                "ProRouting update (OTP push) failed for delivery {DeliveryId}, task {TaskId}: {Error}. Cancelling task.",
+                deliveryRequest.Id, createResult.TaskId, updateResult.ErrorMessage);
+
+            await _thirdPartyProvider.CancelTaskAsync(
+                createResult.TaskId!,
+                "Update/OTP push failed: " + updateResult.ErrorMessage,
+                ct);
+
+            return DispatchResult.Failed(updateResult.ErrorMessage ?? "3PL OTP update failed");
+        }
+
+        _logger.LogInformation(
+            "ProRouting task {TaskId} updated. Waiting {Timeout}s for agent assignment.",
+            createResult.TaskId, _options.AcceptanceTimeoutSeconds);
 
         // Wait for webhook assignment
         await Task.Delay(TimeSpan.FromSeconds(_options.AcceptanceTimeoutSeconds), ct);

--- a/src/Modules/Delivery/RallyAPI.Delivery.Domain/Entities/DeliveryRequest.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Domain/Entities/DeliveryRequest.cs
@@ -33,7 +33,7 @@ public sealed class DeliveryRequest : AggregateRoot
     public OrderCategory OrderCategory { get; private set; } = OrderCategory.FoodAndBeverage;
 
     // OTPs handed to ProRouting via /update — cleartext required by LSP.
-    // PickupCode = 6 digits shown to rider at restaurant.
+    // PickupCode = 4 digits shown to rider at restaurant.
     // DropCode   = 4 digits shared with customer for delivery confirmation.
     public string? PickupCode { get; private set; }
     public string? DropCode { get; private set; }
@@ -149,7 +149,7 @@ public sealed class DeliveryRequest : AggregateRoot
                 ? DeliveryRequestStatus.PendingDispatch
                 : DeliveryRequestStatus.Created,
             OrderCategory = orderCategory,
-            PickupCode = GenerateNumericCode(6),
+            PickupCode = GenerateNumericCode(4),
             DropCode = GenerateNumericCode(4),
             RestaurantId = restaurantId,
             CustomerId = customerId,

--- a/src/RallyAPI.SharedKernel/Abstractions/Delivery/CreateTaskRequest.cs
+++ b/src/RallyAPI.SharedKernel/Abstractions/Delivery/CreateTaskRequest.cs
@@ -56,7 +56,7 @@ public sealed record CreateTaskRequest
     public decimal OrderWeight { get; init; } = 2; // Default 2kg for F&B
 
     /// <summary>
-    /// 6-digit OTP shown to the rider at the restaurant. Provider stores
+    /// 4-digit OTP shown to the rider at the restaurant. Provider stores
     /// this and validates against rider input on pickup.
     /// </summary>
     public string? PickupCode { get; init; }

--- a/src/RallyAPI.SharedKernel/Abstractions/Delivery/IThirdPartyDeliveryProvider.cs
+++ b/src/RallyAPI.SharedKernel/Abstractions/Delivery/IThirdPartyDeliveryProvider.cs
@@ -71,7 +71,7 @@ public sealed record UpdateOrderRequest
 {
     public required string ExternalTaskId { get; init; }
 
-    /// <summary>6-digit OTP shown to the rider at the restaurant.</summary>
+    /// <summary>4-digit OTP shown to the rider at the restaurant.</summary>
     public required string PickupCode { get; init; }
 
     /// <summary>4-digit OTP shared with the customer for delivery confirmation.</summary>


### PR DESCRIPTION
…advance task state; switch pickup OTP to 4 digits

ProRouting was generating its own pickup/drop OTPs because we never called partner/order/update — the create call alone leaves the task at UnFulfilled and ProRouting ignores OTPs sent at create-time. The restaurant dashboard displayed our locally-generated code (586580) while the rider was given ProRouting's auto-generated code (314947), so pickup verification failed.

Adds the UpdateOrderAsync call immediately after CreateTaskAsync in RiderDispatchOrchestrator.AssignVia3PLAsync. If the update fails, cancels the just-created task and returns booking failure (no stray UnFulfilled tasks on ProRouting's side).

Also switches PickupCode from 6 digits to 4 digits per product decision — both pickup and drop codes are now 4 digits. Doc comments updated.