### PR TITLE
fix(infra): honor X-Forwarded-For so per-IP rate limits see real clie…

### DIFF
--- a/src/RallyAPI.Host/Program.cs
+++ b/src/RallyAPI.Host/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.IdentityModel.Tokens;
@@ -285,6 +286,19 @@ builder.Services.AddRateLimiter(options =>
     options.RejectionStatusCode = 429;
 });
 
+// Forwarded headers — Railway terminates TLS at its edge proxy and forwards the
+// client IP in X-Forwarded-For. Without this, Connection.RemoteIpAddress is the
+// proxy's IP for EVERY request, so the per-IP rate limiters above would share one
+// bucket across all users (e.g. 3 OTP sends per 10 min for the whole platform).
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    // Railway's proxy IPs are dynamic and unknown ahead of time; clear the
+    // defaults (loopback-only) so the forwarded headers are honored.
+    options.KnownNetworks.Clear();
+    options.KnownProxies.Clear();
+});
+
 // CORS
 builder.Services.AddCors(options =>
 {
@@ -316,6 +330,10 @@ builder.Services.AddCors(options =>
 
 
 var app = builder.Build();
+
+// Must run FIRST so everything downstream (rate limiter partitions, request
+// logging, auth) sees the real client IP and scheme instead of the proxy's.
+app.UseForwardedHeaders();
 
 // Add Global Exception Handler (early in pipeline!)
 app.UseGlobalExceptionHandler();


### PR DESCRIPTION
…nt IPs

Railway terminates TLS at its edge proxy and forwards the client IP in X-Forwarded-For. The app never configured ForwardedHeaders middleware, so Connection.RemoteIpAddress is the proxy IP for every request.

Why this matters NOW: all rate limiter policies (otp, login, refresh, lead-capture, admin-export fallback) partition by RemoteIpAddress. With ASPNETCORE_ENVIRONMENT=Development the limits are loose (100/min) and nobody notices. The moment the service flips to Production, the OTP policy becomes 3 requests per 10 minutes PER IP - and since every user appears to come from the same proxy IP, that is 3 OTP sends per 10 minutes for the ENTIRE platform. Login would brick the same way.

What changed:
- Configure ForwardedHeadersOptions (XForwardedFor + XForwardedProto) with KnownNetworks/KnownProxies cleared - Railway proxy IPs are dynamic, the standard setup for PaaS hosting.
- app.UseForwardedHeaders() added as the FIRST middleware so the rate limiter, Serilog request logging, and auth all see the real client IP and original scheme.

This unblocks switching ASPNETCORE_ENVIRONMENT to Production on Railway (currently Development, which also exposes Swagger and the dev-only purge/seed/diagnostic endpoints publicly).