### PR TITLE
feat(users): add owner & rider payout bank-details endpoints

### DIFF
--- a/src/Modules/Users/RallyAPI.Users.Application/Admins/Queries/GetRiderOverview/GetRiderOverviewQuery.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Admins/Queries/GetRiderOverview/GetRiderOverviewQuery.cs
@@ -39,4 +39,9 @@ public sealed record RiderOverviewResponse(
 
     // Ratings — placeholder until rider ratings module ships
     decimal AverageRating,
-    int TotalRatings);
+    int TotalRatings,
+
+    // Payout bank details — account number masked (last 4 only)
+    string? BankAccountNumber,
+    string? BankIfscCode,
+    string? BankAccountName);

--- a/src/Modules/Users/RallyAPI.Users.Application/Admins/Queries/GetRiderOverview/GetRiderOverviewQueryHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Admins/Queries/GetRiderOverview/GetRiderOverviewQueryHandler.cs
@@ -71,6 +71,17 @@ internal sealed class GetRiderOverviewQueryHandler
             // No rider ratings module yet — returning zeros is honest.
             // Will populate when the ratings aggregate ships.
             AverageRating: 0m,
-            TotalRatings: 0);
+            TotalRatings: 0,
+
+            BankAccountNumber: Mask(rider.BankAccountNumber),
+            BankIfscCode: rider.BankIfscCode,
+            BankAccountName: rider.BankAccountName);
+    }
+
+    private static string? Mask(string? accountNumber)
+    {
+        if (string.IsNullOrEmpty(accountNumber) || accountNumber.Length < 4)
+            return accountNumber;
+        return new string('*', accountNumber.Length - 4) + accountNumber[^4..];
     }
 }

--- a/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/UpdateBankDetails/UpdateOwnerBankDetailsCommand.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/UpdateBankDetails/UpdateOwnerBankDetailsCommand.cs
@@ -1,0 +1,14 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Users.Application.Owners.Commands.UpdateBankDetails;
+
+/// <summary>
+/// Update a restaurant owner's payout bank details. Used by the owner (self, via JWT sub)
+/// and by an admin (targeting an arbitrary owner). All three fields are required together.
+/// </summary>
+public sealed record UpdateOwnerBankDetailsCommand(
+    Guid OwnerId,
+    string BankAccountNumber,
+    string BankIfscCode,
+    string BankAccountName) : IRequest<Result>;

--- a/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/UpdateBankDetails/UpdateOwnerBankDetailsCommandHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/UpdateBankDetails/UpdateOwnerBankDetailsCommandHandler.cs
@@ -1,0 +1,40 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Application.Abstractions;
+
+namespace RallyAPI.Users.Application.Owners.Commands.UpdateBankDetails;
+
+internal sealed class UpdateOwnerBankDetailsCommandHandler
+    : IRequestHandler<UpdateOwnerBankDetailsCommand, Result>
+{
+    private readonly IRestaurantOwnerRepository _ownerRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public UpdateOwnerBankDetailsCommandHandler(
+        IRestaurantOwnerRepository ownerRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _ownerRepository = ownerRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result> Handle(
+        UpdateOwnerBankDetailsCommand request,
+        CancellationToken cancellationToken)
+    {
+        var owner = await _ownerRepository.GetByIdAsync(request.OwnerId, cancellationToken);
+        if (owner is null)
+            return Result.Failure(Error.NotFound("RestaurantOwner", request.OwnerId));
+
+        var result = owner.UpdateBankDetails(
+            request.BankAccountNumber,
+            request.BankIfscCode,
+            request.BankAccountName);
+
+        if (result.IsFailure)
+            return result;
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+        return Result.Success();
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/UpdateBankDetails/UpdateOwnerBankDetailsCommandValidator.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Owners/Commands/UpdateBankDetails/UpdateOwnerBankDetailsCommandValidator.cs
@@ -1,0 +1,25 @@
+using FluentValidation;
+
+namespace RallyAPI.Users.Application.Owners.Commands.UpdateBankDetails;
+
+public sealed class UpdateOwnerBankDetailsCommandValidator
+    : AbstractValidator<UpdateOwnerBankDetailsCommand>
+{
+    public UpdateOwnerBankDetailsCommandValidator()
+    {
+        RuleFor(x => x.OwnerId)
+            .NotEmpty().WithMessage("Owner ID is required.");
+
+        RuleFor(x => x.BankAccountNumber)
+            .NotEmpty().WithMessage("Bank account number is required.")
+            .MaximumLength(20).WithMessage("Bank account number is too long.");
+
+        RuleFor(x => x.BankIfscCode)
+            .NotEmpty().WithMessage("IFSC code is required.")
+            .Length(11).WithMessage("IFSC code must be exactly 11 characters.");
+
+        RuleFor(x => x.BankAccountName)
+            .NotEmpty().WithMessage("Account holder name is required.")
+            .MaximumLength(255).WithMessage("Account holder name is too long.");
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Riders/Commands/UpdateBankDetails/UpdateRiderBankDetailsCommand.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Riders/Commands/UpdateBankDetails/UpdateRiderBankDetailsCommand.cs
@@ -1,0 +1,13 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Users.Application.Riders.Commands.UpdateBankDetails;
+
+/// <summary>
+/// Rider updates their payout bank details. All three fields are required together.
+/// </summary>
+public sealed record UpdateRiderBankDetailsCommand(
+    Guid RiderId,
+    string BankAccountNumber,
+    string BankIfscCode,
+    string BankAccountName) : IRequest<Result>;

--- a/src/Modules/Users/RallyAPI.Users.Application/Riders/Commands/UpdateBankDetails/UpdateRiderBankDetailsCommandHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Riders/Commands/UpdateBankDetails/UpdateRiderBankDetailsCommandHandler.cs
@@ -1,0 +1,40 @@
+using MediatR;
+using RallyAPI.SharedKernel.Results;
+using RallyAPI.Users.Application.Abstractions;
+
+namespace RallyAPI.Users.Application.Riders.Commands.UpdateBankDetails;
+
+internal sealed class UpdateRiderBankDetailsCommandHandler
+    : IRequestHandler<UpdateRiderBankDetailsCommand, Result>
+{
+    private readonly IRiderRepository _riderRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public UpdateRiderBankDetailsCommandHandler(
+        IRiderRepository riderRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _riderRepository = riderRepository;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result> Handle(
+        UpdateRiderBankDetailsCommand request,
+        CancellationToken cancellationToken)
+    {
+        var rider = await _riderRepository.GetByIdAsync(request.RiderId, cancellationToken);
+        if (rider is null)
+            return Result.Failure(Error.NotFound("Rider", request.RiderId));
+
+        var result = rider.UpdateBankDetails(
+            request.BankAccountNumber,
+            request.BankIfscCode,
+            request.BankAccountName);
+
+        if (result.IsFailure)
+            return result;
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+        return Result.Success();
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Riders/Commands/UpdateBankDetails/UpdateRiderBankDetailsCommandValidator.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Riders/Commands/UpdateBankDetails/UpdateRiderBankDetailsCommandValidator.cs
@@ -1,0 +1,25 @@
+using FluentValidation;
+
+namespace RallyAPI.Users.Application.Riders.Commands.UpdateBankDetails;
+
+public sealed class UpdateRiderBankDetailsCommandValidator
+    : AbstractValidator<UpdateRiderBankDetailsCommand>
+{
+    public UpdateRiderBankDetailsCommandValidator()
+    {
+        RuleFor(x => x.RiderId)
+            .NotEmpty().WithMessage("Rider ID is required.");
+
+        RuleFor(x => x.BankAccountNumber)
+            .NotEmpty().WithMessage("Bank account number is required.")
+            .MaximumLength(20).WithMessage("Bank account number is too long.");
+
+        RuleFor(x => x.BankIfscCode)
+            .NotEmpty().WithMessage("IFSC code is required.")
+            .Length(11).WithMessage("IFSC code must be exactly 11 characters.");
+
+        RuleFor(x => x.BankAccountName)
+            .NotEmpty().WithMessage("Account holder name is required.")
+            .MaximumLength(255).WithMessage("Account holder name is too long.");
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Application/Riders/Queries/GetProfile/GetRiderProfileQuery.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Riders/Queries/GetProfile/GetRiderProfileQuery.cs
@@ -16,4 +16,7 @@ public sealed record RiderProfileResponse(
     bool IsActive,
     bool IsOnline,
     decimal? CurrentLatitude,
-    decimal? CurrentLongitude);
+    decimal? CurrentLongitude,
+    string? BankAccountNumber,
+    string? BankIfscCode,
+    string? BankAccountName);

--- a/src/Modules/Users/RallyAPI.Users.Application/Riders/Queries/GetProfile/GetRiderProfileQueryHandler.cs
+++ b/src/Modules/Users/RallyAPI.Users.Application/Riders/Queries/GetProfile/GetRiderProfileQueryHandler.cs
@@ -33,8 +33,18 @@ internal sealed class GetRiderProfileQueryHandler
             rider.IsActive,
             rider.IsOnline,
             rider.CurrentLatitude,
-            rider.CurrentLongitude);
+            rider.CurrentLongitude,
+            Mask(rider.BankAccountNumber),
+            rider.BankIfscCode,
+            rider.BankAccountName);
 
         return Result.Success(response);
+    }
+
+    private static string? Mask(string? accountNumber)
+    {
+        if (string.IsNullOrEmpty(accountNumber) || accountNumber.Length < 4)
+            return accountNumber;
+        return new string('*', accountNumber.Length - 4) + accountNumber[^4..];
     }
 }

--- a/src/Modules/Users/RallyAPI.Users.Domain/Entities/Rider.cs
+++ b/src/Modules/Users/RallyAPI.Users.Domain/Entities/Rider.cs
@@ -16,6 +16,15 @@ public sealed class Rider : AggregateRoot
     public KycStatus KycStatus { get; private set; }
     public bool IsActive { get; private set; }
     public bool IsOnline { get; private set; }
+
+    /// <summary>Bank account number for weekly payout disbursement. Null until the rider sets it.</summary>
+    public string? BankAccountNumber { get; private set; }
+
+    /// <summary>IFSC code of the payout bank branch (11 chars).</summary>
+    public string? BankIfscCode { get; private set; }
+
+    /// <summary>Account holder name as per bank records.</summary>
+    public string? BankAccountName { get; private set; }
     public decimal? CurrentLatitude { get; private set; }
     public decimal? CurrentLongitude { get; private set; }
     public DateTime? LastLocationUpdate { get; private set; }
@@ -143,6 +152,36 @@ public sealed class Rider : AggregateRoot
         if (newStatus == KycStatus.Rejected)
             IsOnline = false;
 
+        MarkAsUpdated();
+        return Result.Success();
+    }
+
+    public Result UpdateBankDetails(string accountNumber, string ifscCode, string accountName)
+    {
+        if (string.IsNullOrWhiteSpace(accountNumber))
+            return Result.Failure(Error.Validation("Bank account number is required."));
+
+        if (string.IsNullOrWhiteSpace(ifscCode))
+            return Result.Failure(Error.Validation("IFSC code is required."));
+
+        if (string.IsNullOrWhiteSpace(accountName))
+            return Result.Failure(Error.Validation("Account holder name is required."));
+
+        accountNumber = accountNumber.Trim();
+        if (accountNumber.Length > 20)
+            return Result.Failure(Error.Validation("Bank account number is too long."));
+
+        ifscCode = ifscCode.Trim().ToUpperInvariant();
+        if (ifscCode.Length != 11)
+            return Result.Failure(Error.Validation("IFSC code must be exactly 11 characters."));
+
+        accountName = accountName.Trim();
+        if (accountName.Length > 255)
+            return Result.Failure(Error.Validation("Account holder name is too long."));
+
+        BankAccountNumber = accountNumber;
+        BankIfscCode = ifscCode;
+        BankAccountName = accountName;
         MarkAsUpdated();
         return Result.Success();
     }

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Admins/UpdateOwnerBankDetails.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Admins/UpdateOwnerBankDetails.cs
@@ -1,0 +1,44 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Owners.Commands.UpdateBankDetails;
+
+namespace RallyAPI.Users.Endpoints.Admins;
+
+public class UpdateOwnerBankDetails : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPut("/api/admin/owners/{ownerId:guid}/bank", HandleAsync)
+            .WithName("AdminUpdateOwnerBankDetails")
+            .WithTags("Admins")
+            .WithSummary("Admin updates a restaurant owner's payout bank details")
+            .RequireAuthorization("Admin");
+    }
+
+    public sealed record UpdateOwnerBankRequest(
+        string BankAccountNumber,
+        string BankIfscCode,
+        string BankAccountName);
+
+    private static async Task<IResult> HandleAsync(
+        Guid ownerId,
+        UpdateOwnerBankRequest request,
+        ISender sender,
+        CancellationToken ct)
+    {
+        var command = new UpdateOwnerBankDetailsCommand(
+            ownerId,
+            request.BankAccountNumber,
+            request.BankIfscCode,
+            request.BankAccountName);
+
+        var result = await sender.Send(command, ct);
+
+        return result.IsFailure
+            ? result.Error.ToErrorResult()
+            : Results.Ok(new { message = "Bank details updated successfully" });
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Admins/UpdateRiderBankDetails.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Admins/UpdateRiderBankDetails.cs
@@ -1,0 +1,44 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Riders.Commands.UpdateBankDetails;
+
+namespace RallyAPI.Users.Endpoints.Admins;
+
+public class UpdateRiderBankDetails : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPut("/api/admin/riders/{riderId:guid}/bank", HandleAsync)
+            .WithName("AdminUpdateRiderBankDetails")
+            .WithTags("Admins")
+            .WithSummary("Admin updates a rider's payout bank details")
+            .RequireAuthorization("Admin");
+    }
+
+    public sealed record UpdateRiderBankRequest(
+        string BankAccountNumber,
+        string BankIfscCode,
+        string BankAccountName);
+
+    private static async Task<IResult> HandleAsync(
+        Guid riderId,
+        UpdateRiderBankRequest request,
+        ISender sender,
+        CancellationToken ct)
+    {
+        var command = new UpdateRiderBankDetailsCommand(
+            riderId,
+            request.BankAccountNumber,
+            request.BankIfscCode,
+            request.BankAccountName);
+
+        var result = await sender.Send(command, ct);
+
+        return result.IsFailure
+            ? result.Error.ToErrorResult()
+            : Results.Ok(new { message = "Bank details updated successfully" });
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Owners/UpdateBankDetails.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Owners/UpdateBankDetails.cs
@@ -1,0 +1,47 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Owners.Commands.UpdateBankDetails;
+using System.Security.Claims;
+
+namespace RallyAPI.Users.Endpoints.Owners;
+
+public class UpdateBankDetails : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPut("/api/owners/me/bank", HandleAsync)
+            .WithName("UpdateOwnerBankDetails")
+            .WithTags("Owners")
+            .WithSummary("Owner updates their own payout bank details")
+            .RequireAuthorization("Owner");
+    }
+
+    public sealed record UpdateOwnerBankRequest(
+        string BankAccountNumber,
+        string BankIfscCode,
+        string BankAccountName);
+
+    private static async Task<IResult> HandleAsync(
+        UpdateOwnerBankRequest request,
+        ClaimsPrincipal user,
+        ISender sender,
+        CancellationToken ct)
+    {
+        var ownerId = Guid.Parse(user.FindFirstValue("sub")!);
+
+        var command = new UpdateOwnerBankDetailsCommand(
+            ownerId,
+            request.BankAccountNumber,
+            request.BankIfscCode,
+            request.BankAccountName);
+
+        var result = await sender.Send(command, ct);
+
+        return result.IsFailure
+            ? result.Error.ToErrorResult()
+            : Results.Ok(new { message = "Bank details updated successfully" });
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/UpdateBankDetails.cs
+++ b/src/Modules/Users/RallyAPI.Users.Endpoints/Riders/UpdateBankDetails.cs
@@ -1,0 +1,46 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using RallyAPI.SharedKernel.Extensions;
+using RallyAPI.Users.Application.Riders.Commands.UpdateBankDetails;
+using System.Security.Claims;
+
+namespace RallyAPI.Users.Endpoints.Riders;
+
+public class UpdateBankDetails : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPut("/api/v1/riders/bank", HandleAsync)
+            .WithTags("Riders")
+            .WithSummary("Rider updates their payout bank details")
+            .RequireAuthorization("Rider");
+    }
+
+    public sealed record UpdateRiderBankRequest(
+        string BankAccountNumber,
+        string BankIfscCode,
+        string BankAccountName);
+
+    private static async Task<IResult> HandleAsync(
+        UpdateRiderBankRequest request,
+        ClaimsPrincipal user,
+        ISender sender,
+        CancellationToken ct)
+    {
+        var riderId = Guid.Parse(user.FindFirstValue("sub")!);
+
+        var command = new UpdateRiderBankDetailsCommand(
+            riderId,
+            request.BankAccountNumber,
+            request.BankIfscCode,
+            request.BankAccountName);
+
+        var result = await sender.Send(command, ct);
+
+        return result.IsSuccess
+            ? Results.Ok(new { message = "Bank details updated successfully" })
+            : result.Error.ToErrorResult();
+    }
+}

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Configurations/RiderConfiguration.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Configurations/RiderConfiguration.cs
@@ -84,6 +84,22 @@ namespace RallyAPI.Users.Infrastructure.Persistence.Configurations
                 .HasDefaultValue(false)
                 .IsRequired();
 
+            // Bank details (nullable — set by rider for payout)
+            builder.Property(r => r.BankAccountNumber)
+                .HasColumnName("bank_account_number")
+                .HasMaxLength(20)
+                .IsRequired(false);
+
+            builder.Property(r => r.BankIfscCode)
+                .HasColumnName("bank_ifsc_code")
+                .HasMaxLength(11)
+                .IsRequired(false);
+
+            builder.Property(r => r.BankAccountName)
+                .HasColumnName("bank_account_name")
+                .HasMaxLength(255)
+                .IsRequired(false);
+
             // Location tracking
             builder.Property(r => r.CurrentLatitude)
                 .HasColumnName("current_latitude")

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Migrations/20260703100138_AddRiderBankDetails.Designer.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Migrations/20260703100138_AddRiderBankDetails.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RallyAPI.Users.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using RallyAPI.Users.Infrastructure.Persistence;
 namespace RallyAPI.Users.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(UsersDbContext))]
-    partial class UsersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260703100138_AddRiderBankDetails")]
+    partial class AddRiderBankDetails
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Migrations/20260703100138_AddRiderBankDetails.cs
+++ b/src/Modules/Users/RallyAPI.Users.Infrastructure/Persistence/Migrations/20260703100138_AddRiderBankDetails.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RallyAPI.Users.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRiderBankDetails : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "bank_account_name",
+                schema: "users",
+                table: "riders",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "bank_account_number",
+                schema: "users",
+                table: "riders",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "bank_ifsc_code",
+                schema: "users",
+                table: "riders",
+                type: "character varying(11)",
+                maxLength: 11,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "bank_account_name",
+                schema: "users",
+                table: "riders");
+
+            migrationBuilder.DropColumn(
+                name: "bank_account_number",
+                schema: "users",
+                table: "riders");
+
+            migrationBuilder.DropColumn(
+                name: "bank_ifsc_code",
+                schema: "users",
+                table: "riders");
+        }
+    }
+}


### PR DESCRIPTION
Owners could only set bank details at creation (no update path); riders had no bank fields at all — blocking payout disbursement.

- Rider: add BankAccountNumber/BankIfscCode/BankAccountName + UpdateBankDetails() domain method, EF config, and AddRiderBankDetails migration (users.riders)
- Owner update: UpdateOwnerBankDetailsCommand + PUT /api/owners/me/bank (owner) and PUT /api/admin/owners/{ownerId}/bank (admin)
- Rider update: UpdateRiderBankDetailsCommand + PUT /api/v1/riders/bank (rider) and PUT /api/admin/riders/{riderId}/bank (admin)
- Surface masked account number (last 4) in rider profile and admin rider overview
- FluentValidation on all commands (11-char IFSC, required fields, length caps)

Verified end-to-end against local Postgres: null -> update -> masked read, invalid IFSC -> 400, cross-role token -> 403, admin override reflected.