### PR TITLE
fix(delivery): make own-fleet quotes survive Google distance failures

### DIFF
--- a/src/Modules/Pricing/RallyAPI.Pricing.Infrastructure/Services/DeliveryPricingCalculator.cs
+++ b/src/Modules/Pricing/RallyAPI.Pricing.Infrastructure/Services/DeliveryPricingCalculator.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Options;
 using RallyAPI.SharedKernel.Abstractions.Distance;
 using RallyAPI.SharedKernel.Abstractions.Pricing;
+using RallyAPI.SharedKernel.Utilities;
 
 namespace RallyAPI.Pricing.Infrastructure.Services;
 
@@ -41,14 +42,34 @@ public sealed class DeliveryPricingCalculator : IDeliveryPricingCalculator
             request.DropLongitude,
             ct);
 
-        if (!distanceResult.IsSuccess)
+        decimal distanceKm;
+        int estimatedMinutes;
+
+        if (distanceResult.IsSuccess)
         {
-            _logger.LogWarning("Distance calculation failed: {Error}", distanceResult.ErrorMessage);
-            return DeliveryPriceResult.Failure(distanceResult.ErrorMessage ?? "Distance calculation failed");
+            distanceKm = distanceResult.DistanceKm;
+            estimatedMinutes = distanceResult.DurationMinutes;
+        }
+        else
+        {
+            // A transient Google failure must NOT deny a quote when we have coordinates
+            // and an available own-fleet rider. Estimate road distance from the
+            // straight-line (Haversine) distance with an urban-detour correction factor.
+            var straightLineKm = GeoCalculator.CalculateDistanceKm(
+                request.PickupLatitude, request.PickupLongitude,
+                request.DropLatitude, request.DropLongitude);
+
+            var estimatedRoadKm = straightLineKm * _options.StraightLineRoadFactor;
+            distanceKm = Math.Round((decimal)estimatedRoadKm, 2);
+            estimatedMinutes = GeoCalculator.EstimateTravelMinutes(estimatedRoadKm);
+
+            _logger.LogWarning(
+                "Distance API failed ({Error}); falling back to estimated road distance {Distance}km "
+                + "(straight-line {StraightLine:F2}km × {Factor} detour factor)",
+                distanceResult.ErrorMessage, distanceKm, straightLineKm, _options.StraightLineRoadFactor);
         }
 
         // Calculate fee
-        var distanceKm = distanceResult.DistanceKm;
         var fee = CalculateFee(distanceKm);
 
         // Build breakdown
@@ -67,7 +88,7 @@ public sealed class DeliveryPricingCalculator : IDeliveryPricingCalculator
             baseFee: fee.BaseFee,
             finalFee: fee.FinalFee,
             distanceKm: distanceKm,
-            estimatedMinutes: distanceResult.DurationMinutes,
+            estimatedMinutes: estimatedMinutes,
             surgeMultiplier: 1.0m, // TODO: Integrate with surge pricing
             surgeReason: null,
             expiresAt: expiresAt,
@@ -147,4 +168,11 @@ public sealed class DeliveryPricingOptions
     /// How long quotes are valid (minutes).
     /// </summary>
     public int QuoteValidityMinutes { get; set; } = 30;
+
+    /// <summary>
+    /// Multiplier applied to straight-line (Haversine) distance to approximate road
+    /// distance when the Google distance API is unavailable. Urban roads typically
+    /// run 30–50% longer than the crow-flies distance.
+    /// </summary>
+    public double StraightLineRoadFactor { get; set; } = 1.4;
 }

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Services/RiderQueryService.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Services/RiderQueryService.cs
@@ -19,7 +19,7 @@ public sealed class RiderQueryService : IRiderQueryService
     /// <summary>
     /// Maximum age of location data to consider "fresh" (in minutes).
     /// </summary>
-    private const int MaxLocationAgeMinutes = 5;
+    private const int MaxLocationAgeMinutes = 10;
 
     public RiderQueryService(
         UsersDbContext dbContext,


### PR DESCRIPTION
The quote API returned "No delivery options available" whenever Google's distance API hiccupped, even with an available own-fleet rider: pricing returned Failure, the own-fleet quote went null, and the handler silently fell through to 3PL (which then also returned nothing).

DeliveryPricingCalculator now falls back to a Haversine straight-line distance x detour factor (configurable, default 1.4) plus a city-speed time estimate when the distance API fails, so a transient Google error can no longer deny an own-fleet quote.

Also raise the rider location freshness window from 5 to 10 minutes so riders with slightly stale pings stay quote-eligible.