### PR TITLE
feat(riders): add rider self KYC status endpoint

### DIFF
--- a/src/Modules/Users/RallyAPI.Users.Application/Riders/Queries/GetKycStatus/GetRiderKycStatusQuery.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Riders/Queries/GetKycStatus/GetRiderKycStatusQuery.cs
@@ -1,0 +1,25 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Users.Application.Riders.Queries.GetKycStatus;
+
+public sealed record GetRiderKycStatusQuery(Guid RiderId)
+    : IRequest<Result<RiderKycStatusResponse>>;
+
+/// <summary>
+/// The rider's own KYC verification state, for the app's KYC screen.
+/// Lets the rider see their status and which documents they've uploaded /
+/// which are verified — without needing the admin documents endpoint.
+/// </summary>
+public sealed record RiderKycStatusResponse(
+    string KycStatus,
+    bool CanGoOnline,
+    DateTime? LastSubmittedAt,
+    IReadOnlyList<RiderKycDocumentDto> Documents);
+
+public sealed record RiderKycDocumentDto(
+    string DocumentType,
+    string PublicUrl,
+    bool IsVerified,
+    DateTime UploadedAt,
+    DateTime? VerifiedAt);

--- a/src/Modules/Users/RallyAPI.Users.Application/Riders/Queries/GetKycStatus/GetRiderKycStatusQueryHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Riders/Queries/GetKycStatus/GetRiderKycStatusQueryHandler.cs
@@ -1,0 +1,48 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Application.Abstractions;
+using RallyAPI.Users.Domain.Enums;
+
+namespace RallyAPI.Users.Application.Riders.Queries.GetKycStatus;
+
+internal sealed class GetRiderKycStatusQueryHandler
+    : IRequestHandler<GetRiderKycStatusQuery, Result<RiderKycStatusResponse>>
+{
+    private readonly IRiderRepository _riderRepository;
+
+    public GetRiderKycStatusQueryHandler(IRiderRepository riderRepository)
+    {
+        _riderRepository = riderRepository;
+    }
+
+    public async Task<Result<RiderKycStatusResponse>> Handle(
+        GetRiderKycStatusQuery request,
+        CancellationToken cancellationToken)
+    {
+        var rider = await _riderRepository.GetByIdWithKycAsync(request.RiderId, cancellationToken);
+        if (rider is null)
+            return Result.Failure<RiderKycStatusResponse>(Error.NotFound("Rider", request.RiderId));
+
+        var documents = rider.KycDocuments
+            .OrderByDescending(d => d.UploadedAt)
+            .Select(d => new RiderKycDocumentDto(
+                d.DocumentType.ToString(),
+                d.PublicUrl,
+                d.IsVerified,
+                d.UploadedAt,
+                d.VerifiedAt))
+            .ToList();
+
+        DateTime? lastSubmittedAt = rider.KycDocuments.Count > 0
+            ? rider.KycDocuments.Max(d => d.UploadedAt)
+            : null;
+
+        var response = new RiderKycStatusResponse(
+            KycStatus: rider.KycStatus.ToString(),
+            CanGoOnline: rider.KycStatus == KycStatus.Verified,
+            LastSubmittedAt: lastSubmittedAt,
+            Documents: documents);
+
+        return Result.Success(response);
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/GetKycStatus.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/GetKycStatus.cs
@@ -1,0 +1,33 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Riders.Queries.GetKycStatus;
+using System.Security.Claims;
+
+namespace RallyAPI.Users.Endpoints.Riders;
+
+public class GetKycStatus : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/riders/kyc-status", HandleAsync)
+            .WithTags("Riders")
+            .WithSummary("Get the rider's own KYC status and uploaded documents")
+            .RequireAuthorization("Rider");
+    }
+
+    private static async Task<IResult> HandleAsync(
+        ClaimsPrincipal user,
+        ISender sender,
+        CancellationToken ct)
+    {
+        var riderId = Guid.Parse(user.FindFirstValue("sub")!);
+        var result = await sender.Send(new GetRiderKycStatusQuery(riderId), ct);
+
+        return result.IsSuccess
+            ? Results.Ok(result.Value)
+            : result.Error.ToErrorResult();
+    }
+}


### PR DESCRIPTION
Adds GET /api/riders/kyc-status so a rider can see their own verification state and uploaded documents without the admin documents endpoint.

Returns KycStatus (Pending/Verified/Rejected), canGoOnline (status==Verified, the same gate GoOnline enforces), lastSubmittedAt, and the list of uploaded documents (type, public URL, isVerified, uploaded/verified timestamps). Reuses the existing GetByIdWithKycAsync repo load. Read-only; no schema change.

Note: a rejection reason is not surfaced because it is not stored anywhere on the Rider aggregate today (would need a new field + migration).