### PR TITLE
feat(delivery): push own-fleet rider GPS to customer over SignalR

### DIFF
--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/EventHandlers/RiderLocationUpdatedIntegrationEventHandler.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/EventHandlers/RiderLocationUpdatedIntegrationEventHandler.cs
@@ -1,0 +1,65 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using RallyAPI.Delivery.Domain.Abstractions;
+using RallyAPI.SharedKernel.Abstractions.Notifications;
+using RallyAPI.SharedKernel.IntegrationEvents.Riders;
+
+namespace RallyAPI.Delivery.Application.EventHandlers;
+
+/// <summary>
+/// When an own-fleet rider posts a GPS location, forward it to the customer
+/// tracking the order — but only if the rider currently has an active delivery.
+/// Acts as the gatekeeper: no active delivery (idle/online rider) → no-op.
+/// </summary>
+public sealed class RiderLocationUpdatedIntegrationEventHandler
+    : INotificationHandler<RiderLocationUpdatedIntegrationEvent>
+{
+    private readonly IDeliveryRequestRepository _deliveryRequestRepository;
+    private readonly ICustomerNotificationService _customerNotifications;
+    private readonly ILogger<RiderLocationUpdatedIntegrationEventHandler> _logger;
+
+    public RiderLocationUpdatedIntegrationEventHandler(
+        IDeliveryRequestRepository deliveryRequestRepository,
+        ICustomerNotificationService customerNotifications,
+        ILogger<RiderLocationUpdatedIntegrationEventHandler> logger)
+    {
+        _deliveryRequestRepository = deliveryRequestRepository;
+        _customerNotifications = customerNotifications;
+        _logger = logger;
+    }
+
+    public async Task Handle(
+        RiderLocationUpdatedIntegrationEvent notification,
+        CancellationToken cancellationToken)
+    {
+        var delivery = await _deliveryRequestRepository.GetActiveByRiderAsync(
+            notification.RiderId, cancellationToken);
+
+        if (delivery is null)
+            return; // Rider has no active delivery — nothing to forward.
+
+        // Persist the live position so a reconnecting customer sees the last
+        // known location (parity with the 3PL track-callback path).
+        delivery.UpdateLiveLocation(
+            notification.Latitude, notification.Longitude, notification.UpdatedAt);
+        await _deliveryRequestRepository.UpdateAsync(delivery, cancellationToken);
+
+        if (delivery.CustomerId is not Guid customerId)
+        {
+            _logger.LogWarning(
+                "Active delivery {DeliveryId} has no CustomerId; cannot push rider location",
+                delivery.Id);
+            return;
+        }
+
+        await _customerNotifications.SendRiderLocationAsync(
+            customerId,
+            new RiderLocationUpdate(
+                delivery.OrderId,
+                delivery.Id,
+                notification.Latitude,
+                notification.Longitude,
+                notification.UpdatedAt),
+            cancellationToken);
+    }
+}

--- a/src/Modules/Delivery/RallyAPI.Delivery.Domain/Abstractions/IDeliveryRequestRepository.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Domain/Abstractions/IDeliveryRequestRepository.cs
@@ -8,6 +8,13 @@ public interface IDeliveryRequestRepository
     Task<DeliveryRequest?> GetByIdAsync(Guid id, CancellationToken ct = default);
     Task<DeliveryRequest?> GetByIdWithOffersAsync(Guid id, CancellationToken ct = default);
     Task<DeliveryRequest?> GetByOrderIdAsync(Guid orderId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the rider's current in-progress own-fleet delivery (assigned through
+    /// in-transit, before Delivered/terminal), or null if the rider has none.
+    /// Used to forward live GPS to the customer.
+    /// </summary>
+    Task<DeliveryRequest?> GetActiveByRiderAsync(Guid riderId, CancellationToken ct = default);
     Task<IReadOnlyList<DeliveryRequest>> GetByStatusAsync(DeliveryRequestStatus status, CancellationToken ct = default);
     Task<IReadOnlyList<DeliveryRequest>> GetPendingDispatchAsync(DateTime dispatchBefore, CancellationToken ct = default);
     Task AddAsync(DeliveryRequest request, CancellationToken ct = default);

--- a/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Repositories/DeliveryRequestRepository.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Repositories/DeliveryRequestRepository.cs
@@ -34,6 +34,18 @@ public sealed class DeliveryRequestRepository : IDeliveryRequestRepository
             .FirstOrDefaultAsync(r => r.OrderId == orderId, ct);
     }
 
+    public async Task<DeliveryRequest?> GetActiveByRiderAsync(Guid riderId, CancellationToken ct = default)
+    {
+        // RiderId is only ever set for own-fleet deliveries, so this implicitly
+        // excludes 3PL. Active = assigned through in-transit, before Delivered.
+        return await _dbContext.DeliveryRequests
+            .Where(r => r.RiderId == riderId)
+            .Where(r => r.Status >= DeliveryRequestStatus.RiderAssigned)
+            .Where(r => r.Status < DeliveryRequestStatus.Delivered)
+            .OrderByDescending(r => r.AssignedAt)
+            .FirstOrDefaultAsync(ct);
+    }
+
     public async Task<IReadOnlyList<DeliveryRequest>> GetByStatusAsync(
         DeliveryRequestStatus status,
         CancellationToken ct = default)

--- a/src/Modules/Users/RallyAPI.Users.Application/Riders/Commands/UpdateLocation/UpdateRiderLocationCommandHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Riders/Commands/UpdateLocation/UpdateRiderLocationCommandHandler.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using RallyAPI.SharedKernel.IntegrationEvents.Riders;
 using RallyAPI.SharedKernel.Results;
 using RallyAPI.Users.Application.Abstractions;
 
@@ -9,13 +10,16 @@ internal sealed class UpdateRiderLocationCommandHandler
 {
     private readonly IRiderRepository _riderRepository;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IPublisher _publisher;
 
     public UpdateRiderLocationCommandHandler(
         IRiderRepository riderRepository,
-        IUnitOfWork unitOfWork)
+        IUnitOfWork unitOfWork,
+        IPublisher publisher)
     {
         _riderRepository = riderRepository;
         _unitOfWork = unitOfWork;
+        _publisher = publisher;
     }
 
     public async Task<Result> Handle(
@@ -31,6 +35,17 @@ internal sealed class UpdateRiderLocationCommandHandler
             return result;
 
         await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        // Notify the Delivery module so it can forward live position to the
+        // customer if this rider is on an active own-fleet delivery. The
+        // handler there no-ops when there is no active delivery.
+        await _publisher.Publish(
+            new RiderLocationUpdatedIntegrationEvent(
+                request.RiderId,
+                (double)request.Latitude,
+                (double)request.Longitude,
+                DateTime.UtcNow),
+            cancellationToken);
 
         return Result.Success();
     }

--- a/src/RallyAPI.Host/Program.cs
+++ b/src/RallyAPI.Host/Program.cs
@@ -25,7 +25,7 @@ using System.Text.Json;
 using System.Threading.RateLimiting;
 
 // Bootstrap logger — captures startup errors before the host is built
-Log.Logger = new LoggerConfiguration()
+        Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
     .CreateBootstrapLogger();
 
@@ -185,6 +185,9 @@ builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Progr
 
 // Override StubRiderNotificationService with real SignalR implementation
 builder.Services.AddScoped<IRiderNotificationService, SignalRRiderNotificationService>();
+
+// Real-time rider location push to the customer tracking the order
+builder.Services.AddScoped<ICustomerNotificationService, SignalRCustomerNotificationService>();
 
 
 // Add Swagger

--- a/src/RallyAPI.Host/Services/SignalRCustomerNotificationService.cs
+++ b/src/RallyAPI.Host/Services/SignalRCustomerNotificationService.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.SignalR;
+using RallyAPI.Host.Hubs;
+using RallyAPI.SharedKernel.Abstractions.Notifications;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Host.Services;
+
+/// <summary>
+/// Implements ICustomerNotificationService using SignalR.
+/// Pushes to the customer_{id} group, mirroring OrderStatusSignalRHandler.
+/// Lives in Host to avoid a circular dependency on IHubContext{NotificationHub}.
+/// </summary>
+public sealed class SignalRCustomerNotificationService : ICustomerNotificationService
+{
+    private readonly IHubContext<NotificationHub> _hubContext;
+
+    public SignalRCustomerNotificationService(IHubContext<NotificationHub> hubContext)
+    {
+        _hubContext = hubContext;
+    }
+
+    public async Task<Result> SendRiderLocationAsync(
+        Guid customerId,
+        RiderLocationUpdate update,
+        CancellationToken ct = default)
+    {
+        await _hubContext.Clients
+            .Group($"customer_{customerId}")
+            .SendAsync("RiderLocationUpdate", new
+            {
+                orderId = update.OrderId,
+                deliveryRequestId = update.DeliveryRequestId,
+                riderLatitude = update.Latitude,
+                riderLongitude = update.Longitude,
+                updatedAt = update.UpdatedAt
+            }, ct);
+
+        return Result.Success();
+    }
+}

--- a/src/RallyAPI.SharedKernel/Abstractions/Notifications/ICustomerNotificationService.cs
+++ b/src/RallyAPI.SharedKernel/Abstractions/Notifications/ICustomerNotificationService.cs
@@ -1,0 +1,31 @@
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.SharedKernel.Abstractions.Notifications;
+
+/// <summary>
+/// Service for sending real-time notifications to customers.
+/// MVP implementation uses SignalR (pushes to the customer_{id} group).
+/// </summary>
+public interface ICustomerNotificationService
+{
+    /// <summary>
+    /// Pushes a live rider GPS position to the customer tracking their order.
+    /// </summary>
+    /// <param name="customerId">Target customer ID</param>
+    /// <param name="update">Rider location payload</param>
+    /// <param name="ct">Cancellation token</param>
+    Task<Result> SendRiderLocationAsync(
+        Guid customerId,
+        RiderLocationUpdate update,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Live rider position pushed to the customer during an active delivery.
+/// </summary>
+public sealed record RiderLocationUpdate(
+    Guid OrderId,
+    Guid DeliveryRequestId,
+    double Latitude,
+    double Longitude,
+    DateTime UpdatedAt);

--- a/src/RallyAPI.SharedKernel/Domain/IntegrationEvents/Riders/RiderLocationUpdatedIntegrationEvent.cs
+++ b/src/RallyAPI.SharedKernel/Domain/IntegrationEvents/Riders/RiderLocationUpdatedIntegrationEvent.cs
@@ -1,0 +1,31 @@
+using RallyAPI.SharedKernel.Domain;
+
+namespace RallyAPI.SharedKernel.IntegrationEvents.Riders;
+
+/// <summary>
+/// Raised by the Users module whenever an own-fleet rider posts a GPS location.
+/// Consumed by the Delivery module, which checks whether the rider has an active
+/// delivery and, if so, persists the live location and pushes it to the customer.
+///
+/// Published on every location ping; the Delivery handler is the gatekeeper and
+/// no-ops when the rider has no active delivery.
+/// </summary>
+public sealed class RiderLocationUpdatedIntegrationEvent : BaseDomainEvent
+{
+    public Guid RiderId { get; }
+    public double Latitude { get; }
+    public double Longitude { get; }
+    public DateTime UpdatedAt { get; }
+
+    public RiderLocationUpdatedIntegrationEvent(
+        Guid riderId,
+        double latitude,
+        double longitude,
+        DateTime updatedAt)
+    {
+        RiderId = riderId;
+        Latitude = latitude;
+        Longitude = longitude;
+        UpdatedAt = updatedAt;
+    }
+}

--- a/tests/Modules/Delivery/RallyAPI.Delivery.Application.Tests/RiderLocationUpdatedIntegrationEventHandlerTests.cs
+++ b/tests/Modules/Delivery/RallyAPI.Delivery.Application.Tests/RiderLocationUpdatedIntegrationEventHandlerTests.cs
@@ -1,0 +1,114 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using NSubstitute;
+using RallyAPI.Delivery.Application.EventHandlers;
+using RallyAPI.Delivery.Domain.Abstractions;
+using RallyAPI.Delivery.Domain.Entities;
+using RallyAPI.SharedKernel.Abstractions.Notifications;
+using RallyAPI.SharedKernel.IntegrationEvents.Riders;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Delivery.Application.Tests;
+
+public class RiderLocationUpdatedIntegrationEventHandlerTests
+{
+    private readonly IDeliveryRequestRepository _repository;
+    private readonly ICustomerNotificationService _customerNotifications;
+    private readonly ILogger<RiderLocationUpdatedIntegrationEventHandler> _logger;
+    private readonly RiderLocationUpdatedIntegrationEventHandler _handler;
+
+    public RiderLocationUpdatedIntegrationEventHandlerTests()
+    {
+        _repository = Substitute.For<IDeliveryRequestRepository>();
+        _customerNotifications = Substitute.For<ICustomerNotificationService>();
+        _logger = Substitute.For<ILogger<RiderLocationUpdatedIntegrationEventHandler>>();
+        _handler = new RiderLocationUpdatedIntegrationEventHandler(
+            _repository, _customerNotifications, _logger);
+
+        _customerNotifications
+            .SendRiderLocationAsync(Arg.Any<Guid>(), Arg.Any<RiderLocationUpdate>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+    }
+
+    [Fact]
+    public async Task Handle_WhenRiderHasActiveDelivery_PersistsAndPushesToCustomer()
+    {
+        var riderId = Guid.NewGuid();
+        var customerId = Guid.NewGuid();
+        var delivery = BuildActiveDelivery(riderId, customerId);
+
+        _repository.GetActiveByRiderAsync(riderId, Arg.Any<CancellationToken>()).Returns(delivery);
+
+        var evt = new RiderLocationUpdatedIntegrationEvent(
+            riderId, 12.9352, 77.6245, new DateTime(2026, 6, 11, 10, 0, 0, DateTimeKind.Utc));
+
+        await _handler.Handle(evt, CancellationToken.None);
+
+        delivery.LastRiderLatitude.Should().Be(12.9352);
+        delivery.LastRiderLongitude.Should().Be(77.6245);
+        await _repository.Received(1).UpdateAsync(delivery, Arg.Any<CancellationToken>());
+        await _customerNotifications.Received(1).SendRiderLocationAsync(
+            customerId,
+            Arg.Is<RiderLocationUpdate>(u =>
+                u.OrderId == delivery.OrderId &&
+                u.DeliveryRequestId == delivery.Id &&
+                u.Latitude == 12.9352 &&
+                u.Longitude == 77.6245),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoActiveDelivery_DoesNothing()
+    {
+        var riderId = Guid.NewGuid();
+        _repository.GetActiveByRiderAsync(riderId, Arg.Any<CancellationToken>())
+            .Returns((DeliveryRequest?)null);
+
+        var evt = new RiderLocationUpdatedIntegrationEvent(riderId, 1.0, 2.0, DateTime.UtcNow);
+
+        await _handler.Handle(evt, CancellationToken.None);
+
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<DeliveryRequest>(), Arg.Any<CancellationToken>());
+        await _customerNotifications.DidNotReceive().SendRiderLocationAsync(
+            Arg.Any<Guid>(), Arg.Any<RiderLocationUpdate>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenActiveDeliveryHasNoCustomer_PersistsButDoesNotPush()
+    {
+        var riderId = Guid.NewGuid();
+        var delivery = BuildActiveDelivery(riderId, customerId: null);
+
+        _repository.GetActiveByRiderAsync(riderId, Arg.Any<CancellationToken>()).Returns(delivery);
+
+        var evt = new RiderLocationUpdatedIntegrationEvent(riderId, 5.0, 6.0, DateTime.UtcNow);
+
+        await _handler.Handle(evt, CancellationToken.None);
+
+        await _repository.Received(1).UpdateAsync(delivery, Arg.Any<CancellationToken>());
+        await _customerNotifications.DidNotReceive().SendRiderLocationAsync(
+            Arg.Any<Guid>(), Arg.Any<RiderLocationUpdate>(), Arg.Any<CancellationToken>());
+    }
+
+    private static DeliveryRequest BuildActiveDelivery(Guid riderId, Guid? customerId)
+    {
+        var request = DeliveryRequest.Create(
+            id: Guid.NewGuid(),
+            orderId: Guid.NewGuid(),
+            orderNumber: "ORD-LOC-001",
+            quoteId: null,
+            quotedPrice: 100m,
+            pickupLat: 12.935, pickupLng: 77.624, pickupPincode: "560095",
+            pickupAddress: "Restaurant Street", pickupContactName: "Dosa Corner",
+            pickupContactPhone: "+919876543210",
+            dropLat: 12.971, dropLng: 77.594, dropPincode: "560025",
+            dropAddress: "42 Brigade Road", dropContactName: "Priya Singh",
+            dropContactPhone: "+919845678901",
+            customerId: customerId);
+
+        request.StartSearchingOwnFleet();
+        request.AssignOwnFleetRider(riderId, "Ravi Kumar", "+919812345678");
+        return request;
+    }
+}


### PR DESCRIPTION
Own-fleet riders had no live-tracking path: location pings were saved to the Rider entity and went nowhere. Now, when a rider posts a location while on an active delivery, the customer tracking that order receives it in real time.

Flow (integration event, clean module boundaries):
- Users UpdateRiderLocationCommandHandler publishes RiderLocationUpdatedIntegrationEvent after saving.
- Delivery RiderLocationUpdatedIntegrationEventHandler looks up the rider's active own-fleet delivery; if found, persists the live position (UpdateLiveLocation, parity with the 3PL track callback) and forwards to the customer. No active delivery -> no-op.
- Host SignalRCustomerNotificationService pushes 'RiderLocationUpdate' to the customer_{id} group, mirroring OrderStatusSignalRHandler.

Adds the reusable ICustomerNotificationService abstraction the codebase lacked. 3PL is unaffected (RiderId is only set for own-fleet, so the lookup excludes it). No schema change: reuses existing LastRiderLatitude/Longitude columns; only a repo query method was added.