### PR TITLE
fix(menu): insert new menu-item options/groups instead of 0-row update

### DIFF
--- a/src/Modules/Catalog/RallyAPI.Catalog.Application/Abstractions/IMenuItemRepository.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Application/Abstractions/IMenuItemRepository.cs
@@ -14,4 +14,11 @@ public interface IMenuItemRepository
     void Add(MenuItem item);
     void Update(MenuItem item, CancellationToken ct = default);
     void Delete(MenuItem item);
+
+    // Explicitly mark newly-created child entities as Added. Client-set Guid
+    // keys on a tracked aggregate's navigation are otherwise misdetected as
+    // Modified (→ UPDATE affecting 0 rows), so new options/groups must be
+    // added through the context directly.
+    void AddOption(MenuItemOption option);
+    void AddOptionGroup(MenuItemOptionGroup group);
 }

--- a/src/Modules/Catalog/RallyAPI.Catalog.Application/MenuItems/Commands/AddOptionToGroup/AddOptionToGroupCommandHandler.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Application/MenuItems/Commands/AddOptionToGroup/AddOptionToGroupCommandHandler.cs
@@ -50,7 +50,10 @@ internal sealed class AddOptionToGroupCommandHandler
         group.AddOption(option);
         menuItem.AddOption(option);
 
-        _menuItemRepository.Update(menuItem, cancellationToken);
+        // menuItem/group are already tracked; the NEW option must be explicitly
+        // Added or EF misdetects the client-set Guid key as Modified and emits
+        // an UPDATE that affects 0 rows.
+        _menuItemRepository.AddOption(option);
         await _unitOfWork.SaveChangesAsync(cancellationToken);
 
         return new AddOptionToGroupResponse(option.Id);

--- a/src/Modules/Catalog/RallyAPI.Catalog.Application/MenuItems/Commands/CreateOptionGroup/CreateOptionGroupCommandHandler.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Application/MenuItems/Commands/CreateOptionGroup/CreateOptionGroupCommandHandler.cs
@@ -60,7 +60,10 @@ internal sealed class CreateOptionGroupCommandHandler
 
         menuItem.AddOptionGroup(group);
 
-        _menuItemRepository.Update(menuItem, cancellationToken);
+        // menuItem is already tracked; the NEW group (and its grouped options)
+        // must be explicitly Added or EF misdetects the client-set Guid keys as
+        // Modified and emits an UPDATE that affects 0 rows.
+        _menuItemRepository.AddOptionGroup(group);
         await _unitOfWork.SaveChangesAsync(cancellationToken);
 
         return new CreateOptionGroupResponse(group.Id);

--- a/src/Modules/Catalog/RallyAPI.Catalog.Application/MenuItems/Commands/UpdateMenuItem/UpdateMenuItemCommandHandler.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Application/MenuItems/Commands/UpdateMenuItem/UpdateMenuItemCommandHandler.cs
@@ -66,6 +66,7 @@ internal sealed class UpdateMenuItemCommandHandler
                     optionDto.IsDefault);
 
                 menuItem.AddOption(option);
+                _menuItemRepository.AddOption(option); // force Added (INSERT)
             }
         }
 
@@ -98,6 +99,7 @@ internal sealed class UpdateMenuItemCommandHandler
                 }
 
                 menuItem.AddOptionGroup(group);
+                _menuItemRepository.AddOptionGroup(group); // force Added (INSERT), cascades to grouped options
             }
         }
 

--- a/src/Modules/Catalog/RallyAPI.Catalog.Infrastructure/Persistence/Repositories/MenuItemRepository.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Infrastructure/Persistence/Repositories/MenuItemRepository.cs
@@ -89,4 +89,10 @@ internal sealed class MenuItemRepository : IMenuItemRepository
     public void Update(MenuItem item, CancellationToken ct = default) => _context.MenuItems.Update(item);
 
     public void Delete(MenuItem item) => _context.MenuItems.Remove(item);
+
+    // Add(...) forces Added state on the entity (and cascades to any children
+    // reachable via its navigations), so EF emits INSERT rather than UPDATE.
+    public void AddOption(MenuItemOption option) => _context.MenuItemOptions.Add(option);
+
+    public void AddOptionGroup(MenuItemOptionGroup group) => _context.MenuItemOptionGroups.Add(group);
 }


### PR DESCRIPTION
Updating a menu item (PUT /api/restaurant/items/{id}) with option groups returned 500 DbUpdateConcurrencyException ("expected 1 row, affected 0").

Root cause: option/group Guid keys are client-generated but the model treats the key as ValueGeneratedOnAdd. When new child entities are reached via a tracked aggregate's navigation (UpdateMenuItem) or via context.Update(item) (CreateOptionGroup, AddOptionToGroup), EF sees a non-empty key and marks them Modified -> emits UPDATE -> 0 rows affected -> concurrency exception. (CreateMenuItem works because db.Add(graph) force-marks everything Added.)

Fix: explicitly Add new options/groups through the context so EF emits INSERT. Adds IMenuItemRepository.AddOption/AddOptionGroup and uses them in the three affected handlers. Verified against a local Postgres repro: both the empty-children and existing-children (delete + re-add) paths now save correctly.


(cherry picked from commit 471aeb803dafc65ffe9d741076572a8cfa06bbdf)