### PR TITLE
feat(orders): add Kitchen Order Ticket (KOT) endpoint for restaurant …

### DIFF
--- a/specs/kot-print-restaurant-panel.md
+++ b/specs/kot-print-restaurant-panel.md
@@ -1,0 +1,256 @@
+# Feature Spec: Kitchen Order Ticket (KOT) Printing — Restaurant Panel
+
+> **Status**: In Progress (backend done, frontend pending)
+> **Priority**: P1 (High)
+> **Estimated Effort**: ~1.5 days frontend
+> **Module(s)**: Orders (backend done), Restaurant Dashboard (frontend)
+> **Owner**: Backend — done. Frontend — Restaurant Dashboard dev.
+> **Date**: 2026-07-03
+
+---
+
+## 1. Problem Statement
+
+Restaurants need to print a Kitchen Order Ticket (KOT) — a paper slip listing what to
+cook for each order — so kitchen staff aren't reading orders off a screen. The ticket
+must be able to **print automatically the moment a new (paid) order arrives**, and be
+**re-printable** on demand.
+
+## 2. User Stories
+
+- As a **restaurant**, I want a KOT to auto-print when a new order is paid, so the kitchen starts immediately.
+- As a **restaurant**, I want a "Print KOT" button on any order, so I can reprint a lost/smudged ticket.
+
+## 3. Acceptance Criteria
+
+- [ ] New paid order → KOT prints automatically (if auto-print is enabled).
+- [ ] "Print KOT" button on the order detail/card reprints the ticket.
+- [ ] KOT shows: order number, DELIVERY/PICKUP, placed time, item lines (qty × name), per-item + order-level notes, item count.
+- [ ] KOT shows **no pricing** (kitchen doesn't need money).
+- [ ] Auto-print can be toggled off (per-device setting) and doesn't fire twice for the same order.
+- [ ] Layout targets **80mm thermal** (the launch standard — not A4).
+
+## 4. Technical Design
+
+### API Endpoint (BACKEND — DONE)
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| GET | `/api/orders/{orderId}/kot` | `AdminOrRestaurant` | Returns `KitchenTicketDto` (kitchen-only, no pricing). 404 if not found or not the owning restaurant. |
+
+**Response shape (`KitchenTicketDto`):**
+
+```jsonc
+{
+  "orderId": "0f9c...",
+  "orderNumber": "RA-000123",
+  "fulfillmentType": "Pickup",        // enum: "Delivery" | "Pickup"
+  "fulfillmentDisplay": "PICKUP",     // pre-uppercased for the ticket header
+  "customerName": "Aditi",
+  "statusDisplay": "Paid",            // for reprint context
+  "placedAt": "2026-07-03T12:41:09Z",
+  "totalItems": 3,
+  "specialInstructions": "No onions in anything",   // nullable (order-level)
+  "items": [
+    { "itemName": "Paneer Tikka",   "quantity": 2, "specialInstructions": "Extra spicy" },
+    { "itemName": "Butter Naan",    "quantity": 1, "specialInstructions": null }
+  ]
+}
+```
+
+> Auth note: the restaurant's JWT `sub` == its `restaurantId`, and the endpoint only
+> returns tickets for that restaurant. No `restaurantId` needs to be passed by the client.
+
+### SignalR — Auto-print trigger (ALREADY EXISTS, no backend change)
+
+The dashboard already (or should) connect to the shared **`NotificationHub`** and, on
+login as a restaurant, is auto-joined to group `restaurant_{restaurantId}`.
+
+| Event name | Payload | Fires when |
+|------------|---------|-----------|
+| `NewOrderReceived` | `{ orderId, orderNumber, customerId, itemCount, totalAmount, placedAt }` | Customer **pays** (OrderPaidEvent) — this is the incoming-order alert |
+| `OrderStatusUpdate` | `{ orderId, orderNumber, status, message }` | Every later lifecycle change |
+
+**Auto-print = listen for `NewOrderReceived` → fetch `/api/orders/{orderId}/kot` → print.**
+
+SignalR connection (JWT goes on the query string for WebSocket upgrade):
+
+```ts
+import { HubConnectionBuilder } from "@microsoft/signalr";
+
+const connection = new HubConnectionBuilder()
+  .withUrl(`${API_URL}/hubs/notifications?access_token=${getAccessToken()}`)
+  .withAutomaticReconnect()
+  .build();
+```
+
+> Hub is mapped at **`/hubs/notifications`** (confirmed in Program.cs).
+> The dashboard likely already has this connection for the live orders feed — reuse it,
+> don't open a second one.
+
+### Frontend Components
+
+| Component | Page | Description |
+|-----------|------|-------------|
+| `KitchenTicket` | (print-only) | Renders `KitchenTicketDto` into the 80mm print layout |
+| `useKotPrint()` hook | shared | Fetches KOT + triggers print for a given orderId |
+| `useAutoPrintKot()` hook | Orders page | Subscribes to `NewOrderReceived`, dedupes, calls `useKotPrint` |
+| Auto-print toggle | Settings / Orders header | Per-device on/off, persisted to `localStorage` |
+
+### Print approach
+
+Use **`react-to-print`**. It clones the referenced component into its own isolated print
+document, so there's **no `body * { visibility:hidden }` hack and no separate `.css` file** —
+everything is Tailwind, per the house rule. The one thing Tailwind can't express — the 80mm
+**paper size** (`@page`) — is passed as the hook's `pageStyle` string.
+
+```tsx
+import { useReactToPrint } from "react-to-print";
+
+// 80mm thermal paper. `@page` can't be a Tailwind utility, so it lives here only.
+const KOT_PAGE_STYLE = `@page { size: 80mm auto; margin: 3mm; }`;
+
+function useKotPrint() {
+  const ref = useRef<HTMLDivElement>(null);
+  const [ticket, setTicket] = useState<KitchenTicketDto | null>(null);
+
+  const doPrint = useReactToPrint({
+    content: () => ref.current,
+    pageStyle: KOT_PAGE_STYLE,
+  });
+
+  async function printKot(orderId: string) {
+    const data = await api.get<KitchenTicketDto>(`/api/orders/${orderId}/kot`);
+    setTicket(data);
+    requestAnimationFrame(() => doPrint()); // let the ticket render, then print
+  }
+
+  return { ref, ticket, printKot };
+}
+```
+
+All styling is Tailwind. The component is rendered **hidden on screen** (`hidden`) but
+`react-to-print` still clones and prints it. Sized for a ~72mm printable width inside 80mm
+paper, monospace, pure black for thermal legibility.
+
+```tsx
+// KitchenTicket.tsx — Tailwind-only, no stylesheet. Kept in the DOM but visually hidden.
+interface KitchenTicketProps { ticket: KitchenTicketDto; }
+
+export const KitchenTicket = forwardRef<HTMLDivElement, KitchenTicketProps>(
+  ({ ticket }, ref) => (
+    // `hidden` keeps it off-screen; react-to-print unhides its clone in the print doc.
+    <div className="hidden">
+      <div
+        ref={ref}
+        className="w-[72mm] font-mono text-black leading-tight"
+      >
+        <div className="text-center">
+          <div className="text-sm font-bold tracking-widest">
+            {ticket.fulfillmentDisplay}
+          </div>
+          <h1 className="text-2xl font-extrabold my-1">#{ticket.orderNumber}</h1>
+          <div className="text-xs">{new Date(ticket.placedAt).toLocaleString()}</div>
+          <div className="text-sm font-semibold">{ticket.customerName}</div>
+        </div>
+
+        <hr className="my-2 border-black border-dashed" />
+
+        <ul className="space-y-1">
+          {ticket.items.map((it, i) => (
+            <li key={i} className="text-base">
+              <span className="font-extrabold mr-1.5">{it.quantity}×</span>
+              <span className="font-semibold">{it.itemName}</span>
+              {it.specialInstructions && (
+                <div className="pl-4 text-sm italic">↳ {it.specialInstructions}</div>
+              )}
+            </li>
+          ))}
+        </ul>
+
+        {ticket.specialInstructions && (
+          <>
+            <hr className="my-2 border-black border-dashed" />
+            <p className="text-sm italic font-semibold">** {ticket.specialInstructions} **</p>
+          </>
+        )}
+
+        <hr className="my-2 border-black border-dashed" />
+        <p className="font-extrabold">TOTAL ITEMS: {ticket.totalItems}</p>
+      </div>
+    </div>
+  )
+);
+```
+
+> If `w-[72mm]` / `mm` arbitrary values aren't already used in the project, that's the only
+> spot to sanity-check with Tailwind's config — everything else is standard utilities.
+
+### Auto-print hook
+
+```ts
+function useAutoPrintKot(enabled: boolean) {
+  const { ref, ticket, printKot } = useKotPrint();
+  const printed = useRef<Set<string>>(new Set()); // dedupe guard
+
+  useEffect(() => {
+    if (!enabled) return;
+    const onNewOrder = (p: { orderId: string }) => {
+      if (printed.current.has(p.orderId)) return;   // don't double-print
+      printed.current.add(p.orderId);
+      printKot(p.orderId).catch(console.error);
+    };
+    connection.on("NewOrderReceived", onNewOrder);
+    return () => connection.off("NewOrderReceived", onNewOrder);
+  }, [enabled]);
+
+  return { ref, ticket }; // render <KitchenTicket ref={ref} ticket={ticket}/> hidden
+}
+```
+
+## 5. Edge Cases & Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Browser blocks silent printing | First print of a session may show the OS print dialog — unavoidable in a browser. Document for the restaurant; a kiosk/Chrome "kiosk-printing" flag removes the dialog. |
+| Same order fires `NewOrderReceived` twice (reconnect/replay) | Dedupe by `orderId` (see `printed` set). |
+| SignalR drops then reconnects | `withAutomaticReconnect()` rejoins the group on reconnect; missed orders won't auto-print — the live orders list + manual "Print KOT" is the fallback. |
+| KOT fetch 404 | Order not owned by this restaurant or deleted — toast an error, do not print. |
+| Auto-print off | Only the manual button prints. Persist the toggle per device (`localStorage`). |
+
+## 6. Testing Plan
+
+- **Backend handler unit tests**: `GetKitchenTicketQueryHandler` — (a) returns ticket for owning restaurant, (b) returns NotFound for a different restaurant, (c) NotFound for missing order, (d) Admin can read any. Maps items + notes; contains no pricing fields.
+- **Frontend**: `KitchenTicket` renders qty/name/notes and hides pricing; `useAutoPrintKot` dedupes on repeated `NewOrderReceived`; manual print calls the endpoint.
+- **Manual**: real 80mm thermal printer smoke test (layout width, cut).
+
+## 7. Rollout
+
+- [ ] Per-device auto-print toggle (default OFF until validated on real hardware).
+- [ ] Metric: KOTs printed / orders received.
+- [ ] Rollback: hide the button + disable the SignalR listener; endpoint is read-only and safe to leave.
+
+---
+
+## Implementation Notes (updated during build)
+
+### Files Created/Modified (backend — 2026-07-03)
+- `Orders.Application/DTOs/KitchenTicketDto.cs` — new (`KitchenTicketDto` + `KitchenTicketItemDto`)
+- `Orders.Application/Queries/GetKitchenTicket/GetKitchenTicketQuery.cs` — new
+- `Orders.Application/Queries/GetKitchenTicket/GetKitchenTicketQueryHandler.cs` — new (auth: owning Restaurant or Admin)
+- `Orders.Application/Mappings/OrderMappingExtensions.cs` — added `ToKitchenTicket()`
+- `Orders.Endpoints/OrderEndpoints.cs` — added `GET /api/orders/{orderId}/kot`
+
+### Decisions Made
+- KOT reuses `IOrderRepository.GetByIdAsync` + a new mapping — no new persistence/read model needed.
+- Auto-print rides the **existing** `NewOrderReceived` SignalR event (fires on payment) — zero backend change for auto-print.
+- No pricing on the ticket by design.
+- **80mm thermal** is the launch standard (no A4 fallback for v1).
+- **Tailwind-only, no stylesheet** — house rule kept. `react-to-print` isolates the print
+  DOM (no visibility hack); the only non-Tailwind bit is the `@page` size, passed via the
+  hook's `pageStyle` string.
+
+### Open Questions
+- ~~Hub route path~~ → confirmed `/hubs/notifications`.
+- ~~Thermal vs A4~~ → **80mm thermal**.
+- Do we want a paper "cut" / multi-copy (one per station) later?

--- a/src/Modules/Orders/RallyAPI.Orders.Application/DTOs/KitchenTicketDto.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/DTOs/KitchenTicketDto.cs
@@ -1,0 +1,44 @@
+using RallyAPI.Orders.Domain.Enums;
+
+namespace RallyAPI.Orders.Application.DTOs;
+
+/// <summary>
+/// Kitchen Order Ticket (KOT) — the print-oriented, kitchen-facing view of an order.
+/// Deliberately omits all pricing/money fields: the kitchen only needs to know
+/// WHAT to cook, HOW MUCH, and any preparation notes.
+/// </summary>
+public sealed record KitchenTicketDto
+{
+    public Guid OrderId { get; init; }
+    public string OrderNumber { get; init; } = string.Empty;
+
+    // Fulfillment context — kitchens plate/pack differently for pickup vs delivery
+    public FulfillmentType FulfillmentType { get; init; }
+    public string FulfillmentDisplay { get; init; } = string.Empty;
+
+    // Minimal customer identity (name only — no phone/address/pricing on a KOT)
+    public string CustomerName { get; init; } = string.Empty;
+
+    // Current lifecycle status, for reprint context (e.g. "Preparing")
+    public string StatusDisplay { get; init; } = string.Empty;
+
+    // When the customer placed/paid — printed at the top of the ticket
+    public DateTime PlacedAt { get; init; }
+
+    // The lines the kitchen actually cooks
+    public IReadOnlyList<KitchenTicketItemDto> Items { get; init; } = Array.Empty<KitchenTicketItemDto>();
+    public int TotalItems { get; init; }
+
+    // Order-level preparation note (e.g. "No onions in anything", "Ring bell")
+    public string? SpecialInstructions { get; init; }
+}
+
+/// <summary>
+/// A single cook line on the kitchen ticket.
+/// </summary>
+public sealed record KitchenTicketItemDto
+{
+    public string ItemName { get; init; } = string.Empty;
+    public int Quantity { get; init; }
+    public string? SpecialInstructions { get; init; }
+}

--- a/src/Modules/Orders/RallyAPI.Orders.Application/Mappings/OrderMappingExtensions.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/Mappings/OrderMappingExtensions.cs
@@ -84,6 +84,42 @@ public static class OrderMappingExtensions
         };
     }
 
+    /// <summary>
+    /// Maps an order to its kitchen-facing ticket (KOT). No pricing/money —
+    /// only what the kitchen needs to prepare and pack the order.
+    /// </summary>
+    public static KitchenTicketDto ToKitchenTicket(this Order order)
+    {
+        return new KitchenTicketDto
+        {
+            OrderId = order.Id,
+            OrderNumber = order.OrderNumber.Value,
+
+            FulfillmentType = order.FulfillmentType,
+            FulfillmentDisplay = order.FulfillmentType switch
+            {
+                FulfillmentType.Pickup => "PICKUP",
+                _                      => "DELIVERY"
+            },
+
+            CustomerName = order.CustomerName,
+            StatusDisplay = order.Status.GetDisplayName(),
+            PlacedAt = order.CreatedAt,
+
+            Items = order.Items
+                .Select(i => new KitchenTicketItemDto
+                {
+                    ItemName = i.ItemName,
+                    Quantity = i.Quantity,
+                    SpecialInstructions = i.SpecialInstructions
+                })
+                .ToList(),
+            TotalItems = order.Items.Sum(i => i.Quantity),
+
+            SpecialInstructions = order.SpecialInstructions
+        };
+    }
+
     public static OrderItemDto ToDto(this OrderItem item)
     {
         return new OrderItemDto

--- a/src/Modules/Orders/RallyAPI.Orders.Application/Queries/GetKitchenTicket/GetKitchenTicketQuery.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/Queries/GetKitchenTicket/GetKitchenTicketQuery.cs
@@ -1,0 +1,12 @@
+using MediatR;
+using RallyAPI.Orders.Application.DTOs;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Orders.Application.Queries.GetKitchenTicket;
+
+/// <summary>
+/// Query to get the Kitchen Order Ticket (KOT) for an order.
+/// Restaurant-facing: only the owning restaurant (or an Admin) may print it.
+/// </summary>
+public sealed record GetKitchenTicketQuery(Guid OrderId, Guid CallerId, string CallerRole)
+    : IRequest<Result<KitchenTicketDto>>;

--- a/src/Modules/Orders/RallyAPI.Orders.Application/Queries/GetKitchenTicket/GetKitchenTicketQueryHandler.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/Queries/GetKitchenTicket/GetKitchenTicketQueryHandler.cs
@@ -1,0 +1,47 @@
+using MediatR;
+using RallyAPI.Orders.Application.DTOs;
+using RallyAPI.Orders.Application.Mappings;
+using RallyAPI.Orders.Domain.Abstractions;
+using RallyAPI.Orders.Domain.Errors;
+using RallyAPI.SharedKernel.Results;
+
+namespace RallyAPI.Orders.Application.Queries.GetKitchenTicket;
+
+public sealed class GetKitchenTicketQueryHandler
+    : IRequestHandler<GetKitchenTicketQuery, Result<KitchenTicketDto>>
+{
+    private readonly IOrderRepository _orderRepository;
+
+    public GetKitchenTicketQueryHandler(IOrderRepository orderRepository)
+    {
+        _orderRepository = orderRepository;
+    }
+
+    public async Task<Result<KitchenTicketDto>> Handle(
+        GetKitchenTicketQuery query, CancellationToken cancellationToken)
+    {
+        var order = await _orderRepository.GetByIdAsync(query.OrderId, cancellationToken);
+
+        if (order is null)
+        {
+            return Result.Failure<KitchenTicketDto>(OrderErrors.NotFound(query.OrderId));
+        }
+
+        if (!IsAuthorized(order, query.CallerId, query.CallerRole))
+        {
+            // Return NotFound — do not reveal that the order exists to unauthorized callers
+            return Result.Failure<KitchenTicketDto>(OrderErrors.NotFound(query.OrderId));
+        }
+
+        return Result.Success(order.ToKitchenTicket());
+    }
+
+    // A KOT is only ever printed by the kitchen (the owning restaurant) or an Admin.
+    private static bool IsAuthorized(Domain.Entities.Order order, Guid callerId, string callerRole) =>
+        callerRole switch
+        {
+            "Admin"      => true,
+            "Restaurant" => order.RestaurantId == callerId,
+            _            => false
+        };
+}

--- a/src/Modules/Orders/RallyAPI.Orders.Endpoints/OrderEndpoints.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Endpoints/OrderEndpoints.cs
@@ -18,6 +18,7 @@ using RallyAPI.Orders.Application.Queries.GetOrdersByCustomer;
 using RallyAPI.Orders.Application.Commands.AddOrderNote;
 using RallyAPI.Orders.Application.Queries.GetActiveOrders;
 using RallyAPI.Orders.Application.Queries.GetFilteredOrders;
+using RallyAPI.Orders.Application.Queries.GetKitchenTicket;
 using RallyAPI.Orders.Application.Queries.GetOrderById;
 using RallyAPI.Orders.Application.Queries.GetOrderByNumber;
 using RallyAPI.Orders.Application.Queries.GetOrderNotes;
@@ -64,6 +65,14 @@ public static class OrderEndpoints
             .WithSummary("Get order by ID")
             .RequireAuthorization()
             .Produces<OrderDto>()
+            .Produces<ProblemDetails>(StatusCodes.Status404NotFound);
+
+        // Get Kitchen Ticket / KOT (Restaurant or Admin) — print-oriented, no pricing
+        group.MapGet("/{orderId:guid}/kot", GetKitchenTicket)
+            .WithName("GetKitchenTicket")
+            .WithSummary("Get the Kitchen Order Ticket (KOT) for an order")
+            .RequireAuthorization("AdminOrRestaurant")
+            .Produces<KitchenTicketDto>()
             .Produces<ProblemDetails>(StatusCodes.Status404NotFound);
 
         // Get Order by Number
@@ -295,6 +304,25 @@ public static class OrderEndpoints
 
         var callerRole = GetCallerRole(currentUser);
         var result = await mediator.Send(new GetOrderByIdQuery(orderId, currentUser.UserId.Value, callerRole), cancellationToken);
+
+        return result.IsSuccess
+            ? Results.Ok(result.Value)
+            : result.Error.ToErrorResult();
+    }
+
+    private static async Task<IResult> GetKitchenTicket(
+        Guid orderId,
+        IMediator mediator,
+        ICurrentUserService currentUser,
+        CancellationToken cancellationToken)
+    {
+        if (!currentUser.UserId.HasValue)
+            return Results.Unauthorized();
+
+        var callerRole = GetCallerRole(currentUser);
+        var result = await mediator.Send(
+            new GetKitchenTicketQuery(orderId, currentUser.UserId.Value, callerRole),
+            cancellationToken);
 
         return result.IsSuccess
             ? Results.Ok(result.Value)

--- a/tests/Modules/Orders/RallyAPI.Orders.Application.Tests/GetKitchenTicketQueryHandlerTests.cs
+++ b/tests/Modules/Orders/RallyAPI.Orders.Application.Tests/GetKitchenTicketQueryHandlerTests.cs
@@ -1,0 +1,202 @@
+using FluentAssertions;
+using Xunit;
+using NSubstitute;
+using RallyAPI.Orders.Application.Queries.GetKitchenTicket;
+using RallyAPI.Orders.Domain.Abstractions;
+using RallyAPI.Orders.Domain.Entities;
+using RallyAPI.Orders.Domain.Enums;
+using RallyAPI.Orders.Domain.ValueObjects;
+
+namespace RallyAPI.Orders.Application.Tests;
+
+public class GetKitchenTicketQueryHandlerTests
+{
+    private readonly IOrderRepository _orderRepository;
+    private readonly GetKitchenTicketQueryHandler _handler;
+
+    public GetKitchenTicketQueryHandlerTests()
+    {
+        _orderRepository = Substitute.For<IOrderRepository>();
+        _handler = new GetKitchenTicketQueryHandler(_orderRepository);
+    }
+
+    [Fact]
+    public async Task Handle_WhenOwningRestaurantRequests_ShouldReturnTicketWithItemsAndNotes()
+    {
+        var restaurantId = Guid.NewGuid();
+        var order = BuildPaidOrder(restaurantId, orderNote: "No onions in anything");
+        var query = new GetKitchenTicketQuery(order.Id, restaurantId, "Restaurant");
+
+        _orderRepository.GetByIdAsync(order.Id, Arg.Any<CancellationToken>()).Returns(order);
+
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var ticket = result.Value;
+        ticket.OrderNumber.Should().Be(order.OrderNumber.Value);
+        ticket.CustomerName.Should().Be("Priya Singh");
+        ticket.SpecialInstructions.Should().Be("No onions in anything");
+        ticket.TotalItems.Should().Be(3); // 2 + 1
+        ticket.Items.Should().HaveCount(2);
+        ticket.Items[0].ItemName.Should().Be("Paneer Tikka");
+        ticket.Items[0].Quantity.Should().Be(2);
+        ticket.Items[0].SpecialInstructions.Should().Be("Extra spicy");
+        ticket.Items[1].SpecialInstructions.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ForDeliveryOrder_ShouldDisplayDelivery()
+    {
+        var restaurantId = Guid.NewGuid();
+        var order = BuildPaidOrder(restaurantId);
+        var query = new GetKitchenTicketQuery(order.Id, restaurantId, "Restaurant");
+
+        _orderRepository.GetByIdAsync(order.Id, Arg.Any<CancellationToken>()).Returns(order);
+
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.FulfillmentType.Should().Be(FulfillmentType.Delivery);
+        result.Value.FulfillmentDisplay.Should().Be("DELIVERY");
+    }
+
+    [Fact]
+    public async Task Handle_ForPickupOrder_ShouldDisplayPickup()
+    {
+        var restaurantId = Guid.NewGuid();
+        var order = BuildPaidPickupOrder(restaurantId);
+        var query = new GetKitchenTicketQuery(order.Id, restaurantId, "Restaurant");
+
+        _orderRepository.GetByIdAsync(order.Id, Arg.Any<CancellationToken>()).Returns(order);
+
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.FulfillmentType.Should().Be(FulfillmentType.Pickup);
+        result.Value.FulfillmentDisplay.Should().Be("PICKUP");
+    }
+
+    [Fact]
+    public async Task Handle_WhenOrderNotFound_ShouldReturnFailure()
+    {
+        var orderId = Guid.NewGuid();
+        var query = new GetKitchenTicketQuery(orderId, Guid.NewGuid(), "Restaurant");
+
+        _orderRepository.GetByIdAsync(orderId, Arg.Any<CancellationToken>()).Returns((Order?)null);
+
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WhenDifferentRestaurantRequests_ShouldReturnFailure()
+    {
+        var order = BuildPaidOrder(restaurantId: Guid.NewGuid());
+        var query = new GetKitchenTicketQuery(order.Id, Guid.NewGuid(), "Restaurant");
+
+        _orderRepository.GetByIdAsync(order.Id, Arg.Any<CancellationToken>()).Returns(order);
+
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_WhenAdminRequests_ShouldReturnTicketForAnyRestaurant()
+    {
+        var order = BuildPaidOrder(restaurantId: Guid.NewGuid());
+        // Admin caller id is unrelated to the order's restaurant
+        var query = new GetKitchenTicketQuery(order.Id, Guid.NewGuid(), "Admin");
+
+        _orderRepository.GetByIdAsync(order.Id, Arg.Any<CancellationToken>()).Returns(order);
+
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("Customer")]
+    [InlineData("Rider")]
+    [InlineData("")]
+    public async Task Handle_WhenNonRestaurantNonAdminRequests_ShouldReturnFailure(string role)
+    {
+        var order = BuildPaidOrder(restaurantId: Guid.NewGuid());
+        // Even if the caller id happens to match, only Restaurant/Admin roles are allowed
+        var query = new GetKitchenTicketQuery(order.Id, order.RestaurantId, role);
+
+        _orderRepository.GetByIdAsync(order.Id, Arg.Any<CancellationToken>()).Returns(order);
+
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    #region Helpers
+
+    private static Order BuildPaidOrder(Guid restaurantId, string? orderNote = null)
+    {
+        var deliveryAddress = Address.Create(
+            street: "42 Brigade Road",
+            city: "Bengaluru",
+            pincode: "560025",
+            latitude: 12.9716,
+            longitude: 77.5946);
+
+        var deliveryInfo = DeliveryInfo.Create(
+            pickupLatitude: 12.9352,
+            pickupLongitude: 77.6245,
+            pickupPincode: "560095",
+            deliveryAddress: deliveryAddress);
+
+        var pricing = OrderPricing.CreateSimple(subTotal: 300m, deliveryFee: 50m);
+
+        var order = Order.CreatePendingOrder(
+            orderNumber: OrderNumber.Create(dailySequence: 42),
+            customerId: Guid.NewGuid(),
+            customerName: "Priya Singh",
+            restaurantId: restaurantId,
+            restaurantName: "Dosa Corner",
+            pricing: pricing,
+            deliveryInfo: deliveryInfo,
+            specialInstructions: orderNote);
+
+        AddSampleItems(order);
+        order.ConfirmPayment("PAY-TEST-001", null);
+        return order;
+    }
+
+    private static Order BuildPaidPickupOrder(Guid restaurantId)
+    {
+        var pricing = OrderPricing.CreateSimple(subTotal: 300m, deliveryFee: 0m);
+
+        var order = Order.CreatePendingOrder(
+            orderNumber: OrderNumber.Create(dailySequence: 43),
+            customerId: Guid.NewGuid(),
+            customerName: "Priya Singh",
+            restaurantId: restaurantId,
+            restaurantName: "Dosa Corner",
+            pricing: pricing,
+            fulfillmentType: FulfillmentType.Pickup);
+
+        AddSampleItems(order);
+        order.ConfirmPayment("PAY-TEST-002", null);
+        return order;
+    }
+
+    private static void AddSampleItems(Order order)
+    {
+        order.AddItem(OrderItem.Create(
+            Guid.NewGuid(), "Paneer Tikka",
+            Money.FromDecimal(200m, "INR"), 2,
+            specialInstructions: "Extra spicy"));
+
+        order.AddItem(OrderItem.Create(
+            Guid.NewGuid(), "Butter Naan",
+            Money.FromDecimal(50m, "INR"), 1));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
…printing

Adds GET /api/orders/{orderId}/kot returning a kitchen-facing KitchenTicketDto (order number, fulfillment type, items + quantities + prep notes, order-level note) with pricing deliberately omitted. Auth: owning Restaurant or Admin; returns NotFound for other callers so order existence isn't leaked.

Reuses IOrderRepository + a new ToKitchenTicket() mapping — no persistence or migration changes. Auto-print rides the existing NewOrderReceived SignalR event, so no backend change was needed for it.

Includes GetKitchenTicketQueryHandler unit tests (9) and a frontend handoff spec (specs/kot-print-restaurant-panel.md) covering the component, print hook, and auto-print flow for the Restaurant Dashboard dev.