### PR TITLE
feat(riders): add rider earnings summary endpoint

### DIFF
--- a/src/Modules/Users/RallyAPI.Users.Application/Riders/Queries/GetEarningsSummary/GetRiderEarningsSummaryQuery.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Riders/Queries/GetEarningsSummary/GetRiderEarningsSummaryQuery.cs
@@ -1,0 +1,19 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Users.Application.Riders.Queries.GetEarningsSummary;
+
+public sealed record GetRiderEarningsSummaryQuery(Guid RiderId)
+    : IRequest<Result<RiderEarningsSummaryResponse>>;
+
+/// <summary>
+/// Rider-facing earnings snapshot for the app's earnings tab.
+/// Amounts are net payable (base + surge + tips) aggregated from the
+/// rider's weekly payout cycles.
+/// </summary>
+public sealed record RiderEarningsSummaryResponse(
+    decimal TotalEarned,
+    decimal PendingPayout,
+    decimal ThisWeek,
+    decimal ThisMonth,
+    DateTime NextPayoutDateUtc);

--- a/src/Modules/Users/RallyAPI.Users.Application/Riders/Queries/GetEarningsSummary/GetRiderEarningsSummaryQueryHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Riders/Queries/GetEarningsSummary/GetRiderEarningsSummaryQueryHandler.cs
@@ -1,0 +1,53 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Application.Abstractions;
+
+namespace RallyAPI.Users.Application.Riders.Queries.GetEarningsSummary;
+
+internal sealed class GetRiderEarningsSummaryQueryHandler
+    : IRequestHandler<GetRiderEarningsSummaryQuery, Result<RiderEarningsSummaryResponse>>
+{
+    private static readonly TimeZoneInfo IstTimeZone =
+        TimeZoneInfo.FindSystemTimeZoneById("India Standard Time");
+
+    private readonly IRiderPayoutLedgerRepository _ledger;
+
+    public GetRiderEarningsSummaryQueryHandler(IRiderPayoutLedgerRepository ledger)
+    {
+        _ledger = ledger;
+    }
+
+    public async Task<Result<RiderEarningsSummaryResponse>> Handle(
+        GetRiderEarningsSummaryQuery request,
+        CancellationToken cancellationToken)
+    {
+        var nowUtc = DateTime.UtcNow;
+
+        var breakdown = await _ledger.GetEarningsBreakdownAsync(
+            request.RiderId, nowUtc, cancellationToken);
+
+        var response = new RiderEarningsSummaryResponse(
+            TotalEarned: breakdown.Total,
+            PendingPayout: breakdown.Pending,
+            ThisWeek: breakdown.ThisWeek,
+            ThisMonth: breakdown.ThisMonth,
+            NextPayoutDateUtc: NextMondaySixAmIstAsUtc(nowUtc));
+
+        return Result.Success(response);
+    }
+
+    /// <summary>
+    /// Payouts run weekly via RiderPayoutAggregationJob — Monday 06:00 IST.
+    /// Mirrors the cadence used by the admin payout summary.
+    /// </summary>
+    private static DateTime NextMondaySixAmIstAsUtc(DateTime nowUtc)
+    {
+        DateTime nowIst = TimeZoneInfo.ConvertTimeFromUtc(nowUtc, IstTimeZone);
+        int daysUntilMonday = ((int)DayOfWeek.Monday - (int)nowIst.DayOfWeek + 7) % 7;
+        DateTime candidate = nowIst.Date.AddDays(daysUntilMonday).AddHours(6);
+        if (candidate <= nowIst)
+            candidate = candidate.AddDays(7);
+
+        return TimeZoneInfo.ConvertTimeToUtc(candidate, IstTimeZone);
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/GetEarningsSummary.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/GetEarningsSummary.cs
@@ -1,0 +1,33 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Riders.Queries.GetEarningsSummary;
+using System.Security.Claims;
+
+namespace RallyAPI.Users.Endpoints.Riders;
+
+public class GetEarningsSummary : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/riders/earnings", HandleAsync)
+            .WithTags("Riders")
+            .WithSummary("Get rider earnings summary (total/week/month + pending payout)")
+            .RequireAuthorization("Rider");
+    }
+
+    private static async Task<IResult> HandleAsync(
+        ClaimsPrincipal user,
+        ISender sender,
+        CancellationToken ct)
+    {
+        var riderId = Guid.Parse(user.FindFirstValue("sub")!);
+        var result = await sender.Send(new GetRiderEarningsSummaryQuery(riderId), ct);
+
+        return result.IsSuccess
+            ? Results.Ok(result.Value)
+            : result.Error.ToErrorResult();
+    }
+}


### PR DESCRIPTION
Exposes GET /api/riders/earnings for the rider app's earnings tab. The underlying aggregation (IRiderPayoutLedgerRepository.GetEarningsBreakdownAsync) already existed but had no rider-facing endpoint — only admin payout views.

Returns the authenticated rider's lifetime earned, pending payout, and this-week / this-month totals (net payable across weekly payout cycles), plus the next payout date (Monday 06:00 IST, matching the aggregation job and admin summary cadence). Read-only; no schema change.