### PR TITLE
fix(users): return 429 instead of 500 when OTP rate-limited or locked…

### DIFF
--- a/src/Modules/Users/RallyAPI.Users.Application/Abstractions/IOtpService.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Abstractions/IOtpService.cs
@@ -1,7 +1,13 @@
+using RallyAPI.SharedKernel.Results;
+
 namespace RallyAPI.Users.Application.Abstractions;
 
 public interface IOtpService
 {
-    Task<string> GenerateAndSendOtpAsync(string phoneNumber, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Generates, stores and sends an OTP. Returns a failure Result (instead of throwing)
+    /// when the phone is locked out or rate-limited, so callers surface 429 — not 500.
+    /// </summary>
+    Task<Result<string>> GenerateAndSendOtpAsync(string phoneNumber, CancellationToken cancellationToken = default);
     Task<bool> VerifyOtpAsync(string phoneNumber, string otp, CancellationToken cancellationToken = default);
 }

--- a/src/Modules/Users/RallyAPI.Users.Application/Customers/Commands/SendOtp/SendCustomerOtpCommandHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Customers/Commands/SendOtp/SendCustomerOtpCommandHandler.cs
@@ -21,8 +21,10 @@ internal sealed class SendCustomerOtpCommandHandler : IRequestHandler<SendCustom
         if (phoneResult.IsFailure)
             return Result.Failure(phoneResult.Error);
 
-        // Generate and send OTP
-        await _otpService.GenerateAndSendOtpAsync(phoneResult.Value.Value, cancellationToken);
+        // Generate and send OTP — fails with 429 if rate-limited or locked out
+        var otpResult = await _otpService.GenerateAndSendOtpAsync(phoneResult.Value.Value, cancellationToken);
+        if (otpResult.IsFailure)
+            return Result.Failure(otpResult.Error);
 
         return Result.Success();
     }

--- a/src/Modules/Users/RallyAPI.Users.Application/Riders/Commands/SendOtp/SendRiderOtpCommandHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Riders/Commands/SendOtp/SendRiderOtpCommandHandler.cs
@@ -27,7 +27,10 @@ internal sealed class SendRiderOtpCommandHandler : IRequestHandler<SendRiderOtpC
         if (!exists)
             return Result.Failure(Error.Validation("Rider not registered. Contact admin."));
 
-        await _otpService.GenerateAndSendOtpAsync(phoneResult.Value.Value, cancellationToken);
+        // Generate and send OTP — fails with 429 if rate-limited or locked out
+        var otpResult = await _otpService.GenerateAndSendOtpAsync(phoneResult.Value.Value, cancellationToken);
+        if (otpResult.IsFailure)
+            return Result.Failure(otpResult.Error);
 
         return Result.Success();
     }

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Services/OtpService.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Services/OtpService.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using RallyAPI.SharedKernel.Results;
 using RallyAPI.Users.Application.Abstractions;
 using StackExchange.Redis;
 using System.Security.Cryptography;
@@ -28,7 +29,7 @@ public class OtpService : IOtpService
         _logger = logger;
     }
 
-    public async Task<string> GenerateAndSendOtpAsync(
+    public async Task<Result<string>> GenerateAndSendOtpAsync(
         string phoneNumber,
         CancellationToken cancellationToken = default)
     {
@@ -37,8 +38,8 @@ public class OtpService : IOtpService
         // Check if phone is locked out (too many failed attempts)
         if (await _redis.KeyExistsAsync($"otp:lock:{phoneKey}"))
         {
-            throw new InvalidOperationException(
-                "Too many failed attempts. Try again in 15 minutes.");
+            return Result.Failure<string>(Error.TooManyRequests(
+                "Too many failed attempts. Try again in 15 minutes."));
         }
 
         // Rate limit: max 3 OTP requests per 10 minutes per phone
@@ -46,8 +47,8 @@ public class OtpService : IOtpService
         var currentRate = await _redis.StringGetAsync(rateKey);
         if (currentRate.HasValue && (int)currentRate >= RateLimitPerPhone)
         {
-            throw new InvalidOperationException(
-                "Too many OTP requests. Please wait before trying again.");
+            return Result.Failure<string>(Error.TooManyRequests(
+                "Too many OTP requests. Please wait before trying again."));
         }
 
         // Generate OTP
@@ -94,7 +95,7 @@ public class OtpService : IOtpService
             _logger.LogError("Failed to send OTP SMS to {Phone}", phoneNumber);
         }
 
-        return otp;
+        return Result.Success(otp);
     }
 
     public async Task<bool> VerifyOtpAsync(

--- a/src/RallyAPI.SharedKernel/Extensions/EndpointExtensions.cs
+++ b/src/RallyAPI.SharedKernel/Extensions/EndpointExtensions.cs
@@ -42,6 +42,7 @@ public static class EndpointExtensions
         var c when c.Contains("Unauthorized") => StatusCodes.Status401Unauthorized,
         var c when c.Contains("Forbidden")    => StatusCodes.Status403Forbidden,
         var c when c.Contains("Conflict")     => StatusCodes.Status409Conflict,
+        var c when c.Contains("TooManyRequests") => StatusCodes.Status429TooManyRequests,
         var c when c.Contains("Validation")   => StatusCodes.Status400BadRequest,
         _                                     => StatusCodes.Status400BadRequest
     };

--- a/src/RallyAPI.SharedKernel/Results/Error.cs
+++ b/src/RallyAPI.SharedKernel/Results/Error.cs
@@ -54,6 +54,12 @@ public sealed class Error
     public static Error Conflict(string message) =>
         new("Conflict.Error", message);
 
+    /// <summary>
+    /// Rate-limit / lockout errors. Maps to HTTP 429 in <c>EndpointExtensions.GetStatusCode</c>.
+    /// </summary>
+    public static Error TooManyRequests(string message) =>
+        new("RateLimit.TooManyRequests", message);
+
     public static Error Unauthorized(string message = "Unauthorized access.") =>
         new("Unauthorized.Error", message);
 

--- a/tests/Modules/Users/RallyAPI.Users.Infrastructure.Tests/OtpServiceTests.cs
+++ b/tests/Modules/Users/RallyAPI.Users.Infrastructure.Tests/OtpServiceTests.cs
@@ -33,29 +33,31 @@ public sealed class OtpServiceTests
     // --- GenerateAndSendOtpAsync ---
 
     [Fact]
-    public async Task GenerateAndSendOtp_WhenPhoneIsLockedOut_ShouldThrowInvalidOperationException()
+    public async Task GenerateAndSendOtp_WhenPhoneIsLockedOut_ShouldReturnTooManyRequestsFailure()
     {
         _db.KeyExistsAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
             .Returns(Task.FromResult(true));
 
-        var act = async () => await _service.GenerateAndSendOtpAsync(Phone);
+        var result = await _service.GenerateAndSendOtpAsync(Phone);
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*Too many failed*");
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("RateLimit.TooManyRequests");
+        result.Error.Message.Should().Contain("Too many failed");
     }
 
     [Fact]
-    public async Task GenerateAndSendOtp_WhenRateLimitExceeded_ShouldThrowInvalidOperationException()
+    public async Task GenerateAndSendOtp_WhenRateLimitExceeded_ShouldReturnTooManyRequestsFailure()
     {
         _db.KeyExistsAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
             .Returns(Task.FromResult(false));
         _db.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
             .Returns(Task.FromResult((RedisValue)3)); // at the 3-per-10min limit
 
-        var act = async () => await _service.GenerateAndSendOtpAsync(Phone);
+        var result = await _service.GenerateAndSendOtpAsync(Phone);
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*Too many OTP requests*");
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("RateLimit.TooManyRequests");
+        result.Error.Message.Should().Contain("Too many OTP requests");
     }
 
     [Fact]
@@ -65,12 +67,13 @@ public sealed class OtpServiceTests
         _smsService.SendAsync(Phone, Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(true));
 
-        var otp = await _service.GenerateAndSendOtpAsync(Phone);
+        var result = await _service.GenerateAndSendOtpAsync(Phone);
 
-        otp.Should().MatchRegex(@"^\d{6}$"); // cryptographically random 6-digit OTP
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().MatchRegex(@"^\d{6}$"); // cryptographically random 6-digit OTP
         await _smsService.Received(1).SendAsync(
             Phone,
-            Arg.Is<string>(m => m.Contains(otp)),
+            Arg.Is<string>(m => m.Contains(result.Value)),
             Arg.Any<CancellationToken>());
     }
 
@@ -97,10 +100,11 @@ public sealed class OtpServiceTests
         _smsService.SendAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(false)); // SMS provider failure
 
-        var otp = await _service.GenerateAndSendOtpAsync(Phone);
+        var result = await _service.GenerateAndSendOtpAsync(Phone);
 
         // OTP is still stored in Redis; operation should not fail
-        otp.Should().MatchRegex(@"^\d{6}$");
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().MatchRegex(@"^\d{6}$");
     }
 
     // --- VerifyOtpAsync ---


### PR DESCRIPTION
… out

OtpService threw InvalidOperationException for the lockout (3 failed verifies -> 15 min lock) and rate-limit (3 sends per 10 min) guards. The global exception middleware turned that into a generic 500 InternalError with no actionable message - observed in production when a customer retried OTP sends during testing.

What changed:
- IOtpService.GenerateAndSendOtpAsync now returns Result<string> instead of throwing for expected business failures (Result pattern, per project architecture rules).
- New Error.TooManyRequests factory (code RateLimit.TooManyRequests) and EndpointExtensions mapping -> HTTP 429.
- Customer and Rider SendOtp handlers propagate the failure, so the API now responds: 429 {"error":"RateLimit.TooManyRequests", "message":"Too many failed attempts. Try again in 15 minutes."} (or "Too many OTP requests..." for the send rate limit) instead of 500 {"error":"InternalError","message":"An unexpected error occurred."}
- OtpServiceTests updated: throw assertions replaced with Result failure assertions. Build green, 10/10 tests pass.

Frontend can now distinguish rate-limiting from real server errors and show a proper countdown/retry message.