### PR TITLE
fix(users): send OTP under both otp and var params to AuthKey SID mode

### DIFF
--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Services/AuthKeyOtpService.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Services/AuthKeyOtpService.cs
@@ -117,8 +117,13 @@ public class AuthKeyOtpService : ISmsService
             case "sid":
                 // AuthKey SID — DLT entity/template are bound to the SID dashboard-side,
                 // so no sender/pe_id/template_id params are needed in the URL.
+                // Send the OTP under BOTH param names: AuthKey's variable mapping for
+                // SID 42317 ({#var#} template) silently switched from `otp` to `var`
+                // on 2026-06-05, delivering SMS with an EMPTY code. Supplying both
+                // keeps delivery working whichever name the template is mapped to.
                 query["sid"] = _options.Sid;
                 query["otp"] = otp;
+                query["var"] = otp;
                 break;
 
             case "dlt-template":


### PR DESCRIPTION
AuthKey's variable mapping for SID 42317 (the {#var#} DLT template) silently switched from accepting `otp=` to requiring `var=` on 2026-06-05. Result: SMS delivered with an EMPTY code slot - "your OTP for verification is . Please do not share..." - while the API response still said Submitted Successfully.

Timeline (all to the same number, same key, same SID):
- morning:   otp=482913 delivered WITH code, var=735246 delivered WITH code
- afternoon: otp=918273 delivered EMPTY, var=556677 delivered WITH code
- verified:  otp=445566&var=445566 (this fix's shape) delivered WITH code

Fix: AuthKeyOtpService sid mode now sends the OTP under BOTH param names. Whichever name the template variable is mapped to dashboard-side, the code populates - immune to AuthKey remapping it again.