### PR TITLE
fix(delivery): unblock own-fleet rider arrival + enforce OTP validation

### DIFF
--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Behaviors/ValidationBehavior.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Behaviors/ValidationBehavior.cs
@@ -1,0 +1,68 @@
+using FluentValidation;
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Delivery.Application.Behaviors;
+
+/// <summary>
+/// MediatR pipeline behavior that runs FluentValidation validators before the
+/// handler. On failure it returns a <see cref="Result"/>/<see cref="Result{T}"/>
+/// with field-level <see cref="FieldError"/> details instead of throwing, so
+/// malformed commands (e.g. a missing/non-4-digit pickup or drop code) are
+/// rejected with a clean 400 rather than reaching the handler.
+/// </summary>
+public sealed class ValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : class
+{
+    private readonly IEnumerable<IValidator<TRequest>> _validators;
+
+    public ValidationBehavior(IEnumerable<IValidator<TRequest>> validators)
+    {
+        _validators = validators;
+    }
+
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        if (!_validators.Any())
+            return await next();
+
+        var context = new ValidationContext<TRequest>(request);
+
+        var validationResults = await Task.WhenAll(
+            _validators.Select(v => v.ValidateAsync(context, cancellationToken)));
+
+        var failures = validationResults
+            .SelectMany(r => r.Errors)
+            .Where(f => f is not null)
+            .ToList();
+
+        if (failures.Count == 0)
+            return await next();
+
+        var fieldErrors = failures
+            .Select(f => new FieldError(f.PropertyName, f.ErrorMessage))
+            .ToList();
+
+        var error = Error.ValidationFailed(fieldErrors);
+
+        if (typeof(TResponse).IsGenericType &&
+            typeof(TResponse).GetGenericTypeDefinition() == typeof(Result<>))
+        {
+            var resultType = typeof(TResponse).GetGenericArguments()[0];
+            var failureMethod = typeof(Result)
+                .GetMethods()
+                .First(m => m.Name == "Failure" && m.IsGenericMethod)
+                .MakeGenericMethod(resultType);
+
+            return (TResponse)failureMethod.Invoke(null, new object[] { error })!;
+        }
+
+        if (typeof(TResponse) == typeof(Result))
+            return (TResponse)(object)Result.Failure(error);
+
+        throw new ValidationException(failures);
+    }
+}

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/MarkDelivered/MarkDeliveredCommandHandler.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/MarkDelivered/MarkDeliveredCommandHandler.cs
@@ -65,7 +65,8 @@ public sealed class MarkDeliveredCommandHandler : IRequestHandler<MarkDeliveredC
         }
     }
 
-    private static bool CodeMatches(string? expected, string submitted) =>
+    private static bool CodeMatches(string? expected, string? submitted) =>
         !string.IsNullOrWhiteSpace(expected) &&
+        !string.IsNullOrWhiteSpace(submitted) &&
         string.Equals(expected.Trim(), submitted.Trim(), StringComparison.Ordinal);
 }

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/MarkPickedUp/MarkPickedUpCommandHandler.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/MarkPickedUp/MarkPickedUpCommandHandler.cs
@@ -55,7 +55,8 @@ public sealed class MarkPickedUpCommandHandler : IRequestHandler<MarkPickedUpCom
         }
     }
 
-    private static bool CodeMatches(string? expected, string submitted) =>
+    private static bool CodeMatches(string? expected, string? submitted) =>
         !string.IsNullOrWhiteSpace(expected) &&
+        !string.IsNullOrWhiteSpace(submitted) &&
         string.Equals(expected.Trim(), submitted.Trim(), StringComparison.Ordinal);
 }

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/DependencyInjection.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/DependencyInjection.cs
@@ -1,5 +1,8 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using FluentValidation;
+using MediatR;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using RallyAPI.Delivery.Application.Behaviors;
 using RallyAPI.Delivery.Application.Services;
 
 namespace RallyAPI.Delivery.Application;
@@ -10,9 +13,17 @@ public static class DependencyInjection
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        // MediatR
+        var assembly = typeof(DependencyInjection).Assembly;
+
+        // MediatR + validation pipeline
         services.AddMediatR(cfg =>
-            cfg.RegisterServicesFromAssembly(typeof(DependencyInjection).Assembly));
+        {
+            cfg.RegisterServicesFromAssembly(assembly);
+            cfg.AddBehavior(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
+        });
+
+        // FluentValidation validators (MarkPickedUp, MarkDelivered, DeclineDeliveryOffer, ...)
+        services.AddValidatorsFromAssembly(assembly);
 
         // Options
         services.Configure<PrepTimeOptions>(

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/RallyAPI.Delivery.Application.csproj
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/RallyAPI.Delivery.Application.csproj
@@ -9,6 +9,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentValidation" Version="11.9.0" />
+		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
 		<PackageReference Include="MediatR" Version="12.4.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
 	</ItemGroup>

--- a/src/Modules/Delivery/RallyAPI.Delivery.Domain/Entities/DeliveryRequest.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Domain/Entities/DeliveryRequest.cs
@@ -310,7 +310,13 @@ public sealed class DeliveryRequest : AggregateRoot
 
     public void MarkRiderArrivedPickup()
     {
-        EnsureStatus(DeliveryRequestStatus.RiderEnRoutePickup);
+        // Own-fleet riders go straight from RiderAssigned to arrived — the rider
+        // app has no separate "en route to pickup" step (only 3PL callbacks set
+        // RiderEnRoutePickup). Accept the assigned states so arrival isn't blocked.
+        EnsureStatus(
+            DeliveryRequestStatus.RiderAssigned,
+            DeliveryRequestStatus.Assigned3PL,
+            DeliveryRequestStatus.RiderEnRoutePickup);
 
         Status = DeliveryRequestStatus.RiderArrivedPickup;
         ArrivedPickupAt = DateTime.UtcNow;

--- a/tests/Modules/Delivery/RallyAPI.Delivery.Application.Tests/MarkPickedUpCommandHandlerTests.cs
+++ b/tests/Modules/Delivery/RallyAPI.Delivery.Application.Tests/MarkPickedUpCommandHandlerTests.cs
@@ -69,6 +69,32 @@ public class MarkPickedUpCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_WhenPickupCodeIsNull_ShouldFailCleanlyNotThrow()
+    {
+        // A null/missing code must be rejected as an invalid code, not blow up
+        // with a NullReferenceException (500). Validation normally catches this,
+        // but the handler must be null-safe on its own.
+        var riderId = Guid.NewGuid();
+        var delivery = BuildArrivedAtPickup(riderId);
+
+        _repository.GetByIdAsync(delivery.Id, Arg.Any<CancellationToken>()).Returns(delivery);
+
+        var command = new MarkPickedUpCommand
+        {
+            DeliveryRequestId = delivery.Id,
+            RiderId = riderId,
+            PickupCode = null!
+        };
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Message.Should().Contain("Invalid pickup code");
+        delivery.Status.Should().Be(DeliveryRequestStatus.RiderArrivedPickup);
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<DeliveryRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Handle_WhenRiderNotAssigned_ShouldFailBeforeCodeCheck()
     {
         var assignedRider = Guid.NewGuid();

--- a/tests/Modules/Delivery/RallyAPI.Delivery.Application.Tests/OwnFleetDeliveryLifecycleTests.cs
+++ b/tests/Modules/Delivery/RallyAPI.Delivery.Application.Tests/OwnFleetDeliveryLifecycleTests.cs
@@ -1,0 +1,132 @@
+using FluentAssertions;
+using Xunit;
+using RallyAPI.Delivery.Domain.Entities;
+using RallyAPI.Delivery.Domain.Enums;
+
+namespace RallyAPI.Delivery.Application.Tests;
+
+/// <summary>
+/// Regression tests for the own-fleet rider delivery lifecycle.
+///
+/// Own-fleet riders (the rider web app) have no "en route to pickup" step —
+/// only 3PL/ProRouting callbacks set <see cref="DeliveryRequestStatus.RiderEnRoutePickup"/>.
+/// After accepting an offer the request sits at <see cref="DeliveryRequestStatus.RiderAssigned"/>,
+/// so every status transition the rider drives must be reachable from there.
+///
+/// The four rider endpoints under test:
+///   1. arrived-pickup → MarkRiderArrivedPickup()
+///   2. pickup         → MarkPickedUp()
+///   3. arrived-drop   → MarkRiderArrivedDrop()
+///   4. delivered      → MarkDelivered()
+/// </summary>
+public class OwnFleetDeliveryLifecycleTests
+{
+    private static DeliveryRequest NewAssignedRequest()
+    {
+        var req = DeliveryRequest.Create(
+            id: Guid.NewGuid(),
+            orderId: Guid.NewGuid(),
+            orderNumber: "TEST-0001",
+            quoteId: null,
+            quotedPrice: 50m,
+            pickupLat: 28.6315, pickupLng: 77.2167, pickupPincode: "110001",
+            pickupAddress: "Restaurant", pickupContactName: "Store", pickupContactPhone: "+919999999999",
+            dropLat: 28.6129, dropLng: 77.2295, dropPincode: "110002",
+            dropAddress: "Customer", dropContactName: "Cust", dropContactPhone: "+918888888888",
+            orderCategory: OrderCategory.FoodAndBeverage);
+
+        // Own-fleet accept path: search own fleet → rider accepts → RiderAssigned.
+        req.StartSearchingOwnFleet();
+        req.AssignOwnFleetRider(Guid.NewGuid(), "Test Rider", "+917777777777");
+
+        req.Status.Should().Be(DeliveryRequestStatus.RiderAssigned);
+        return req;
+    }
+
+    // ─── 1. arrived-pickup (the reported bug) ──────────────────────────
+    [Fact]
+    public void MarkRiderArrivedPickup_DirectlyFromRiderAssigned_Succeeds()
+    {
+        // This is the exact scenario that produced:
+        // "Invalid status transition. Current: RiderAssigned, Allowed: RiderEnRoutePickup"
+        var req = NewAssignedRequest();
+
+        var act = () => req.MarkRiderArrivedPickup();
+
+        act.Should().NotThrow();
+        req.Status.Should().Be(DeliveryRequestStatus.RiderArrivedPickup);
+        req.ArrivedPickupAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void MarkRiderArrivedPickup_FromEnRoutePickup_StillSucceeds()
+    {
+        // 3PL path still works: RiderAssigned → en-route → arrived.
+        var req = NewAssignedRequest();
+        req.MarkRiderEnRoutePickup();
+
+        var act = () => req.MarkRiderArrivedPickup();
+
+        act.Should().NotThrow();
+        req.Status.Should().Be(DeliveryRequestStatus.RiderArrivedPickup);
+    }
+
+    // ─── 2. pickup ─────────────────────────────────────────────────────
+    [Fact]
+    public void MarkPickedUp_FromArrivedPickup_Succeeds()
+    {
+        var req = NewAssignedRequest();
+        req.MarkRiderArrivedPickup();
+
+        var act = () => req.MarkPickedUp();
+
+        act.Should().NotThrow();
+        req.Status.Should().Be(DeliveryRequestStatus.PickedUp);
+        req.PickedUpAt.Should().NotBeNull();
+    }
+
+    // ─── 3. arrived-drop ───────────────────────────────────────────────
+    [Fact]
+    public void MarkRiderArrivedDrop_FromPickedUp_Succeeds()
+    {
+        var req = NewAssignedRequest();
+        req.MarkRiderArrivedPickup();
+        req.MarkPickedUp();
+
+        var act = () => req.MarkRiderArrivedDrop();
+
+        act.Should().NotThrow();
+        req.Status.Should().Be(DeliveryRequestStatus.RiderArrivedDrop);
+        req.ArrivedDropAt.Should().NotBeNull();
+    }
+
+    // ─── 4. delivered ──────────────────────────────────────────────────
+    [Fact]
+    public void MarkDelivered_FromArrivedDrop_Succeeds()
+    {
+        var req = NewAssignedRequest();
+        req.MarkRiderArrivedPickup();
+        req.MarkPickedUp();
+        req.MarkRiderArrivedDrop();
+
+        var act = () => req.MarkDelivered();
+
+        act.Should().NotThrow();
+        req.Status.Should().Be(DeliveryRequestStatus.Delivered);
+        req.DeliveredAt.Should().NotBeNull();
+    }
+
+    // ─── Full chain — the whole own-fleet flow, end to end ─────────────
+    [Fact]
+    public void FullOwnFleetLifecycle_FromAssignedToDelivered_DrivesCleanly()
+    {
+        var req = NewAssignedRequest();
+
+        req.MarkRiderArrivedPickup();
+        req.MarkPickedUp();
+        req.MarkRiderArrivedDrop();
+        req.MarkDelivered();
+
+        req.Status.Should().Be(DeliveryRequestStatus.Delivered);
+    }
+}


### PR DESCRIPTION
Own-fleet riders sit at RiderAssigned after accepting an offer (the rider app has no "en route to pickup" step — only 3PL callbacks set RiderEnRoutePickup). MarkRiderArrivedPickup required exactly RiderEnRoutePickup, so arrival threw "Invalid status transition. Current: RiderAssigned, Allowed: RiderEnRoutePickup" (400). Allow RiderAssigned / Assigned3PL, mirroring MarkRiderArrivedDrop which already tolerates the skip.

Also harden the pickup/drop OTP path:
- The Delivery module never registered its FluentValidation validators or a ValidationBehavior pipeline, so MarkPickedUp/MarkDelivered validators were dead code. Add the behavior + AddValidatorsFromAssembly (and the missing FluentValidation.DependencyInjectionExtensions package), matching the other modules.
- CodeMatches called submitted.Trim() without a null check, so a null code threw NullReferenceException (500) instead of a clean rejection. Make the matcher null-safe in both handlers.

Tests: full own-fleet lifecycle (arrived-pickup -> pickup -> arrived-drop ->
delivered) and a null pickup-code regression test. 54 passing.