### PR TITLE
feat(delivery): add rider-eligibility diagnostic endpoint

### DIFF
--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/DTOs/RiderEligibilityDiagnosticsDto.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/DTOs/RiderEligibilityDiagnosticsDto.cs
@@ -1,0 +1,17 @@
+using RallyAPI.SharedKernel.Abstractions.Riders;
+
+namespace RallyAPI.Delivery.Application.DTOs;
+
+/// <summary>
+/// Result of the rider-eligibility diagnostic: every evaluated rider plus a summary,
+/// so ops can see who would receive an offer for a pickup and why the rest are excluded.
+/// </summary>
+public sealed record RiderEligibilityDiagnosticsDto
+{
+    public required double PickupLatitude { get; init; }
+    public required double PickupLongitude { get; init; }
+    public required double RadiusKm { get; init; }
+    public required int TotalEvaluated { get; init; }
+    public required int EligibleCount { get; init; }
+    public required IReadOnlyList<RiderEligibilityReport> Riders { get; init; }
+}

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Queries/DiagnoseRiderEligibility/DiagnoseRiderEligibilityQuery.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Queries/DiagnoseRiderEligibility/DiagnoseRiderEligibilityQuery.cs
@@ -1,0 +1,16 @@
+using MediatR;
+using RallyAPI.Delivery.Application.DTOs;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Delivery.Application.Queries.DiagnoseRiderEligibility;
+
+/// <summary>
+/// Diagnoses why riders would or would not receive a delivery offer for a pickup
+/// location. When <see cref="RiderId"/> is set, reports just that rider; otherwise
+/// sweeps all riders. <see cref="RadiusKm"/> defaults to the dispatch search radius.
+/// </summary>
+public sealed record DiagnoseRiderEligibilityQuery(
+    double PickupLatitude,
+    double PickupLongitude,
+    double? RadiusKm,
+    Guid? RiderId) : IRequest<Result<RiderEligibilityDiagnosticsDto>>;

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Queries/DiagnoseRiderEligibility/DiagnoseRiderEligibilityQueryHandler.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Queries/DiagnoseRiderEligibility/DiagnoseRiderEligibilityQueryHandler.cs
@@ -1,0 +1,58 @@
+using MediatR;
+using Microsoft.Extensions.Options;
+using RallyAPI.Delivery.Application.DTOs;
+using RallyAPI.Delivery.Application.Services;
+using RallyAPI.SharedKernel.Abstractions.Riders;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Delivery.Application.Queries.DiagnoseRiderEligibility;
+
+public sealed class DiagnoseRiderEligibilityQueryHandler
+    : IRequestHandler<DiagnoseRiderEligibilityQuery, Result<RiderEligibilityDiagnosticsDto>>
+{
+    private readonly IRiderQueryService _riderQueryService;
+    private readonly DispatchOptions _dispatchOptions;
+
+    public DiagnoseRiderEligibilityQueryHandler(
+        IRiderQueryService riderQueryService,
+        IOptions<DispatchOptions> dispatchOptions)
+    {
+        _riderQueryService = riderQueryService;
+        _dispatchOptions = dispatchOptions.Value;
+    }
+
+    public async Task<Result<RiderEligibilityDiagnosticsDto>> Handle(
+        DiagnoseRiderEligibilityQuery request,
+        CancellationToken cancellationToken)
+    {
+        // Default to the same radius real dispatch uses, so the diagnostic matches
+        // production behavior unless the caller deliberately widens it.
+        var radiusKm = request.RadiusKm ?? _dispatchOptions.SearchRadiusKm;
+
+        IReadOnlyList<RiderEligibilityReport> reports = request.RiderId.HasValue
+            ? new[]
+            {
+                await _riderQueryService.DiagnoseEligibilityAsync(
+                    request.RiderId.Value,
+                    request.PickupLatitude,
+                    request.PickupLongitude,
+                    radiusKm,
+                    cancellationToken)
+            }
+            : await _riderQueryService.DiagnoseAllRidersAsync(
+                request.PickupLatitude,
+                request.PickupLongitude,
+                radiusKm,
+                ct: cancellationToken);
+
+        return Result.Success(new RiderEligibilityDiagnosticsDto
+        {
+            PickupLatitude = request.PickupLatitude,
+            PickupLongitude = request.PickupLongitude,
+            RadiusKm = radiusKm,
+            TotalEvaluated = reports.Count,
+            EligibleCount = reports.Count(r => r.Eligible),
+            Riders = reports
+        });
+    }
+}

--- a/src/Modules/Delivery/RallyAPI.Delivery.Endpoints/AdminDeliveryEndpoints.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Endpoints/AdminDeliveryEndpoints.cs
@@ -4,6 +4,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using RallyAPI.Delivery.Application.Commands.PushOtpsToProvider;
 using RallyAPI.Delivery.Application.Commands.RefreshDeliveryStatus;
+using RallyAPI.Delivery.Application.DTOs;
+using RallyAPI.Delivery.Application.Queries.DiagnoseRiderEligibility;
 using RallyAPI.SharedKernel.Extensions;
 
 namespace RallyAPI.Delivery.Endpoints;
@@ -32,7 +34,35 @@ public static class AdminDeliveryEndpoints
             .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status404NotFound);
 
+        group.MapGet("/diagnostics/rider-eligibility", DiagnoseRiderEligibility)
+            .WithName("DiagnoseRiderEligibility")
+            .WithSummary("Explain why riders would or would not receive an offer for a pickup location")
+            .WithDescription(
+                "Runs every offer-eligibility gate (active, online, KYC, not-on-delivery, has-location, "
+                + "location-fresh, within-radius) for each rider and reports pass/fail with actual values. "
+                + "Omit riderId to sweep all riders; pass riderId to inspect one. radiusKm defaults to the "
+                + "dispatch search radius.")
+            .RequireAuthorization("Admin")
+            .Produces<RiderEligibilityDiagnosticsDto>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status403Forbidden);
+
         return app;
+    }
+
+    private static async Task<IResult> DiagnoseRiderEligibility(
+        double pickupLat,
+        double pickupLng,
+        ISender sender,
+        CancellationToken ct,
+        double? radiusKm = null,
+        Guid? riderId = null)
+    {
+        var query = new DiagnoseRiderEligibilityQuery(pickupLat, pickupLng, radiusKm, riderId);
+        var result = await sender.Send(query, ct);
+
+        return result.IsSuccess
+            ? Results.Ok(result.Value)
+            : result.Error.ToErrorResult();
     }
 
     private static async Task<IResult> RefreshStatus(

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Services/RiderQueryService.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Services/RiderQueryService.cs
@@ -199,6 +199,156 @@ public sealed class RiderQueryService : IRiderQueryService
         };
     }
 
+    /// <inheritdoc />
+    public async Task<RiderEligibilityReport> DiagnoseEligibilityAsync(
+        Guid riderId,
+        double pickupLatitude,
+        double pickupLongitude,
+        double radiusKm,
+        CancellationToken ct = default)
+    {
+        var rider = await _dbContext.Riders
+            .AsNoTracking()
+            .Where(r => r.Id == riderId)
+            .Select(r => new RiderEligibilitySnapshot
+            {
+                Id = r.Id,
+                Name = r.Name,
+                IsActive = r.IsActive,
+                IsOnline = r.IsOnline,
+                KycStatus = r.KycStatus.ToString(),
+                CurrentDeliveryId = r.CurrentDeliveryId,
+                Latitude = r.CurrentLatitude.HasValue ? (double)r.CurrentLatitude.Value : null,
+                Longitude = r.CurrentLongitude.HasValue ? (double)r.CurrentLongitude.Value : null,
+                LastLocationUpdate = r.LastLocationUpdate
+            })
+            .FirstOrDefaultAsync(ct);
+
+        if (rider is null)
+        {
+            return new RiderEligibilityReport
+            {
+                RiderId = riderId,
+                Found = false,
+                Eligible = false,
+                Checks = [],
+                FailedChecks = ["Exists"]
+            };
+        }
+
+        return BuildReport(rider, pickupLatitude, pickupLongitude, radiusKm);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<RiderEligibilityReport>> DiagnoseAllRidersAsync(
+        double pickupLatitude,
+        double pickupLongitude,
+        double radiusKm,
+        int maxRiders = 200,
+        CancellationToken ct = default)
+    {
+        // Intentionally NOT pre-filtered by location/online — the whole point of the
+        // diagnostic is to surface WHY a rider is excluded (e.g. a far-away or offline
+        // rider), so we evaluate every rider and let the gates explain themselves.
+        var riders = await _dbContext.Riders
+            .AsNoTracking()
+            .OrderByDescending(r => r.IsOnline)
+            .ThenBy(r => r.Name)
+            .Take(maxRiders)
+            .Select(r => new RiderEligibilitySnapshot
+            {
+                Id = r.Id,
+                Name = r.Name,
+                IsActive = r.IsActive,
+                IsOnline = r.IsOnline,
+                KycStatus = r.KycStatus.ToString(),
+                CurrentDeliveryId = r.CurrentDeliveryId,
+                Latitude = r.CurrentLatitude.HasValue ? (double)r.CurrentLatitude.Value : null,
+                Longitude = r.CurrentLongitude.HasValue ? (double)r.CurrentLongitude.Value : null,
+                LastLocationUpdate = r.LastLocationUpdate
+            })
+            .ToListAsync(ct);
+
+        return riders
+            .Select(r => BuildReport(r, pickupLatitude, pickupLongitude, radiusKm))
+            // Eligible first, then closest to pickup.
+            .OrderByDescending(r => r.Eligible)
+            .ThenBy(r => r.DistanceToPickupKm ?? double.MaxValue)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Evaluates every offer-eligibility gate for one rider, in the same order
+    /// <see cref="GetAvailableRidersAsync"/> applies them. Single source of truth for
+    /// both diagnostic entry points.
+    /// </summary>
+    private static RiderEligibilityReport BuildReport(
+        RiderEligibilitySnapshot r,
+        double pickupLatitude,
+        double pickupLongitude,
+        double radiusKm)
+    {
+        var locationCutoff = DateTime.UtcNow.AddMinutes(-MaxLocationAgeMinutes);
+        var hasLocation = r.Latitude.HasValue && r.Longitude.HasValue;
+
+        double? distanceKm = hasLocation
+            ? Math.Round(GeoCalculator.CalculateDistanceKm(
+                pickupLatitude, pickupLongitude, r.Latitude!.Value, r.Longitude!.Value), 2)
+            : null;
+
+        var locationAgeText = r.LastLocationUpdate.HasValue
+            ? $"{(DateTime.UtcNow - r.LastLocationUpdate.Value).TotalMinutes:F1} min ago"
+            : "never";
+
+        var checks = new List<RiderEligibilityCheck>
+        {
+            new() { Name = "IsActive", Passed = r.IsActive,
+                Actual = r.IsActive.ToString(), Requirement = "true" },
+            new() { Name = "IsOnline", Passed = r.IsOnline,
+                Actual = r.IsOnline.ToString(), Requirement = "true" },
+            new() { Name = "KycVerified", Passed = r.KycStatus == "Verified",
+                Actual = r.KycStatus, Requirement = "Verified" },
+            new() { Name = "NotOnAnotherDelivery", Passed = r.CurrentDeliveryId is null,
+                Actual = r.CurrentDeliveryId?.ToString() ?? "null", Requirement = "null (no active delivery)" },
+            new() { Name = "HasLocation", Passed = hasLocation,
+                Actual = hasLocation ? $"({r.Latitude}, {r.Longitude})" : "missing",
+                Requirement = "lat/lng present" },
+            new() { Name = "LocationFresh",
+                Passed = r.LastLocationUpdate.HasValue && r.LastLocationUpdate.Value >= locationCutoff,
+                Actual = locationAgeText, Requirement = $"within {MaxLocationAgeMinutes} min" },
+            new() { Name = "WithinSearchRadius",
+                Passed = distanceKm.HasValue && distanceKm.Value <= radiusKm,
+                Actual = distanceKm.HasValue ? $"{distanceKm.Value} km" : "unknown (no location)",
+                Requirement = $"<= {radiusKm} km from pickup" }
+        };
+
+        var failed = checks.Where(c => !c.Passed).Select(c => c.Name).ToList();
+
+        return new RiderEligibilityReport
+        {
+            RiderId = r.Id,
+            RiderName = r.Name,
+            Found = true,
+            Eligible = failed.Count == 0,
+            DistanceToPickupKm = distanceKm,
+            Checks = checks,
+            FailedChecks = failed
+        };
+    }
+
+    private sealed class RiderEligibilitySnapshot
+    {
+        public Guid Id { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public bool IsActive { get; init; }
+        public bool IsOnline { get; init; }
+        public string KycStatus { get; init; } = string.Empty;
+        public Guid? CurrentDeliveryId { get; init; }
+        public double? Latitude { get; init; }
+        public double? Longitude { get; init; }
+        public DateTime? LastLocationUpdate { get; init; }
+    }
+
     /// <summary>
     /// Creates a display name (first name + last initial).
     /// "Rahul Kumar" → "Rahul K."

--- a/src/RallyAPI.SharedKernel/Abstractions/Riders/IRiderQueryService.cs
+++ b/src/RallyAPI.SharedKernel/Abstractions/Riders/IRiderQueryService.cs
@@ -64,6 +64,31 @@ public interface IRiderQueryService
     Task<RiderPublicInfo?> GetRiderPublicInfoAsync(
         Guid riderId,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Diagnoses why a specific rider would or would not receive a delivery offer
+    /// for the given pickup location. Runs every gate used by
+    /// <see cref="GetAvailableRidersAsync"/> and reports each one's pass/fail with
+    /// the rider's actual value. Ops/debug only.
+    /// </summary>
+    Task<RiderEligibilityReport> DiagnoseEligibilityAsync(
+        Guid riderId,
+        double pickupLatitude,
+        double pickupLongitude,
+        double radiusKm,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Runs the eligibility diagnostic across all riders (capped) for a pickup
+    /// location, so callers can see at a glance which riders are eligible and why
+    /// the rest are excluded. Ops/debug only.
+    /// </summary>
+    Task<IReadOnlyList<RiderEligibilityReport>> DiagnoseAllRidersAsync(
+        double pickupLatitude,
+        double pickupLongitude,
+        double radiusKm,
+        int maxRiders = 200,
+        CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/RallyAPI.SharedKernel/Abstractions/Riders/RiderEligibilityReport.cs
+++ b/src/RallyAPI.SharedKernel/Abstractions/Riders/RiderEligibilityReport.cs
@@ -1,0 +1,42 @@
+namespace RallyAPI.SharedKernel.Abstractions.Riders;
+
+/// <summary>
+/// Diagnostic report explaining whether a rider is eligible to receive a delivery
+/// offer for a given pickup location, and exactly which gate(s) failed if not.
+/// Mirrors the filters applied by <see cref="IRiderQueryService.GetAvailableRidersAsync"/>.
+/// </summary>
+public sealed record RiderEligibilityReport
+{
+    public required Guid RiderId { get; init; }
+    public string? RiderName { get; init; }
+
+    /// <summary>False when no rider exists with this id.</summary>
+    public bool Found { get; init; }
+
+    /// <summary>True only when every check passed — i.e. the rider would receive an offer.</summary>
+    public bool Eligible { get; init; }
+
+    /// <summary>Straight-line distance from the rider's last known location to the pickup, in km.</summary>
+    public double? DistanceToPickupKm { get; init; }
+
+    /// <summary>Every gate evaluated, in dispatch order.</summary>
+    public IReadOnlyList<RiderEligibilityCheck> Checks { get; init; } = [];
+
+    /// <summary>Names of the gates that failed (empty when eligible).</summary>
+    public IReadOnlyList<string> FailedChecks { get; init; } = [];
+}
+
+/// <summary>
+/// A single eligibility gate result.
+/// </summary>
+public sealed record RiderEligibilityCheck
+{
+    public required string Name { get; init; }
+    public required bool Passed { get; init; }
+
+    /// <summary>The rider's actual value for this gate (human-readable).</summary>
+    public string? Actual { get; init; }
+
+    /// <summary>What the gate requires to pass (human-readable).</summary>
+    public string? Requirement { get; init; }
+}

--- a/tests/RallyAPI.Integration.Tests/Infrastructure/IntegrationTestFactory.cs
+++ b/tests/RallyAPI.Integration.Tests/Infrastructure/IntegrationTestFactory.cs
@@ -234,6 +234,19 @@ public sealed class IntegrationTestFactory : WebApplicationFactory<Program>, IAs
 
         public Task<RiderPublicInfo?> GetRiderPublicInfoAsync(Guid riderId, CancellationToken ct = default)
             => Task.FromResult<RiderPublicInfo?>(null);
+
+        public Task<RiderEligibilityReport> DiagnoseEligibilityAsync(
+            Guid riderId, double pickupLatitude, double pickupLongitude, double radiusKm,
+            CancellationToken ct = default)
+            => Task.FromResult(new RiderEligibilityReport
+            {
+                RiderId = riderId, Found = false, Eligible = false
+            });
+
+        public Task<IReadOnlyList<RiderEligibilityReport>> DiagnoseAllRidersAsync(
+            double pickupLatitude, double pickupLongitude, double radiusKm, int maxRiders = 200,
+            CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<RiderEligibilityReport>>(Array.Empty<RiderEligibilityReport>());
     }
 
     private sealed class StubDeliveryPricingCalculator : IDeliveryPricingCalculator


### PR DESCRIPTION
Adds GET /api/deliveries/diagnostics/rider-eligibility (admin only) to explain why a rider would or would not receive a delivery offer for a pickup location. Runs every gate real dispatch uses (active, online, KYC, not-on-delivery, has-location, location-fresh, within-radius) and reports each one's pass/fail with the rider's actual value.

Omit riderId to sweep all riders (eligible first, then closest); pass riderId to inspect one. radiusKm defaults to the dispatch search radius. This automates diffing two riders to find why one gets offers and another doesn't.

Gate logic lives in a single BuildReport helper in RiderQueryService that mirrors GetAvailableRidersAsync and reuses the same freshness window, so the diagnostic can't drift from production dispatch behavior.