### PR TITLE
feat(admins): add endpoint to approve/reject rider KYC

### DIFF
--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Admins/UpdateRiderKyc.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Admins/UpdateRiderKyc.cs
@@ -1,0 +1,43 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Admins.Commands.UpdateRiderKyc;
+using RallyAPI.Users.Domain.Enums;
+using System.Security.Claims;
+
+namespace RallyAPI.Users.Endpoints.Admins;
+
+public class UpdateRiderKyc : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPatch("/api/riders/{riderId:guid}/kyc-status", HandleAsync)
+            .WithName("UpdateRiderKycStatus")
+            .WithSummary("Approve or reject a rider's KYC (admin)")
+            .WithTags("Admins")
+            .RequireAuthorization("Admin");
+    }
+
+    private static async Task<IResult> HandleAsync(
+        Guid riderId,
+        [FromBody] UpdateRiderKycStatusRequest request,
+        ClaimsPrincipal user,
+        ISender sender,
+        CancellationToken cancellationToken)
+    {
+        var adminId = Guid.Parse(user.FindFirstValue("sub")!);
+        var result = await sender.Send(
+            new UpdateRiderKycCommand(adminId, riderId, request.NewKycStatus),
+            cancellationToken);
+
+        return result.IsFailure
+            ? result.Error.ToErrorResult()
+            : Results.Ok();
+    }
+}
+
+/// <summary>Body: { "newKycStatus": "Verified" | "Rejected" | "Pending" }</summary>
+public sealed record UpdateRiderKycStatusRequest(KycStatus NewKycStatus);


### PR DESCRIPTION
PATCH /api/riders/{riderId}/kyc-status maps the existing UpdateRiderKycCommand, which previously had a handler + validator but no HTTP route — meaning no rider could be verified and therefore none could pass the GoOnline KYC gate.

Body: { "newKycStatus": "Verified" | "Rejected" | "Pending" }. Admin auth; the handler additionally blocks the Support admin role. Matches the sibling /api/riders/{riderId}/kyc-documents route. No schema change.