### PR TITLE
feat(riders): version rider-facing API routes under /api/v1

### DIFF
--- a/src/Modules/Delivery/RallyAPI.Delivery.Endpoints/RiderDeliveryEndpoints.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Endpoints/RiderDeliveryEndpoints.cs
@@ -21,7 +21,7 @@ public static class RiderDeliveryEndpoints
 {
     public static IEndpointRouteBuilder MapRiderDeliveryEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("/api/rider/delivery")
+        var group = app.MapGroup("/api/v1/rider/delivery")
             .WithTags("Rider Delivery")
             .RequireAuthorization("Rider")
             .WithOpenApi();

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/GetEarningsSummary.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/GetEarningsSummary.cs
@@ -12,7 +12,7 @@ public class GetEarningsSummary : IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapGet("/api/riders/earnings", HandleAsync)
+        app.MapGet("/api/v1/riders/earnings", HandleAsync)
             .WithTags("Riders")
             .WithSummary("Get rider earnings summary (total/week/month + pending payout)")
             .RequireAuthorization("Rider");

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/GetKycStatus.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/GetKycStatus.cs
@@ -12,7 +12,7 @@ public class GetKycStatus : IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapGet("/api/riders/kyc-status", HandleAsync)
+        app.MapGet("/api/v1/riders/kyc-status", HandleAsync)
             .WithTags("Riders")
             .WithSummary("Get the rider's own KYC status and uploaded documents")
             .RequireAuthorization("Rider");

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/GetProfile.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/GetProfile.cs
@@ -12,7 +12,7 @@ public class GetProfile : IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapGet("/api/riders/profile", HandleAsync)
+        app.MapGet("/api/v1/riders/profile", HandleAsync)
             .WithTags("Riders")
             .WithSummary("Get rider profile")
             .RequireAuthorization("Rider");

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/GoOffline.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/GoOffline.cs
@@ -12,7 +12,7 @@ public class GoOffline : IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapPost("/api/riders/status/offline", HandleAsync)
+        app.MapPost("/api/v1/riders/status/offline", HandleAsync)
             .WithTags("Riders")
             .WithSummary("Set rider status to offline")
             .RequireAuthorization("Rider");

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/GoOnline.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/GoOnline.cs
@@ -12,7 +12,7 @@ public class GoOnline : IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapPost("/api/riders/status/online", HandleAsync)
+        app.MapPost("/api/v1/riders/status/online", HandleAsync)
             .WithTags("Riders")
             .WithSummary("Set rider status to online")
             .RequireAuthorization("Rider");

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/SendOtp.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/SendOtp.cs
@@ -11,7 +11,7 @@ public class SendOtp : IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapPost("/api/riders/otp/send", HandleAsync)
+        app.MapPost("/api/v1/riders/otp/send", HandleAsync)
             .WithTags("Riders")
             .WithSummary("Send OTP to rider phone")
             .AllowAnonymous()

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/UpdateLocation.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/UpdateLocation.cs
@@ -12,7 +12,7 @@ public class UpdateLocation : IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapPost("/api/riders/location", HandleAsync)
+        app.MapPost("/api/v1/riders/location", HandleAsync)
             .WithTags("Riders")
             .WithSummary("Update rider current location")
             .RequireAuthorization("Rider");

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/UpdateProfile.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/UpdateProfile.cs
@@ -26,7 +26,7 @@ public class UpdateProfile : IEndpoint
 
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapPut("/api/riders/profile", HandleAsync)
+        app.MapPut("/api/v1/riders/profile", HandleAsync)
             .WithTags("Riders")
             .WithSummary("Update rider profile")
             .RequireAuthorization("Rider");

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/VerifyOtp.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/VerifyOtp.cs
@@ -11,7 +11,7 @@ public class VerifyOtp : IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapPost("/api/riders/otp/verify", HandleAsync)
+        app.MapPost("/api/v1/riders/otp/verify", HandleAsync)
             .WithTags("Riders")
             .WithSummary("Verify OTP and get token")
             .AllowAnonymous()


### PR DESCRIPTION
Prefix all rider-facing endpoints with /api/v1 ahead of mobile app development so the frontend can target a stable, versioned contract.

- Users rider endpoints: /api/riders/... -> /api/v1/riders/... (otp send/verify, profile get/update, earnings, kyc-status, status online/offline, location)
- Rider delivery group: /api/rider/delivery/... -> /api/v1/rider/delivery/...

Customer, restaurant, admin, and webhook routes are unchanged (we control both sides for the web apps). The two rider KYC routes under /api/users/riders/... are intentionally left for a later pass.