### PR TITLE
fix(delivery): keep broadcast dispatch race-safe when a rider rejects

### DIFF
--- a/specs/own-fleet-first-dispatch.md
+++ b/specs/own-fleet-first-dispatch.md
@@ -161,6 +161,7 @@ None new. Relies on the existing empty-body xmin migration already on `staging`.
 | Zero eligible own riders | `GetAvailableRidersAsync` empty → return `Failed` from own phase → book 3PL immediately. No delay, no `MarkFailed`. |
 | Riders offered, none accept | Window elapses → `ExpireAllPendingOffers` → fall to 3PL. |
 | Two riders accept ~same instant | xmin makes one write win; loser gets `Result.Failure("already assigned")` (409), loser `CurrentDeliveryId` untouched. |
+| A rider **rejects** during the window | Decline bumps xmin on another connection. Orchestrator reloads FRESH (`GetByIdFreshAsync`) and re-reads real status before/after each write — a token change is NOT read as an accept. Falls back to 3PL cleanly; no spurious OwnFleet success and no concurrency-exception crash. Decline handler itself uses `TryUpdateAsync` (benign "already responded" on a lost race, not a 500). |
 | Rider accepts as window is closing | Poll or final reload detects `RiderAssigned` → `Success(OwnFleet)`; 3PL never booked. |
 | Notification send fails for some riders | Broadcast proceeds; those riders simply don't get the offer. Log per-rider failures. |
 | 3PL `CreateTask` fails after own miss | `MarkFailed(NoRidersAvailable, "Own fleet + 3PL exhausted")`, no dangling task. |
@@ -192,12 +193,17 @@ None new. Relies on the existing empty-body xmin migration already on `staging`.
 
 ## Implementation Notes (updated during build)
 
-### Files to Modify
-- `src/Modules/Delivery/RallyAPI.Delivery.Application/Services/RiderDispatchOrchestrator.cs` — flip order; replace sequential loop with broadcast + single polling window; options.
+### Files Modified
+- `src/Modules/Delivery/RallyAPI.Delivery.Application/Services/RiderDispatchOrchestrator.cs` — flip order; broadcast + single polling window; options; fresh-reload + status re-check on every concurrency-guarded write (reject-safe).
 - `src/Modules/Delivery/RallyAPI.Delivery.Domain/Entities/DeliveryRequest.cs` — repoint `StartSearching()` to `SearchingOwnFleet`.
 - `src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/AcceptDeliveryOffer/AcceptDeliveryOfferCommandHandler.cs` — status guard, `TryUpdateAsync`, reorder rider write (§4.3).
+- `src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/DeclineDeliveryOffer/DeclineDeliveryOfferCommandHandler.cs` — `TryUpdateAsync` so a reject that races the dispatcher returns a benign result, not a 500.
+- `src/Modules/Delivery/RallyAPI.Delivery.Domain/Abstractions/IDeliveryRequestRepository.cs` + `.../Repositories/DeliveryRequestRepository.cs` — new `GetByIdFreshAsync` (detaches the stale identity-map copy, reloads with current xmin).
 - `src/RallyAPI.Host/appsettings.json` — `OwnFleetFirst`, `OfferPollIntervalSeconds`.
-- `tests/Modules/Delivery/RallyAPI.Delivery.Application.Tests/RiderDispatchOrchestratorTests.cs` (+ accept-handler tests) — update/extend.
+- `tests/Modules/Delivery/RallyAPI.Delivery.Application.Tests/RiderDispatchOrchestratorTests.cs` + `DeclineDeliveryOfferCommandHandlerTests.cs` — updated/extended (incl. reject regression test).
+
+### Key correctness note (added after first cut)
+The inline dispatcher runs on ONE long-lived DbContext. Its tracking reloads return the dispatcher's own STALE copy, so any write after a rider accept/**reject** (committed on another connection, bumping xmin) would either throw `DbUpdateConcurrencyException` or misread the token change as an acceptance. Fix: reload via `GetByIdFreshAsync` immediately before each mutate→`TryUpdateAsync`, and on a lost race re-read the true status (`GetCurrentStatusAsync`) to decide accept-vs-fallback rather than assuming "accepted." Retry loops capped by `MaxConcurrencyRetries`; if still contended, bail to the recovery service.
 
 ### Decisions Made
 - **Broadcast (parallel), not sequential** — fire offers to ALL eligible riders in radius, cap `MaxRidersToTry` (10), first-accept-wins. (Supersedes the earlier "cap to nearest 1–2" idea.)

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/DeclineDeliveryOffer/DeclineDeliveryOfferCommandHandler.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/DeclineDeliveryOffer/DeclineDeliveryOfferCommandHandler.cs
@@ -59,10 +59,19 @@ public sealed class DeclineDeliveryOfferCommandHandler : IRequestHandler<Decline
 
         offer.Reject(request.Reason);
 
-        await _requestRepository.UpdateAsync(deliveryRequest, cancellationToken);
+        // Concurrency-guarded: the dispatcher may write this same row (expire offers / fall to
+        // 3PL) at the same moment. On a lost race the reject simply didn't stick — surface it as
+        // a benign "already responded" rather than a 500.
+        if (!await _requestRepository.TryUpdateAsync(deliveryRequest, cancellationToken))
+        {
+            _logger.LogInformation(
+                "Decline of offer {OfferId} by rider {RiderId} lost a concurrency race; offer already resolved.",
+                request.OfferId, request.RiderId);
+            return Result.Failure(DeliveryErrors.OfferAlreadyResponded);
+        }
 
         _logger.LogInformation(
-            "Offer {OfferId} declined by rider {RiderId}. Dispatch orchestrator will try next rider on timeout.",
+            "Offer {OfferId} declined by rider {RiderId}. Dispatch orchestrator will fall back on timeout.",
             request.OfferId, request.RiderId);
 
         return Result.Success();

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Services/RiderDispatchOrchestrator.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Services/RiderDispatchOrchestrator.cs
@@ -11,6 +11,11 @@ namespace RallyAPI.Delivery.Application.Services;
 
 public sealed class RiderDispatchOrchestrator
 {
+    // Caps the reload-and-retry loops that transition to 3PL / mark Failed when a concurrent
+    // rider decline or accept keeps bumping the delivery's concurrency token. A handful of
+    // attempts is plenty; if still contended we bail and let the recovery service pick it up.
+    private const int MaxConcurrencyRetries = 5;
+
     private readonly IRiderQueryService _riderQueryService;
     private readonly IRiderNotificationService _notificationService;
     private readonly IThirdPartyDeliveryProvider _thirdPartyProvider;
@@ -71,53 +76,82 @@ public sealed class RiderDispatchOrchestrator
             "No own-fleet rider took delivery {DeliveryId}. Falling back to 3PL.",
             deliveryRequest.Id);
 
-        // Reload fresh: the own-fleet phase probed status via GetCurrentStatusAsync and
-        // may have detached the tracked entity on a concurrency-guarded write.
-        var fresh = await _requestRepository.GetByIdAsync(deliveryRequest.Id, ct);
-        if (fresh is null)
+        // Move the request into 3PL search. This can race a rider decline/accept committed on
+        // another connection (which bumps xmin), so reload FRESH and retry rather than writing
+        // through the dispatcher's stale tracked copy. A concurrent accept short-circuits.
+        DeliveryRequest? fresh = null;
+        for (var attempt = 0; attempt < MaxConcurrencyRetries; attempt++)
         {
-            return DispatchResult.Failed("Delivery request no longer exists");
+            fresh = await _requestRepository.GetByIdFreshAsync(deliveryRequest.Id, ct);
+            if (fresh is null)
+            {
+                return DispatchResult.Failed("Delivery request no longer exists");
+            }
+            if (fresh.Status >= DeliveryRequestStatus.RiderAssigned)
+            {
+                return DispatchResult.Success(fresh.FleetType ?? FleetType.OwnFleet, fresh.RiderId);
+            }
+            if (fresh.Status == DeliveryRequestStatus.Searching3PL)
+            {
+                break; // already there (e.g. a concurrent path moved it)
+            }
+            if (fresh.Status is not (DeliveryRequestStatus.SearchingOwnFleet
+                or DeliveryRequestStatus.Created
+                or DeliveryRequestStatus.PendingDispatch))
+            {
+                // Terminal/unexpected (Cancelled/Failed/etc.) — nothing to dispatch.
+                return DispatchResult.Failed($"Delivery in non-dispatchable status {fresh.Status}");
+            }
+
+            fresh.StartSearching3PL();
+            if (await _requestRepository.TryUpdateAsync(fresh, ct))
+            {
+                break;
+            }
+            // Lost the write to a concurrent decline/accept — loop and re-decide on fresh state.
         }
 
-        // A rider may have accepted right at the window boundary — never override it.
-        if (fresh.Status >= DeliveryRequestStatus.RiderAssigned)
-        {
-            return DispatchResult.Success(fresh.FleetType ?? FleetType.OwnFleet, fresh.RiderId);
-        }
-
-        fresh.StartSearching3PL();
-        await _requestRepository.UpdateAsync(fresh, ct);
-
-        var thirdPartyResult = await AssignVia3PLAsync(fresh, ct);
+        var thirdPartyResult = await AssignVia3PLAsync(fresh!, ct);
         if (thirdPartyResult.IsSuccess)
         {
             return thirdPartyResult;
         }
 
-        // Both own fleet and 3PL exhausted → terminal failure (concurrency-guarded).
-        fresh = await _requestRepository.GetByIdAsync(fresh.Id, ct);
-        if (fresh is null)
+        // Both own fleet and 3PL exhausted → terminal failure. Same fresh-reload + retry so a
+        // reject/accept that changed xmin never turns into a spurious concurrency crash, and a
+        // genuine assignment is honored instead of clobbered to Failed.
+        for (var attempt = 0; attempt < MaxConcurrencyRetries; attempt++)
         {
-            return DispatchResult.Failed("Delivery request no longer exists");
-        }
-        if (fresh.Status >= DeliveryRequestStatus.RiderAssigned)
-        {
-            return DispatchResult.Success(fresh.FleetType ?? FleetType.OwnFleet, fresh.RiderId);
+            fresh = await _requestRepository.GetByIdFreshAsync(deliveryRequest.Id, ct);
+            if (fresh is null)
+            {
+                return DispatchResult.Failed("Delivery request no longer exists");
+            }
+            if (fresh.Status >= DeliveryRequestStatus.RiderAssigned)
+            {
+                _logger.LogInformation(
+                    "Delivery {DeliveryId} was assigned ({Status}) before the terminal fail — honoring it.",
+                    fresh.Id, fresh.Status);
+                return DispatchResult.Success(fresh.FleetType ?? FleetType.OwnFleet, fresh.RiderId);
+            }
+
+            // MarkFailed self-guards against Status >= RiderAssigned, so this only fails a
+            // request that is genuinely still unassigned.
+            fresh.MarkFailed(
+                DeliveryFailureReason.NoRidersAvailable,
+                "All dispatch options exhausted (Own Fleet declined/unavailable and 3PL failed/timed out)");
+
+            if (await _requestRepository.TryUpdateAsync(fresh, ct))
+            {
+                return DispatchResult.Failed("All dispatch options exhausted");
+            }
+            // Lost to a concurrent write — reload and re-check whether it was an assignment.
         }
 
-        fresh.MarkFailed(
-            DeliveryFailureReason.NoRidersAvailable,
-            "All dispatch options exhausted (Own Fleet declined/unavailable and 3PL failed/timed out)");
-
-        if (!await _requestRepository.TryUpdateAsync(fresh, ct))
-        {
-            _logger.LogInformation(
-                "Delivery {DeliveryId} failure write rejected by concurrency token — a rider accepted concurrently. Honoring the assignment.",
-                fresh.Id);
-            return DispatchResult.Success(FleetType.OwnFleet, null);
-        }
-
-        return DispatchResult.Failed("All dispatch options exhausted");
+        _logger.LogWarning(
+            "Delivery {DeliveryId} terminal-fail write kept losing the concurrency race; leaving for the recovery service.",
+            deliveryRequest.Id);
+        return DispatchResult.Failed("All dispatch options exhausted (contended)");
     }
 
     /// <summary>
@@ -207,7 +241,7 @@ public sealed class RiderDispatchOrchestrator
             }
             if (status >= DeliveryRequestStatus.RiderAssigned)
             {
-                var assigned = await _requestRepository.GetByIdAsync(deliveryRequest.Id, ct);
+                var assigned = await _requestRepository.GetByIdFreshAsync(deliveryRequest.Id, ct);
                 _logger.LogInformation(
                     "Own-fleet rider {RiderId} accepted delivery {DeliveryId}.",
                     assigned?.RiderId, deliveryRequest.Id);
@@ -215,23 +249,27 @@ public sealed class RiderDispatchOrchestrator
             }
         }
 
-        // Window elapsed with no acceptance → expire pending offers and fall back to 3PL.
-        var latest = await _requestRepository.GetByIdWithOffersAsync(deliveryRequest.Id, ct);
-        if (latest is null)
+        // Window elapsed. Re-read the TRUE status: did a rider accept right at the boundary?
+        var finalStatus = await _requestRepository.GetCurrentStatusAsync(deliveryRequest.Id, ct);
+        if (finalStatus is null)
         {
             return DispatchResult.Failed("Delivery request no longer exists");
         }
-        if (latest.Status >= DeliveryRequestStatus.RiderAssigned)
+        if (finalStatus >= DeliveryRequestStatus.RiderAssigned)
         {
-            return DispatchResult.Success(FleetType.OwnFleet, latest.RiderId);
+            var assigned = await _requestRepository.GetByIdFreshAsync(deliveryRequest.Id, ct);
+            return DispatchResult.Success(FleetType.OwnFleet, assigned?.RiderId);
         }
 
-        latest.ExpireAllPendingOffers();
-        if (!await _requestRepository.TryUpdateAsync(latest, ct))
+        // No acceptance → best-effort expire the pending offers (they are past ExpiresAt by now
+        // anyway) and fall back to 3PL. This write is NON-critical: if it loses the concurrency
+        // race to a rider decline/accept we simply move on — we do NOT treat that as an accept
+        // (a reject also bumps xmin), so the caller's fresh status re-check decides the outcome.
+        var latest = await _requestRepository.GetByIdFreshAsync(deliveryRequest.Id, ct);
+        if (latest is { Status: DeliveryRequestStatus.SearchingOwnFleet })
         {
-            // A rider accepted between our last poll and this write — honor it.
-            var assigned = await _requestRepository.GetByIdAsync(deliveryRequest.Id, ct);
-            return DispatchResult.Success(FleetType.OwnFleet, assigned?.RiderId);
+            latest.ExpireAllPendingOffers();
+            await _requestRepository.TryUpdateAsync(latest, ct); // result intentionally ignored
         }
 
         _logger.LogInformation(

--- a/src/Modules/Delivery/RallyAPI.Delivery.Domain/Abstractions/IDeliveryRequestRepository.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Domain/Abstractions/IDeliveryRequestRepository.cs
@@ -36,6 +36,16 @@ public interface IDeliveryRequestRepository
     /// </summary>
     Task<DeliveryRequestStatus?> GetCurrentStatusAsync(Guid id, CancellationToken ct = default);
 
+    /// <summary>
+    /// Reloads the aggregate (root + offers) bypassing the change-tracker identity map,
+    /// so the returned entity reflects accept/decline writes committed on OTHER connections
+    /// and carries the CURRENT concurrency token (xmin). Use this before a
+    /// mutate-then-<see cref="TryUpdateAsync"/> in the long-lived inline dispatcher: a plain
+    /// tracking reload would hand back the dispatcher's own stale copy, whose write then
+    /// either throws a concurrency exception or clobbers a concurrent change.
+    /// </summary>
+    Task<DeliveryRequest?> GetByIdFreshAsync(Guid id, CancellationToken ct = default);
+
     Task AddAsync(DeliveryRequest request, CancellationToken ct = default);
     Task UpdateAsync(DeliveryRequest request, CancellationToken ct = default);
 

--- a/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Repositories/DeliveryRequestRepository.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Repositories/DeliveryRequestRepository.cs
@@ -97,6 +97,24 @@ public sealed class DeliveryRequestRepository : IDeliveryRequestRepository
         return rows.Count > 0 ? rows[0] : null;
     }
 
+    public async Task<DeliveryRequest?> GetByIdFreshAsync(Guid id, CancellationToken ct = default)
+    {
+        // Detach any tracked copy of this aggregate (root + its offers) that the long-lived
+        // dispatch context is holding, so the reload reflects accept/decline writes committed
+        // on other connections and picks up the current xmin. Without this, EF returns the
+        // stale identity-map instance and its next write conflicts or clobbers.
+        var stale = _dbContext.ChangeTracker.Entries()
+            .Where(e => (e.Entity is DeliveryRequest dr && dr.Id == id)
+                     || (e.Entity is RiderOffer ro && ro.DeliveryRequestId == id))
+            .ToList();
+        foreach (var entry in stale)
+            entry.State = EntityState.Detached;
+
+        return await _dbContext.DeliveryRequests
+            .Include(r => r.RiderOffers)
+            .FirstOrDefaultAsync(r => r.Id == id, ct);
+    }
+
     public async Task AddAsync(DeliveryRequest request, CancellationToken ct = default)
     {
         await _dbContext.DeliveryRequests.AddAsync(request, ct);

--- a/tests/Modules/Delivery/RallyAPI.Delivery.Application.Tests/DeclineDeliveryOfferCommandHandlerTests.cs
+++ b/tests/Modules/Delivery/RallyAPI.Delivery.Application.Tests/DeclineDeliveryOfferCommandHandlerTests.cs
@@ -110,6 +110,8 @@ public class DeclineDeliveryOfferCommandHandlerTests
             .Returns(new[] { deliveryRequest });
         _repository.GetByIdWithOffersAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
             .Returns(deliveryRequest);
+        _repository.TryUpdateAsync(deliveryRequest, Arg.Any<CancellationToken>())
+            .Returns(true);
 
         var command = new DeclineDeliveryOfferCommand { OfferId = offer.Id, RiderId = riderId, Reason = "Too far" };
 
@@ -118,7 +120,7 @@ public class DeclineDeliveryOfferCommandHandlerTests
         result.IsSuccess.Should().BeTrue();
         offer.Status.Should().Be(RiderOfferStatus.Rejected);
         offer.RejectionReason.Should().Be("Too far");
-        await _repository.Received(1).UpdateAsync(deliveryRequest, Arg.Any<CancellationToken>());
+        await _repository.Received(1).TryUpdateAsync(deliveryRequest, Arg.Any<CancellationToken>());
     }
 
     #region Helpers

--- a/tests/Modules/Delivery/RallyAPI.Delivery.Application.Tests/RiderDispatchOrchestratorTests.cs
+++ b/tests/Modules/Delivery/RallyAPI.Delivery.Application.Tests/RiderDispatchOrchestratorTests.cs
@@ -310,15 +310,18 @@ public class RiderDispatchOrchestratorTests
             .GetAvailableRidersAsync(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<double>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(new[] { BuildRider(riderA), BuildRider(riderB) });
 
-        // Window (0s) elapses; the reload reflects that riderA accepted during broadcast.
+        // Window (0s) elapses; the fresh status read reflects that riderA accepted mid-broadcast.
         _repository
-            .GetByIdWithOffersAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
+            .GetCurrentStatusAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
             .Returns(_ =>
             {
                 if (deliveryRequest.Status == DeliveryRequestStatus.SearchingOwnFleet)
                     deliveryRequest.AssignOwnFleetRider(riderA, "Suresh", "+919876543210");
-                return deliveryRequest;
+                return (DeliveryRequestStatus?)deliveryRequest.Status;
             });
+        _repository
+            .GetByIdFreshAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
+            .Returns(_ => deliveryRequest);
 
         var orchestrator = BuildOwnFirstOrchestrator();
 
@@ -354,7 +357,7 @@ public class RiderDispatchOrchestratorTests
                 return (DeliveryRequestStatus?)deliveryRequest.Status;
             });
         _repository
-            .GetByIdAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
+            .GetByIdFreshAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
             .Returns(_ => deliveryRequest);
 
         // 1s window so the poll loop actually runs one iteration.
@@ -379,7 +382,7 @@ public class RiderDispatchOrchestratorTests
             .Returns(Array.Empty<AvailableRider>());
 
         _repository
-            .GetByIdAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
+            .GetByIdFreshAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
             .Returns(_ => deliveryRequest);
 
         _thirdPartyProvider
@@ -420,10 +423,7 @@ public class RiderDispatchOrchestratorTests
 
         // Nobody accepts: reload after the window still shows SearchingOwnFleet.
         _repository
-            .GetByIdWithOffersAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
-            .Returns(_ => deliveryRequest);
-        _repository
-            .GetByIdAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
+            .GetByIdFreshAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
             .Returns(_ => deliveryRequest);
 
         _thirdPartyProvider
@@ -458,7 +458,7 @@ public class RiderDispatchOrchestratorTests
             .Returns(Array.Empty<AvailableRider>());
 
         _repository
-            .GetByIdAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
+            .GetByIdFreshAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
             .Returns(_ => deliveryRequest);
 
         _thirdPartyProvider
@@ -472,6 +472,55 @@ public class RiderDispatchOrchestratorTests
         result.IsSuccess.Should().BeFalse();
         deliveryRequest.Status.Should().Be(DeliveryRequestStatus.Failed);
         deliveryRequest.FailureReason.Should().Be(DeliveryFailureReason.NoRidersAvailable);
+    }
+
+    [Fact]
+    public async Task OwnFleetFirst_WhenRiderRejects_ShouldFallBackTo3PL_NotSucceedAsOwnFleetOrCrash()
+    {
+        // Regression: a rider REJECTING an offer bumps the delivery's xmin from another
+        // connection. The dispatcher's own-fleet writes (expire offers / move to 3PL) then lose
+        // the concurrency race while status is still SearchingOwnFleet. The orchestrator must
+        // re-read the real status and fall back to 3PL — NOT misread the token change as an
+        // acceptance (return OwnFleet) and NOT throw a concurrency exception.
+        var riderId = Guid.NewGuid();
+        var deliveryRequest = BuildCreatedRequest();
+
+        _riderQueryService
+            .GetAvailableRidersAsync(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<double>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { BuildRider(riderId) });
+
+        _repository
+            .GetByIdFreshAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
+            .Returns(_ => deliveryRequest);
+
+        // No rider accepts (the one rider rejected) — every fresh status probe still reads
+        // SearchingOwnFleet until we successfully transition to 3PL.
+        _repository
+            .GetCurrentStatusAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                if (deliveryRequest.Status == DeliveryRequestStatus.Searching3PL)
+                    deliveryRequest.Assign3PLRider("TASK-R", "ProRouting", "Rahul", "+91999", null, 95m);
+                return (DeliveryRequestStatus?)deliveryRequest.Status;
+            });
+
+        // The decline bumped xmin: any write attempted WHILE still SearchingOwnFleet loses the
+        // race (returns false). Writes made after transitioning off SearchingOwnFleet commit.
+        _repository
+            .TryUpdateAsync(Arg.Any<DeliveryRequest>(), Arg.Any<CancellationToken>())
+            .Returns(ci => ((DeliveryRequest)ci[0]!).Status != DeliveryRequestStatus.SearchingOwnFleet);
+
+        _thirdPartyProvider
+            .CreateTaskAsync(Arg.Any<CreateTaskRequest>(), Arg.Any<CancellationToken>())
+            .Returns(CreateTaskResult.Success("TASK-R", deliveryRequest.OrderId.ToString(), "searching", null, "ProRouting"));
+
+        var orchestrator = BuildOwnFirstOrchestrator();
+
+        var result = await orchestrator.DispatchAsync(deliveryRequest);
+
+        result.IsSuccess.Should().BeTrue();
+        result.FleetType.Should().Be(FleetType.ThirdParty);
+        deliveryRequest.Status.Should().NotBe(DeliveryRequestStatus.Failed);
     }
 
     #region Helpers


### PR DESCRIPTION
A rider declining an offer bumps the delivery's xmin on a separate connection. The inline dispatcher runs on one long-lived DbContext whose tracking reloads return its own stale copy, so its next write either threw DbUpdateConcurrencyException (crash) or misread the token change as an acceptance and wrongly reported OwnFleet success.

- Add IDeliveryRequestRepository.GetByIdFreshAsync: detaches the stale identity-map copy and reloads with the current xmin.
- Orchestrator own-first path: reload fresh before every concurrency- guarded write and re-read true status (GetCurrentStatusAsync) on a lost race to decide accept-vs-fallback; retries capped by MaxConcurrencyRetries.
- Broadcast timeout no longer treats TryUpdateAsync==false as "accepted"; the expire-offers write is best-effort.
- DeclineDeliveryOffer handler uses TryUpdateAsync -> benign result on a raced reject instead of a 500.
- Tests: reject regression test + fresh-reload stubs; decline test updated.