### PR TITLE
feat(delivery): add paginated rider delivery history endpoint

### DIFF
--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/DTOs/RiderDeliveryHistoryDto.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/DTOs/RiderDeliveryHistoryDto.cs
@@ -1,0 +1,27 @@
+namespace RallyAPI.Delivery.Application.DTOs;
+
+/// <summary>
+/// One completed delivery in the rider's history tab.
+/// </summary>
+public sealed record RiderDeliveryHistoryItemDto
+{
+    public required Guid DeliveryRequestId { get; init; }
+    public required string OrderNumber { get; init; }
+    public required string RestaurantName { get; init; }
+    public required string DropAddress { get; init; }
+    public required string DropPincode { get; init; }
+    public required decimal Earnings { get; init; }
+    public decimal? DistanceKm { get; init; }
+    public DateTime? CompletedAt { get; init; }
+}
+
+/// <summary>
+/// Paginated rider delivery history.
+/// </summary>
+public sealed record RiderDeliveryHistoryResponse
+{
+    public required IReadOnlyList<RiderDeliveryHistoryItemDto> Items { get; init; }
+    public required int TotalCount { get; init; }
+    public required int Page { get; init; }
+    public required int PageSize { get; init; }
+}

--- a/src/Modules/Delivery/RallyAPI.Delivery.Endpoints/RiderDeliveryEndpoints.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Endpoints/RiderDeliveryEndpoints.cs
@@ -89,6 +89,12 @@ public static class RiderDeliveryEndpoints
             .Produces<DeliveryRequestDto>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status204NoContent);
 
+        // Get Delivery History (paginated)
+        group.MapGet("/history", GetDeliveryHistory)
+            .WithName("GetRiderDeliveryHistory")
+            .WithSummary("Get rider's completed delivery history (paginated)")
+            .Produces<RiderDeliveryHistoryResponse>(StatusCodes.Status200OK);
+
         return app;
     }
 
@@ -370,6 +376,84 @@ public static class RiderDeliveryEndpoints
         };
 
         return Results.Ok(dto);
+    }
+
+    private static async Task<IResult> GetDeliveryHistory(
+        int? page,
+        int? pageSize,
+        ICurrentUserService currentUser,
+        DeliveryDbContext dbContext,
+        CancellationToken ct)
+    {
+        if (!currentUser.UserId.HasValue)
+            return Results.Unauthorized();
+
+        var riderId = currentUser.UserId.Value;
+
+        var pageNum = page is > 0 ? page.Value : 1;
+        var size = pageSize switch
+        {
+            null or <= 0 => 20,
+            > 100 => 100,
+            _ => pageSize.Value
+        };
+
+        var baseQuery = dbContext.DeliveryRequests
+            .AsNoTracking()
+            .Where(r => r.RiderId == riderId && r.Status == DeliveryRequestStatus.Delivered);
+
+        var totalCount = await baseQuery.CountAsync(ct);
+
+        var pageRows = await baseQuery
+            .OrderByDescending(r => r.DeliveredAt)
+            .Skip((pageNum - 1) * size)
+            .Take(size)
+            .Select(r => new
+            {
+                r.Id,
+                r.OrderNumber,
+                r.PickupContactName,
+                r.DropAddress,
+                r.DropPincode,
+                r.DistanceKm,
+                r.DeliveredAt
+            })
+            .ToListAsync(ct);
+
+        // Per-delivery rider earnings live on the accepted offer. Fetch them for
+        // this page in one query rather than a correlated subquery per row.
+        var ids = pageRows.Select(r => r.Id).ToList();
+        var earningsLookup = (await dbContext.RiderOffers
+                .AsNoTracking()
+                .Where(o => ids.Contains(o.DeliveryRequestId)
+                    && o.RiderId == riderId
+                    && o.Status == RiderOfferStatus.Accepted)
+                .Select(o => new { o.DeliveryRequestId, o.Earnings })
+                .ToListAsync(ct))
+            .GroupBy(x => x.DeliveryRequestId)
+            .ToDictionary(g => g.Key, g => g.First().Earnings);
+
+        var items = pageRows
+            .Select(r => new RiderDeliveryHistoryItemDto
+            {
+                DeliveryRequestId = r.Id,
+                OrderNumber = r.OrderNumber,
+                RestaurantName = r.PickupContactName,
+                DropAddress = r.DropAddress,
+                DropPincode = r.DropPincode,
+                Earnings = earningsLookup.TryGetValue(r.Id, out var e) ? e : 0m,
+                DistanceKm = r.DistanceKm,
+                CompletedAt = r.DeliveredAt
+            })
+            .ToList();
+
+        return Results.Ok(new RiderDeliveryHistoryResponse
+        {
+            Items = items,
+            TotalCount = totalCount,
+            Page = pageNum,
+            PageSize = size
+        });
     }
 
     private static ProblemDetails CreateProblemDetails(Error error) => new()


### PR DESCRIPTION
Adds GET /api/rider/delivery/history?page=&pageSize= for the rider app's history tab — previously missing (only the current active delivery was queryable).

Returns the authenticated rider's completed (Delivered) deliveries, newest first: order number, restaurant, drop address/pincode, distance, completed-at, and per-delivery earnings (from the accepted RiderOffer). Earnings are fetched for each page in a single batched query rather than a correlated subquery. pageSize defaults to 20, capped at 100. Read-only; no schema change.