### PR TITLE
chore(infra): surface startup errors + raise healthcheck timeout to 200s

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -4,6 +4,6 @@ dockerfilePath = "Dockerfile"
 
 [deploy]
 healthcheckPath = "/health"
-healthcheckTimeout = 120
+healthcheckTimeout = 200
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 3

--- a/src/RallyAPI.Host/Program.cs
+++ b/src/RallyAPI.Host/Program.cs
@@ -48,6 +48,10 @@ builder.Host.UseSerilog((context, services, configuration) => configuration
     .Enrich.FromLogContext()
     .Enrich.WithEnvironmentName()
     .Enrich.WithThreadId()
+    // Always write to console, even when appsettings.json (which carries the
+    // Serilog config) is absent from the deployed image — otherwise post-startup
+    // logs and exceptions vanish on Railway, making boot failures invisible.
+    .WriteTo.Console()
     // Route Serilog Error+ events (incl. those logged by ExceptionHandlingMiddleware,
     // which catches exceptions so they never reach Sentry's ASP.NET middleware) into
     // the Sentry SDK already initialized by UseSentry(). InitializeSdk=false avoids a
@@ -488,6 +492,9 @@ using (var scope = app.Services.CreateScope())
     }
     catch (Exception ex)
     {
+        // Write straight to stderr too: on Railway the Serilog config may be absent
+        // and a buffered/async sink can lose this before the crash kills the process.
+        Console.Error.WriteLine($"[STARTUP MIGRATION ERROR] {ex}");
         logger.LogError(ex, "An error occurred while migrating the database.");
         throw;
     }
@@ -498,6 +505,7 @@ app.Run();
 }
 catch (Exception ex)
 {
+    Console.Error.WriteLine($"[STARTUP FATAL] {ex}");
     Log.Fatal(ex, "Application terminated unexpectedly");
 }
 finally


### PR DESCRIPTION
Railway showed no logs past the bootstrap line because appsettings.json (which holds the Serilog console config) is gitignored and absent from the image, so the post-Build() logger had no sinks — boot crashes were invisible.

- Add an explicit .WriteTo.Console() in code so logs always surface, config file or not.
- Write the migration error and the top-level fatal straight to stderr as a belt-and-suspenders in case a sink is buffered/lost before the process dies.
- healthcheckTimeout 120 -> 200.

Purpose: make the actual startup exception visible on the next deploy.