### PR TITLE
fix(infra): only initialize Sentry when a DSN is configured

### DIFF
--- a/src/RallyAPI.Host/Program.cs
+++ b/src/RallyAPI.Host/Program.cs
@@ -39,8 +39,15 @@ try
 var builder = WebApplication.CreateBuilder(args);
 
 // Sentry error tracking. DSN is read from config "Sentry:Dsn" / env SENTRY_DSN.
-// When the DSN is empty (local dev, CI) the SDK no-ops, so this is safe everywhere.
-builder.WebHost.UseSentry();
+// Only initialize when a DSN is actually configured: UseSentry() throws
+// ArgumentNullException on a null/unset DSN (only an empty STRING no-ops). On
+// Railway appsettings.json isn't in the image and SENTRY_DSN is unset -> null ->
+// it crashed the whole app on startup. Guarding makes it safe with no DSN.
+var sentryDsn = builder.Configuration["Sentry:Dsn"];
+if (!string.IsNullOrWhiteSpace(sentryDsn))
+{
+    builder.WebHost.UseSentry();
+}
 
 builder.Host.UseSerilog((context, services, configuration) => configuration
     .ReadFrom.Configuration(context.Configuration)


### PR DESCRIPTION
UseSentry() throws ArgumentNullException when the DSN is null/unset — only an empty STRING no-ops, not a missing value. On Railway appsettings.json isn't in the image and SENTRY_DSN is unset, so the DSN resolved to null and Sentry crashed the app on startup (caught only after adding the console/stderr diagnostics — Serilog had no sink so it was invisible). This was the actual boot failure, not the migrations.

Guard UseSentry() behind a non-empty DSN check. The Serilog .WriteTo.Sentry sink uses InitializeSdk=false, so it safely no-ops against the disabled hub.