### PR TITLE
fix(delivery): never fail an order for lack of a rider — keep 3PL sea…

### DIFF
--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Services/RiderDispatchOrchestrator.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Services/RiderDispatchOrchestrator.cs
@@ -136,45 +136,37 @@ public sealed class RiderDispatchOrchestrator
         else
         {
             _logger.LogInformation(
-                "3PL already attempted for delivery {DeliveryId}; own-fleet retry exhausted — marking failed.",
+                "3PL already booked for delivery {DeliveryId}; own fleet found nobody — staying in 3PL search.",
                 deliveryRequest.Id);
         }
 
-        // Own fleet + 3PL exhausted → terminal failure. Same fresh-reload + retry so a
-        // reject/accept that changed xmin never turns into a spurious concurrency crash, and a
-        // genuine assignment is honored instead of clobbered to Failed.
-        for (var attempt = 0; attempt < MaxConcurrencyRetries; attempt++)
+        // Own fleet found no rider and 3PL wasn't booked this round (provider error, or the
+        // handoff didn't stick). We NEVER fail an order for lack of a rider — 3PL is the
+        // guaranteed backstop, it just takes time and costs more. Leave the delivery in 3PL
+        // search so the recovery service keeps re-booking the provider until an agent is
+        // assigned. A concurrent accept short-circuits.
+        fresh = await _requestRepository.GetByIdFreshAsync(deliveryRequest.Id, ct);
+        if (fresh is null)
         {
-            fresh = await _requestRepository.GetByIdFreshAsync(deliveryRequest.Id, ct);
-            if (fresh is null)
-            {
-                return DispatchResult.Failed("Delivery request no longer exists");
-            }
-            if (fresh.Status >= DeliveryRequestStatus.RiderAssigned)
-            {
-                _logger.LogInformation(
-                    "Delivery {DeliveryId} was assigned ({Status}) before the terminal fail — honoring it.",
-                    fresh.Id, fresh.Status);
-                return DispatchResult.Success(fresh.FleetType ?? FleetType.OwnFleet, fresh.RiderId);
-            }
-
-            // MarkFailed self-guards against Status >= RiderAssigned, so this only fails a
-            // request that is genuinely still unassigned.
-            fresh.MarkFailed(
-                DeliveryFailureReason.NoRidersAvailable,
-                "All dispatch options exhausted (Own Fleet declined/unavailable and 3PL failed/timed out)");
-
-            if (await _requestRepository.TryUpdateAsync(fresh, ct))
-            {
-                return DispatchResult.Failed("All dispatch options exhausted");
-            }
-            // Lost to a concurrent write — reload and re-check whether it was an assignment.
+            return DispatchResult.Failed("Delivery request no longer exists");
+        }
+        if (fresh.Status >= DeliveryRequestStatus.RiderAssigned)
+        {
+            return DispatchResult.Success(fresh.FleetType ?? FleetType.OwnFleet, fresh.RiderId);
         }
 
+        // Put/keep it in 3PL search with no live task so the recovery service re-books promptly.
+        if (fresh.Status == DeliveryRequestStatus.SearchingOwnFleet)
+            fresh.StartSearching3PL();
+        else if (fresh.Status == DeliveryRequestStatus.Searching3PL)
+            fresh.ResetForThirdPartyRetry();
+        await _requestRepository.TryUpdateAsync(fresh, ct);
+
         _logger.LogWarning(
-            "Delivery {DeliveryId} terminal-fail write kept losing the concurrency race; leaving for the recovery service.",
+            "No rider yet for delivery {DeliveryId} (own fleet empty; 3PL not booked this round). " +
+            "Keeping it in 3PL search — recovery will keep retrying the provider until an agent is assigned.",
             deliveryRequest.Id);
-        return DispatchResult.Failed("All dispatch options exhausted (contended)");
+        return DispatchResult.Failed("No rider yet — staying in 3PL search");
     }
 
     /// <summary>
@@ -378,16 +370,14 @@ public sealed class RiderDispatchOrchestrator
 
         if (!riders.Any())
         {
-            _logger.LogInformation("No riders available in Own Fleet");
-            deliveryRequest.MarkFailed(DeliveryFailureReason.NoRidersAvailable, "All dispatch options exhausted (ProRouting failed/timed out and Own Fleet unavailable)");
-            if (!await _requestRepository.TryUpdateAsync(deliveryRequest, ct))
-            {
-                _logger.LogInformation(
-                    "Delivery {DeliveryId} failure write rejected by concurrency token — a rider accepted concurrently. Honoring the assignment.",
-                    deliveryRequest.Id);
-                return DispatchResult.Success(FleetType.OwnFleet, null);
-            }
-            return DispatchResult.Failed("No riders available after exhausting all options.");
+            // Never fail for lack of an own-fleet rider — hand to the 3PL backstop and let the
+            // recovery service keep it searching until the provider assigns an agent.
+            _logger.LogInformation(
+                "No own-fleet riders for delivery {DeliveryId}; handing to 3PL search (never failing for no rider).",
+                deliveryRequest.Id);
+            deliveryRequest.StartSearching3PL();
+            await _requestRepository.TryUpdateAsync(deliveryRequest, ct);
+            return DispatchResult.Failed("No own-fleet riders — staying in 3PL search");
         }
 
         // Sequential notification
@@ -477,19 +467,22 @@ public sealed class RiderDispatchOrchestrator
         }
 
         _logger.LogInformation(
-            "All {Count} Own Fleet riders exhausted",
-            riders.Count);
+            "All {Count} Own Fleet riders exhausted for delivery {DeliveryId}; handing to 3PL search (never failing for no rider).",
+            riders.Count, deliveryRequest.Id);
 
-        deliveryRequest.MarkFailed(DeliveryFailureReason.NoRidersAvailable, "All dispatch options exhausted (ProRouting failed/timed out and Own Fleet declined)");
-        if (!await _requestRepository.TryUpdateAsync(deliveryRequest, ct))
+        // Never fail for no rider — hand to the 3PL backstop and let recovery keep it searching.
+        deliveryRequest = (await _requestRepository.GetByIdFreshAsync(deliveryRequest.Id, ct))!;
+        if (deliveryRequest is null)
+            return DispatchResult.Failed("Delivery request no longer exists");
+        if (deliveryRequest.Status >= DeliveryRequestStatus.RiderAssigned)
+            return DispatchResult.Success(deliveryRequest.FleetType ?? FleetType.OwnFleet, deliveryRequest.RiderId);
+        if (deliveryRequest.Status == DeliveryRequestStatus.SearchingOwnFleet)
         {
-            _logger.LogInformation(
-                "Delivery {DeliveryId} failure write rejected by concurrency token — a rider accepted concurrently. Honoring the assignment.",
-                deliveryRequest.Id);
-            return DispatchResult.Success(FleetType.OwnFleet, null);
+            deliveryRequest.StartSearching3PL();
+            await _requestRepository.TryUpdateAsync(deliveryRequest, ct);
         }
 
-        return DispatchResult.Failed("All riders exhausted");
+        return DispatchResult.Failed("Own fleet exhausted — staying in 3PL search");
     }
 
     private async Task<DispatchResult> AssignVia3PLAsync(
@@ -660,8 +653,9 @@ public sealed class DispatchOptions
 
     /// <summary>
     /// How long we let the 3PL provider search for an agent (after a non-blocking handoff)
-    /// before the recovery service cancels the task and retries own fleet once. Enforced
-    /// out-of-band by DeliveryDispatchRecoveryService, not by blocking the dispatch thread.
+    /// before the recovery service cancels the stale task and RE-BOOKS a fresh 3PL task. We never
+    /// give up / fail for lack of a rider — 3PL is the guaranteed backstop, it just takes time.
+    /// Enforced out-of-band by DeliveryDispatchRecoveryService, not by blocking the dispatch thread.
     /// </summary>
     public int ThirdPartySearchTimeoutMinutes { get; set; } = 15;
 

--- a/src/Modules/Delivery/RallyAPI.Delivery.Domain/Abstractions/IDeliveryRequestRepository.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Domain/Abstractions/IDeliveryRequestRepository.cs
@@ -24,8 +24,14 @@ public interface IDeliveryRequestRepository
     /// (no status change) since before <paramref name="stuckBefore"/>. Used by the
     /// dispatch recovery service to re-trigger dispatch for orders whose inline
     /// dispatch was interrupted and never retried.
+    ///
+    /// <paramref name="createdAfter"/> is a hard age floor: requests created before it are
+    /// NEVER returned. This stops a deploy/restart from resurrecting long-dead orders — a stuck
+    /// order worth recovering is minutes old, not weeks. (Incident 2026-07-09: without this floor,
+    /// the recovery service re-dispatched 68 April/May orders and booked real 3PL riders for them.)
     /// </summary>
-    Task<IReadOnlyList<DeliveryRequest>> GetStuckForRedispatchAsync(DateTime stuckBefore, CancellationToken ct = default);
+    Task<IReadOnlyList<DeliveryRequest>> GetStuckForRedispatchAsync(
+        DateTime stuckBefore, DateTime createdAfter, CancellationToken ct = default);
 
     /// <summary>
     /// Returns deliveries handed off to the 3PL provider (status <c>Searching3PL</c> with a

--- a/src/Modules/Delivery/RallyAPI.Delivery.Domain/Entities/DeliveryRequest.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Domain/Entities/DeliveryRequest.cs
@@ -489,6 +489,29 @@ public sealed class DeliveryRequest : AggregateRoot
         UpdatedAt = DateTime.UtcNow;
     }
 
+    /// <summary>
+    /// Resets a 3PL search whose provider task timed out (no agent yet) so a FRESH task can be
+    /// booked. Stays in <see cref="DeliveryRequestStatus.Searching3PL"/> and clears the stale task
+    /// identifiers AND <see cref="ThirdPartyDispatchedAt"/>, so the next dispatch creates a new
+    /// provider task. We never give up on 3PL for lack of a rider — it always assigns eventually,
+    /// it just takes time. Cancelling the stale provider task is the caller's responsibility.
+    /// </summary>
+    public void ResetForThirdPartyRetry()
+    {
+        EnsureStatus(DeliveryRequestStatus.Searching3PL);
+
+        ExternalTaskId = null;
+        ExternalTrackingUrl = null;
+        ExternalLspName = null;
+        ExternalRiderName = null;
+        ExternalRiderPhone = null;
+        ThirdPartyDispatchedAt = null;
+
+        Status = DeliveryRequestStatus.Searching3PL;
+        FleetType = Enums.FleetType.ThirdParty;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
     #endregion
 
     #region Rider Offers

--- a/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Repositories/DeliveryRequestRepository.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Repositories/DeliveryRequestRepository.cs
@@ -69,6 +69,7 @@ public sealed class DeliveryRequestRepository : IDeliveryRequestRepository
 
     public async Task<IReadOnlyList<DeliveryRequest>> GetStuckForRedispatchAsync(
         DateTime stuckBefore,
+        DateTime createdAfter,
         CancellationToken ct = default)
     {
         return await _dbContext.DeliveryRequests
@@ -77,6 +78,9 @@ public sealed class DeliveryRequestRepository : IDeliveryRequestRepository
                      || r.Status == DeliveryRequestStatus.SearchingOwnFleet
                      || r.Status == DeliveryRequestStatus.Searching3PL)
             .Where(r => r.RiderId == null)
+            // Hard age floor: never resurrect stale orders. A recoverable stuck order is minutes
+            // old; anything older is dead and must not be re-dispatched (or re-booked to 3PL).
+            .Where(r => r.CreatedAt >= createdAfter)
             // Exclude deliveries that have been handed off to the 3PL provider and are legitimately
             // waiting on its webhook — re-triggering those would create a duplicate provider task.
             // Their timeout is enforced separately by GetThirdPartySearchTimedOutAsync.

--- a/src/Modules/Orders/RallyAPI.Orders.Domain/Entities/Order.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Domain/Entities/Order.cs
@@ -416,6 +416,13 @@ public sealed class Order : AggregateRoot
     /// </summary>
     public void MarkFailed(string? reason = null)
     {
+        // Never clobber a terminal order. A delivered/cancelled/rejected/refunded order must not
+        // flip to Failed because a late or stale delivery-failure event arrived after completion —
+        // that was showing customers "Failed" on orders they had actually received. Also makes
+        // re-fails idempotent.
+        if (Status.IsTerminal())
+            return;
+
         Status = OrderStatus.Failed;
         CancellationNotes = reason?.Trim();
         UpdatedAt = DateTime.UtcNow;

--- a/src/RallyAPI.Host/BackgroundServices/DeliveryDispatchRecoveryService.cs
+++ b/src/RallyAPI.Host/BackgroundServices/DeliveryDispatchRecoveryService.cs
@@ -23,10 +23,10 @@ namespace RallyAPI.Host.BackgroundServices;
 ///
 /// (2) 3PL search timeout: after own fleet finds no rider we hand off to the 3PL provider
 /// NON-BLOCKING (status Searching3PL). The provider's webhook flips us to Assigned3PL when an
-/// agent accepts. This service enforces the ceiling: a Searching3PL delivery whose provider
-/// search has run past <see cref="DispatchOptions.ThirdPartySearchTimeoutMinutes"/> gets its
-/// provider task cancelled and own fleet retried once (which then fails if still no rider —
-/// ThirdPartyDispatchedAt marks that 3PL was already attempted).
+/// agent accepts. If a Searching3PL delivery's provider search runs past
+/// <see cref="DispatchOptions.ThirdPartySearchTimeoutMinutes"/> with no agent, this service
+/// cancels the stale task and RE-BOOKS a fresh 3PL task (never gives up / never fails for lack
+/// of a rider — 3PL is the guaranteed backstop, it just takes time).
 ///
 /// Re-dispatch is safe: TriggerDispatch is idempotent per state, and the xmin concurrency token
 /// rejects a losing write (skipped, retried next tick).
@@ -181,14 +181,14 @@ public sealed class DeliveryDispatchRecoveryService : BackgroundService
 
         var batch = timedOut.Take(BatchSize).ToList();
         _logger.LogWarning(
-            "3PL search timeout: {Total} delivery(ies) past {Minutes}min with no agent, retrying own fleet for {Batch}",
+            "3PL search timeout: {Total} delivery(ies) past {Minutes}min with no agent, re-booking a fresh 3PL task for {Batch}",
             timedOut.Count, _dispatchOptions.ThirdPartySearchTimeoutMinutes, batch.Count);
 
         foreach (var request in batch)
         {
             try
             {
-                // Reload fresh and take over only if still genuinely waiting on 3PL — a webhook
+                // Reload fresh and act only if still genuinely waiting on 3PL — a webhook
                 // may have assigned an agent between the query and now.
                 var fresh = await repository.GetByIdFreshAsync(request.Id, ct);
                 if (fresh is null || fresh.Status != DeliveryRequestStatus.Searching3PL)
@@ -196,36 +196,38 @@ public sealed class DeliveryDispatchRecoveryService : BackgroundService
 
                 var taskId = fresh.ExternalTaskId;
 
-                // Flip to own-fleet search FIRST (xmin-guarded). If a concurrent webhook assigned
-                // an agent, this loses the race — skip, don't cancel the live task.
-                fresh.TransitionToOwnFleetSearch();
+                // Reset the 3PL search FIRST (xmin-guarded), clearing the stale task so the next
+                // dispatch books a FRESH one. If a concurrent webhook assigned an agent, this loses
+                // the race — skip, don't cancel the live task. We never give up on 3PL for lack of
+                // a rider; it always assigns eventually, it just takes time.
+                fresh.ResetForThirdPartyRetry();
                 if (!await repository.TryUpdateAsync(fresh, ct))
                 {
                     _logger.LogInformation(
-                        "3PL timeout takeover of delivery {DeliveryId} lost the race to a webhook assignment; skipping.",
+                        "3PL timeout re-book of delivery {DeliveryId} lost the race to a webhook assignment; skipping.",
                         request.Id);
                     continue;
                 }
 
                 _logger.LogWarning(
-                    "3PL search timed out for delivery {DeliveryId} (Order {OrderId}, task {TaskId}); cancelling and retrying own fleet.",
+                    "3PL search timed out for delivery {DeliveryId} (Order {OrderId}, task {TaskId}); cancelling stale task and re-booking 3PL.",
                     fresh.Id, fresh.OrderId, taskId);
 
                 if (!string.IsNullOrEmpty(taskId))
                 {
-                    var cancel = await provider.CancelTaskAsync(taskId, "3PL search timeout — retrying own fleet", ct);
+                    var cancel = await provider.CancelTaskAsync(taskId, "3PL search timeout — re-booking a fresh task", ct);
                     if (!cancel.IsSuccess)
                         _logger.LogWarning(
                             "Failed to cancel timed-out 3PL task {TaskId} for delivery {DeliveryId}: {Error}",
                             taskId, fresh.Id, cancel.ErrorMessage);
                 }
 
-                // Retry own fleet once. The fallback in the orchestrator sees ThirdPartyDispatchedAt
-                // is set and will mark the delivery Failed rather than looping back to 3PL.
+                // Re-dispatch: the delivery is Searching3PL with no live task, so dispatch books a
+                // fresh 3PL task and keeps searching. The order is never failed for lack of a rider.
                 var result = await sender.Send(new TriggerDispatchCommand { DeliveryRequestId = fresh.Id }, ct);
                 if (result.IsFailure)
                     _logger.LogWarning(
-                        "Own-fleet retry after 3PL timeout for delivery {DeliveryId} returned failure: {Error}",
+                        "3PL re-book after timeout for delivery {DeliveryId} returned failure: {Error}",
                         fresh.Id, result.Error);
             }
             catch (Exception ex)

--- a/src/RallyAPI.Host/BackgroundServices/DeliveryDispatchRecoveryService.cs
+++ b/src/RallyAPI.Host/BackgroundServices/DeliveryDispatchRecoveryService.cs
@@ -35,6 +35,13 @@ public sealed class DeliveryDispatchRecoveryService : BackgroundService
 {
     private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(15);
     private static readonly TimeSpan StuckThreshold = TimeSpan.FromMinutes(2);
+
+    // Hard age floor for stuck-recovery: never re-dispatch an order created longer ago than this.
+    // A genuinely recoverable stuck order (interrupted dispatch) is minutes old; anything older is
+    // dead. Without this, a deploy/restart re-dispatches the entire historical backlog and books
+    // real 3PL riders for months-old orders (incident 2026-07-09: 68 April/May orders re-booked).
+    private static readonly TimeSpan StuckMaxAge = TimeSpan.FromHours(3);
+
     private const int BatchSize = 10;
 
     private readonly IServiceScopeFactory _scopeFactory;
@@ -132,8 +139,10 @@ public sealed class DeliveryDispatchRecoveryService : BackgroundService
         var repository = scope.ServiceProvider.GetRequiredService<IDeliveryRequestRepository>();
         var sender = scope.ServiceProvider.GetRequiredService<ISender>();
 
-        var stuckBefore = DateTime.UtcNow - StuckThreshold;
-        var stuck = await repository.GetStuckForRedispatchAsync(stuckBefore, ct);
+        var now = DateTime.UtcNow;
+        var stuckBefore = now - StuckThreshold;
+        var createdAfter = now - StuckMaxAge;
+        var stuck = await repository.GetStuckForRedispatchAsync(stuckBefore, createdAfter, ct);
         if (stuck.Count == 0)
             return;
 

--- a/tests/Modules/Delivery/RallyAPI.Delivery.Application.Tests/RiderDispatchOrchestratorTests.cs
+++ b/tests/Modules/Delivery/RallyAPI.Delivery.Application.Tests/RiderDispatchOrchestratorTests.cs
@@ -159,7 +159,7 @@ public class RiderDispatchOrchestratorTests
     }
 
     [Fact]
-    public async Task DispatchAsync_When3PLFailsAndNoRidersAvailable_ShouldMarkFailedAndReturnFailure()
+    public async Task DispatchAsync_When3PLFailsAndNoRidersAvailable_ShouldStayInThirdPartySearchNotFail()
     {
         var deliveryRequest = BuildCreatedRequest();
 
@@ -173,12 +173,14 @@ public class RiderDispatchOrchestratorTests
 
         var result = await _orchestrator.DispatchAsync(deliveryRequest);
 
+        // We never fail an order for lack of a rider — it stays in 3PL search so recovery re-books.
         result.IsSuccess.Should().BeFalse();
-        deliveryRequest.Status.Should().Be(DeliveryRequestStatus.Failed);
+        deliveryRequest.Status.Should().Be(DeliveryRequestStatus.Searching3PL);
+        deliveryRequest.Status.Should().NotBe(DeliveryRequestStatus.Failed);
     }
 
     [Fact]
-    public async Task DispatchAsync_When3PLFailsAndAllRidersDecline_ShouldMarkFailedAfterExhaustingRiders()
+    public async Task DispatchAsync_When3PLFailsAndAllRidersDecline_ShouldStayInThirdPartySearchNotFail()
     {
         var riderId = Guid.NewGuid();
         var deliveryRequest = BuildCreatedRequest();
@@ -198,22 +200,27 @@ public class RiderDispatchOrchestratorTests
             .Returns(_ => deliveryRequest);
 
         _repository
+            .GetByIdFreshAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
+            .Returns(_ => deliveryRequest);
+
+        _repository
             .GetCurrentStatusAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
             .Returns(_ => (DeliveryRequestStatus?)deliveryRequest.Status);
 
         var result = await _orchestrator.DispatchAsync(deliveryRequest);
 
+        // No rider accepted, but we never fail — the delivery is handed back to 3PL search.
         result.IsSuccess.Should().BeFalse();
-        deliveryRequest.Status.Should().Be(DeliveryRequestStatus.Failed);
+        deliveryRequest.Status.Should().Be(DeliveryRequestStatus.Searching3PL);
+        deliveryRequest.Status.Should().NotBe(DeliveryRequestStatus.Failed);
     }
 
     [Fact]
-    public async Task DispatchAsync_WhenRiderAcceptsAsTerminalFailWriteRaces_ShouldHonorAssignmentNotFail()
+    public async Task DispatchAsync_WhenRiderAcceptsBeforeTerminal_ShouldHonorAssignmentNotFail()
     {
-        // The residual sub-second race: every fresh status probe still reads SearchingOwnFleet,
-        // but the rider's acceptance commits on another connection right before the terminal
-        // Failed write. xmin catches it — TryUpdateAsync returns false (UPDATE matched 0 rows).
-        // The orchestrator must treat that as the rider winning, NOT fail the delivery.
+        // A rider's acceptance commits on another connection just as own fleet is exhausted.
+        // The loop's stale probes still read SearchingOwnFleet, but the terminal fresh reload
+        // sees the assignment and honors it — the delivery is never failed nor overwritten.
         var riderId = Guid.NewGuid();
         var deliveryRequest = BuildCreatedRequest();
 
@@ -229,20 +236,26 @@ public class RiderDispatchOrchestratorTests
             .GetByIdWithOffersAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
             .Returns(_ => deliveryRequest);
 
-        // Probes never see the accept (stale identity-map symptom the token defends against).
+        // Probes never see the accept (stale identity-map symptom the fresh reload defends against).
         _repository
             .GetCurrentStatusAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
             .Returns(_ => (DeliveryRequestStatus?)deliveryRequest.Status);
 
-        // The guarded terminal write loses the race.
+        // The terminal fresh reload sees the concurrent acceptance.
         _repository
-            .TryUpdateAsync(Arg.Any<DeliveryRequest>(), Arg.Any<CancellationToken>())
-            .Returns(false);
+            .GetByIdFreshAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                if (deliveryRequest.Status == DeliveryRequestStatus.SearchingOwnFleet)
+                    deliveryRequest.AssignOwnFleetRider(riderId, "Rider", "+91999");
+                return deliveryRequest;
+            });
 
         var result = await _orchestrator.DispatchAsync(deliveryRequest);
 
         result.IsSuccess.Should().BeTrue();
         result.FleetType.Should().Be(FleetType.OwnFleet);
+        deliveryRequest.Status.Should().NotBe(DeliveryRequestStatus.Failed);
     }
 
     [Fact]
@@ -435,7 +448,7 @@ public class RiderDispatchOrchestratorTests
     }
 
     [Fact]
-    public async Task OwnFleetFirst_WhenOwnFleetAnd3PLBothFail_ShouldMarkFailed()
+    public async Task OwnFleetFirst_WhenOwnFleetAnd3PLBothFail_ShouldStayInThirdPartySearchNeverFail()
     {
         var deliveryRequest = BuildCreatedRequest();
 
@@ -455,9 +468,11 @@ public class RiderDispatchOrchestratorTests
 
         var result = await orchestrator.DispatchAsync(deliveryRequest);
 
+        // Own fleet empty and 3PL booking failed this round — the order must NOT fail. It stays
+        // in 3PL search so the recovery service keeps re-booking the provider.
         result.IsSuccess.Should().BeFalse();
-        deliveryRequest.Status.Should().Be(DeliveryRequestStatus.Failed);
-        deliveryRequest.FailureReason.Should().Be(DeliveryFailureReason.NoRidersAvailable);
+        deliveryRequest.Status.Should().Be(DeliveryRequestStatus.Searching3PL);
+        deliveryRequest.Status.Should().NotBe(DeliveryRequestStatus.Failed);
     }
 
     [Fact]
@@ -510,11 +525,11 @@ public class RiderDispatchOrchestratorTests
     }
 
     [Fact]
-    public async Task OwnFleetFirst_WhenThirdPartyAlreadyDispatched_RetryOwnFleetFailsInsteadOfLoopingBackTo3PL()
+    public async Task OwnFleetFirst_WhenOwnFleetEmptyAfterPriorThirdParty_ShouldStayInThirdPartySearchNeverFail()
     {
-        // Simulate the post-3PL-timeout state the recovery service produces: 3PL was tried
-        // (ThirdPartyDispatchedAt set) then handed back to own fleet. If this own-fleet retry
-        // also finds no rider, the delivery must be Failed — NOT dispatched to 3PL a second time.
+        // Even in the legacy post-3PL state (ThirdPartyDispatchedAt set, handed to own fleet),
+        // an empty own fleet must NOT fail the order — it goes back to 3PL search so recovery
+        // keeps re-booking the provider. 3PL is the guaranteed backstop; we never give up.
         var deliveryRequest = BuildCreatedRequest();
         deliveryRequest.StartSearchingOwnFleet();
         deliveryRequest.StartSearching3PL();
@@ -535,10 +550,8 @@ public class RiderDispatchOrchestratorTests
         var result = await orchestrator.DispatchAsync(deliveryRequest);
 
         result.IsSuccess.Should().BeFalse();
-        deliveryRequest.Status.Should().Be(DeliveryRequestStatus.Failed);
-        // Must NOT book 3PL again.
-        await _thirdPartyProvider.DidNotReceive().CreateTaskAsync(
-            Arg.Any<CreateTaskRequest>(), Arg.Any<CancellationToken>());
+        deliveryRequest.Status.Should().Be(DeliveryRequestStatus.Searching3PL);
+        deliveryRequest.Status.Should().NotBe(DeliveryRequestStatus.Failed);
     }
 
     #region Helpers

--- a/tests/Modules/Orders/RallyAPI.Orders.Domain.Tests/OrderAggregateTests.cs
+++ b/tests/Modules/Orders/RallyAPI.Orders.Domain.Tests/OrderAggregateTests.cs
@@ -303,6 +303,39 @@ public class OrderAggregateTests
     }
 
     [Fact]
+    public void MarkFailed_WhenOrderIsDelivered_ShouldNotClobberToFailed()
+    {
+        // Regression: a late/stale delivery-failure event must NOT flip a delivered order to
+        // Failed — customers were seeing "Failed" on orders they had actually received.
+        var order = CreatePaidOrder();
+        order.Confirm();
+        order.StartPreparing();
+        order.MarkReadyForPickup();
+        order.AssignRider(Guid.NewGuid());
+        order.MarkPickedUp();
+        order.MarkDelivered();
+
+        order.MarkFailed("Delivery failed: stale event");
+
+        order.Status.Should().Be(OrderStatus.Delivered);
+        order.DeliveredAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void MarkFailed_WhenOrderStillInProgress_ShouldFail()
+    {
+        // The guard only protects terminal orders — a genuinely in-progress order can still fail.
+        var order = CreatePaidOrder();
+        order.Confirm();
+        order.StartPreparing();
+        order.MarkReadyForPickup();
+
+        order.MarkFailed("Delivery failed");
+
+        order.Status.Should().Be(OrderStatus.Failed);
+    }
+
+    [Fact]
     public void GetValidTransitions_WhenPaid_ShouldReturnPreparingConfirmedRejectedCancelled()
     {
         var order = CreatePaidOrder();

--- a/tests/RallyAPI.Integration.Tests/Flows/EarlyDispatchIntegrationTests.cs
+++ b/tests/RallyAPI.Integration.Tests/Flows/EarlyDispatchIntegrationTests.cs
@@ -120,11 +120,32 @@ public sealed class EarlyDispatchIntegrationTests : IntegrationTestBase
         var past = await SeedPendingRequestAsync(dispatchAt: now.AddMinutes(-1));
 
         // Simulate the recovery tick 5 min later so the idle (UpdatedAt) threshold is satisfied.
-        var stuck = await QueryAsync(repo => repo.GetStuckForRedispatchAsync(now.AddMinutes(5)));
+        // createdAfter is a day back so the age floor doesn't exclude the freshly-seeded rows.
+        var stuck = await QueryAsync(repo =>
+            repo.GetStuckForRedispatchAsync(now.AddMinutes(5), now.AddDays(-1)));
 
         stuck.Should().Contain(r => r.Id == past, "a past-due PendingDispatch is genuinely stuck");
         stuck.Should().NotContain(r => r.Id == future,
             "a PendingDispatch scheduled for the future must not be front-run by the 2-min net");
+    }
+
+    // ─── Scenario 6: stuck-recovery age floor — never resurrect old orders ──────────────────────
+
+    [Fact]
+    public async Task GetStuckForRedispatch_ExcludesOrdersOlderThanAgeFloor()
+    {
+        var now = DateTime.UtcNow;
+
+        var recent = await SeedPendingRequestAsync(dispatchAt: now.AddMinutes(-1));
+        var ancient = await SeedPendingRequestAsync(dispatchAt: now.AddMinutes(-1), createdAt: now.AddDays(-40));
+
+        // Age floor at 3h back: the 40-day-old order must be excluded, the fresh one included.
+        var stuck = await QueryAsync(repo =>
+            repo.GetStuckForRedispatchAsync(now.AddMinutes(5), now.AddHours(-3)));
+
+        stuck.Should().Contain(r => r.Id == recent, "a recent stuck order is recoverable");
+        stuck.Should().NotContain(r => r.Id == ancient,
+            "an order older than the age floor must never be re-dispatched (the 2026-07-09 backlog bug)");
     }
 
     // NOTE: a full place-order → confirm → event-pipeline HTTP test is intentionally omitted.
@@ -171,7 +192,7 @@ public sealed class EarlyDispatchIntegrationTests : IntegrationTestBase
         return quote.Id;
     }
 
-    private async Task<Guid> SeedPendingRequestAsync(DateTime dispatchAt)
+    private async Task<Guid> SeedPendingRequestAsync(DateTime dispatchAt, DateTime? createdAt = null)
     {
         using var scope = Factory.Services.CreateScope();
         var repo = scope.ServiceProvider.GetRequiredService<IDeliveryRequestRepository>();
@@ -187,6 +208,16 @@ public sealed class EarlyDispatchIntegrationTests : IntegrationTestBase
             dropAddress: "Gate", dropContactName: "C", dropContactPhone: "+919876543210",
             dispatchAt: dispatchAt);
         await repo.AddAsync(request);
+
+        // CreatedAt is stamped to now by the factory; backdate it via raw SQL when a test needs
+        // to simulate an old order (the age-floor scenario).
+        if (createdAt is not null)
+        {
+            var db = scope.ServiceProvider.GetRequiredService<DeliveryDbContext>();
+            await db.Database.ExecuteSqlRawAsync(
+                "update delivery.delivery_requests set created_at = {0} where id = {1}",
+                createdAt.Value, request.Id);
+        }
         return request.Id;
     }
 


### PR DESCRIPTION
…rching

An order could end in Failed when own fleet found nobody and 3PL wasn't placed (provider error or the 15-min search timeout). That's wrong: 3PL is the guaranteed backstop — it always assigns eventually, it just takes time and costs more. We must never auto-fail a paid order for "no rider".

- RiderDispatchOrchestrator: remove all three MarkFailed(NoRidersAvailable) sites. When own fleet is empty and 3PL can't be booked this round, the delivery is left in Searching3PL so the recovery service keeps re-booking the provider until an agent is assigned.
- DeliveryDispatchRecoveryService: the 3PL search-timeout sweep now cancels the stale task and RE-BOOKS a fresh 3PL task instead of retrying own fleet and failing.
- DeliveryRequest.ResetForThirdPartyRetry(): clears the stale task + dispatch marker while staying in Searching3PL so the next dispatch books fresh.

Net: a delivery can only reach Assigned3PL/delivered — never Failed for lack of a rider. Tests updated to the new contract (67 pass).