### PR TITLE
bugs solved and feature udpate

### DIFF
--- a/specs/pricing-platform-fee-gst.md
+++ b/specs/pricing-platform-fee-gst.md
@@ -1,0 +1,98 @@
+# Spec: Platform Fee + GST + New Delivery Tiers (config-driven)
+
+> **Status**: PLAN — awaiting approval before implementation
+> **Branch**: `feature/pricing-platform-fee-gst` (off `master`)
+> **Priority**: P1 — production pricing / money
+> **Constraint**: must be reliable — no regression from any existing mutation/usage combination.
+
+---
+
+## 1. Target pricing model
+
+### Customer (paid on top of food subtotal)
+| Component | Rule |
+|---|---|
+| Delivery fee | ₹20 for 0–3 km, then +₹15 per km (ceil) for 3–5 km. Max at 5 km = ₹50. |
+| Platform fee | ₹10 flat |
+| GST | 18% on **(delivery fee + platform fee)** only |
+
+Example @1.42 km: delivery ₹20 + platform ₹10 + GST ₹5.40 = **₹35.40** delivery-side (food subtotal + 5% food GST are separate, unchanged).
+Example @4.2 km: delivery ₹50 + platform ₹10 + GST ₹10.80 = **₹70.80**.
+
+### Restaurant (deducted from payout, **replaces** commission flat fee)
+| Component | Rule |
+|---|---|
+| Delivery charge | ₹35 flat |
+| Platform charge | ₹15 flat |
+| GST | 18% on (35 + 15) = ₹9 |
+| **Total restaurant charge** | **₹59** |
+
+Net payout = food subtotal − ₹50 − ₹9 GST − 1% TDS. (5% food GST info line unchanged.)
+
+## 2. Config knobs (all Railway-overridable)
+```
+Delivery__Pricing__BaseFee              = 20
+Delivery__Pricing__PerKmRate            = 15
+Delivery__Pricing__BaseDistanceKm       = 3
+Delivery__Pricing__CustomerPlatformFee  = 10
+Delivery__Pricing__GstPercent           = 18
+Delivery__RestaurantCharge__DeliveryFee = 35
+Delivery__RestaurantCharge__PlatformFee = 15
+Delivery__RestaurantCharge__GstPercent  = 18
+```
+New options classes bound from config sections → change values in Railway without a redeploy of code.
+
+## 2b. Uniform customer pricing across fleets (resolved)
+The customer always pays **our** pricing — delivery tier + platform + GST — whether the order is fulfilled by own fleet or 3PL. The 3PL provider's quoted price is **our cost only** (margin tracking), never the customer's delivery fee. So `GetQuote` computes the customer delivery fee from our tiers for BOTH paths; the 3PL provider price is recorded as cost, not shown to the customer.
+
+## 3. Critical invariant (reliability)
+**`DeliveryQuote.FinalFee` MUST stay = delivery fee only.** It is the rider-earnings basis (`CalculateEarnings(QuotedPrice)`) and the 3PL `OrderAmount`. Platform fee + GST are **separate additive fields** — never folded into FinalFee, or riders would be paid a % of the platform fee/GST.
+
+## 4. Files to change (grouped)
+
+### A. Customer quote — Pricing module
+- `DeliveryPricingOptions`: BaseFee 30→20, PerKmRate 10→15; **add** `CustomerPlatformFee`, `GstPercent`.
+- `DeliveryPriceResult`: **add** `PlatformFee`, `GstAmount`, `TotalPayable` (additive, non-breaking).
+- `DeliveryPricingCalculator`: compute platform + GST, add breakdown lines; **FinalFee unchanged (delivery only)**.
+- `DeliveryQuoteDto` + quote endpoint mapping: return `platformFee`, `gst`, `totalPayable` (additive).
+
+### B. Quote persistence — Delivery module
+- `DeliveryQuote` entity: **add** `PlatformFee`, `GstAmount` (nullable, default 0) → **migration**.
+- `CreateOwnFleet` / `CreateThirdParty` factories + `GetQuoteCommandHandler`: populate + map them.
+
+### C. Order bill — Orders module
+- `OrderPricing`: **add** `PlatformFee`, `DeliveryGst` (optional, default 0); `Total` includes them → **migration**.
+- PlaceOrder request DTO: **add optional** `PlatformFee`, `DeliveryGst`.
+- Customer bill/label DTO: show the two new lines.
+
+### D. Restaurant payout — Orders module
+- New `RestaurantChargeOptions` (config).
+- `OrderDeliveredPayoutLedgerHandler`: source the charge from config (`DeliveryFee + PlatformFee`) instead of `restaurant.CommissionFlatFee`.
+- `PayoutLedger.Create`: charge = ₹50, GST = 18% of charge; make the rate config-driven.
+
+## 5. Migrations (all additive, safe)
+- `DeliveryQuote`: `PlatformFee`, `GstAmount` — nullable.
+- `Order` (OrderPricing owned type): `PlatformFee`, `DeliveryGst` — nullable/default 0.
+- No column drops, no type changes, no data rewrite. Apply on Railway **before** merge (deploy-safety rule).
+
+## 6. Reliability / regression analysis — "won't break other usages"
+| Area | Impact | Why safe |
+|---|---|---|
+| Rider earnings | none | FinalFee still delivery-only |
+| 3PL `OrderAmount` | none | uses QuotedPrice = FinalFee |
+| Existing orders/quotes | none | new columns nullable/default 0 |
+| Old frontend app (doesn't send new fields) | none | new order fields default 0 → identical Total as today |
+| Existing PayoutLedger rows | none | only new rows use new formula |
+| Dispatch / early-dispatch | none | pricing change is orthogonal |
+| **Restaurant economics** | **CHANGES** | flat ₹50+GST replaces per-restaurant `CommissionFlatFee` for all new deliveries — intended, but a real behavior change to confirm |
+| PricingEngineTests / integration | update needed | expected fee values change |
+
+## 7. Decisions (resolved)
+1. **Backend-authoritative pricing — YES (safest for money).** At placement, the delivery-side charges (delivery fee + platform fee + GST) are taken from the **stored `DeliveryQuote`** (loaded by `QuoteId`), NOT from the frontend's `pricing` object. The frontend's delivery/platform/GST values are ignored/overridden. If a delivery order has no resolvable quote → reject with a clear "refresh your quote" error. Food subtotal + 5% food tax path unchanged. Quote expiry does **not** block (the customer was shown that price); a missing/invalid `QuoteId` does.
+2. **No free-delivery threshold.** Delivery is always charged; drop the `FreeDeliveryThreshold` from any logic. All amounts come from Railway config only.
+3. **Restaurant charge = ₹50, kept as two config components (₹35 delivery + ₹15 platform) for clarity, summed to one commission charge.** Minimal code change: `OrderDeliveredPayoutLedgerHandler` sources `DeliveryFee + PlatformFee` from `RestaurantChargeOptions` (instead of `restaurant.CommissionFlatFee`) and passes the ₹50 sum into the existing `PayoutLedger.Create(commissionFlatFee:)`. The two components stay **separate in config** so the split is never a mystery; GST (18%) is already computed on the charge inside `PayoutLedger.Create`. No PayoutLedger schema change required (optional later: store the 35/15 split as two columns for audit).
+
+## 8. Test plan
+- Unit: delivery tiers (0–3 = ₹20; 3.5 = ₹35; 5 = ₹50); platform + GST math; FinalFee unchanged; OrderPricing total with platform+GST; PayoutLedger with ₹50 charge + ₹9 GST.
+- Regression: existing dispatch/order/pricing suites green (FinalFee semantics unchanged).
+- Integration: quote returns new breakdown; order stores platform+GST; payout ledger uses new charge.

--- a/specs/pricing-platform-fee-gst.md
+++ b/specs/pricing-platform-fee-gst.md
@@ -45,6 +45,12 @@ New options classes bound from config sections → change values in Railway with
 ## 2b. Uniform customer pricing across fleets (resolved)
 The customer always pays **our** pricing — delivery tier + platform + GST — whether the order is fulfilled by own fleet or 3PL. The 3PL provider's quoted price is **our cost only** (margin tracking), never the customer's delivery fee. So `GetQuote` computes the customer delivery fee from our tiers for BOTH paths; the 3PL provider price is recorded as cost, not shown to the customer.
 
+## 2c. Pickup orders (resolved)
+Pickup orders carry the **platform fee + its GST only** — no delivery fee, no delivery GST.
+So platform fee is an **order-level** charge (delivery AND pickup); delivery fee + its GST are delivery-only.
+- Delivery order bill (authoritative from the stored quote): delivery fee + platform fee + GST(delivery+platform).
+- Pickup order bill: platform fee + GST(platform), computed from config at placement (no quote exists).
+
 ## 3. Critical invariant (reliability)
 **`DeliveryQuote.FinalFee` MUST stay = delivery fee only.** It is the rider-earnings basis (`CalculateEarnings(QuotedPrice)`) and the 3PL `OrderAmount`. Platform fee + GST are **separate additive fields** — never folded into FinalFee, or riders would be paid a % of the platform fee/GST.
 

--- a/src/Modules/Catalog/RallyAPI.Catalog.Application/Abstractions/IMenuItemRepository.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Application/Abstractions/IMenuItemRepository.cs
@@ -14,4 +14,11 @@ public interface IMenuItemRepository
     void Add(MenuItem item);
     void Update(MenuItem item, CancellationToken ct = default);
     void Delete(MenuItem item);
+
+    // Explicitly mark newly-created child entities as Added. Client-set Guid
+    // keys on a tracked aggregate's navigation are otherwise misdetected as
+    // Modified (→ UPDATE affecting 0 rows), so new options/groups must be
+    // added through the context directly.
+    void AddOption(MenuItemOption option);
+    void AddOptionGroup(MenuItemOptionGroup group);
 }

--- a/src/Modules/Catalog/RallyAPI.Catalog.Application/MenuItems/Commands/AddOptionToGroup/AddOptionToGroupCommandHandler.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Application/MenuItems/Commands/AddOptionToGroup/AddOptionToGroupCommandHandler.cs
@@ -50,7 +50,10 @@ internal sealed class AddOptionToGroupCommandHandler
         group.AddOption(option);
         menuItem.AddOption(option);
 
-        _menuItemRepository.Update(menuItem, cancellationToken);
+        // menuItem/group are already tracked; the NEW option must be explicitly
+        // Added or EF misdetects the client-set Guid key as Modified and emits
+        // an UPDATE that affects 0 rows.
+        _menuItemRepository.AddOption(option);
         await _unitOfWork.SaveChangesAsync(cancellationToken);
 
         return new AddOptionToGroupResponse(option.Id);

--- a/src/Modules/Catalog/RallyAPI.Catalog.Application/MenuItems/Commands/CreateOptionGroup/CreateOptionGroupCommandHandler.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Application/MenuItems/Commands/CreateOptionGroup/CreateOptionGroupCommandHandler.cs
@@ -60,7 +60,10 @@ internal sealed class CreateOptionGroupCommandHandler
 
         menuItem.AddOptionGroup(group);
 
-        _menuItemRepository.Update(menuItem, cancellationToken);
+        // menuItem is already tracked; the NEW group (and its grouped options)
+        // must be explicitly Added or EF misdetects the client-set Guid keys as
+        // Modified and emits an UPDATE that affects 0 rows.
+        _menuItemRepository.AddOptionGroup(group);
         await _unitOfWork.SaveChangesAsync(cancellationToken);
 
         return new CreateOptionGroupResponse(group.Id);

--- a/src/Modules/Catalog/RallyAPI.Catalog.Application/MenuItems/Commands/UpdateMenuItem/UpdateMenuItemCommandHandler.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Application/MenuItems/Commands/UpdateMenuItem/UpdateMenuItemCommandHandler.cs
@@ -66,6 +66,7 @@ internal sealed class UpdateMenuItemCommandHandler
                     optionDto.IsDefault);
 
                 menuItem.AddOption(option);
+                _menuItemRepository.AddOption(option); // force Added (INSERT)
             }
         }
 
@@ -98,6 +99,7 @@ internal sealed class UpdateMenuItemCommandHandler
                 }
 
                 menuItem.AddOptionGroup(group);
+                _menuItemRepository.AddOptionGroup(group); // force Added (INSERT), cascades to grouped options
             }
         }
 

--- a/src/Modules/Catalog/RallyAPI.Catalog.Infrastructure/Persistence/Repositories/MenuItemRepository.cs
+++ b/src/Modules/Catalog/RallyAPI.Catalog.Infrastructure/Persistence/Repositories/MenuItemRepository.cs
@@ -89,4 +89,10 @@ internal sealed class MenuItemRepository : IMenuItemRepository
     public void Update(MenuItem item, CancellationToken ct = default) => _context.MenuItems.Update(item);
 
     public void Delete(MenuItem item) => _context.MenuItems.Remove(item);
+
+    // Add(...) forces Added state on the entity (and cascades to any children
+    // reachable via its navigations), so EF emits INSERT rather than UPDATE.
+    public void AddOption(MenuItemOption option) => _context.MenuItemOptions.Add(option);
+
+    public void AddOptionGroup(MenuItemOptionGroup group) => _context.MenuItemOptionGroups.Add(group);
 }

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/GetQuote/GetQuoteCommandHandler.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/GetQuote/GetQuoteCommandHandler.cs
@@ -60,7 +60,11 @@ public sealed class GetQuoteCommandHandler : IRequestHandler<GetQuoteCommand, Re
         IReadOnlyList<PriceComponent>? deliveryBreakdown)
     {
         var platformFee = _quotePricing.CustomerPlatformFee;
-        var gstAmount = Math.Round((deliveryFee + platformFee) * _quotePricing.GstPercent / 100m, 2);
+
+        // GST is charged per component so delivery and platform rates can differ in future.
+        var deliveryGst = Math.Round(deliveryFee * _quotePricing.DeliveryGstPercent / 100m, 2);
+        var platformGst = Math.Round(platformFee * _quotePricing.PlatformGstPercent / 100m, 2);
+        var gstAmount = deliveryGst + platformGst;
 
         var lines = new List<PriceComponent>();
         if (deliveryBreakdown is { Count: > 0 })
@@ -71,7 +75,7 @@ public sealed class GetQuoteCommandHandler : IRequestHandler<GetQuoteCommand, Re
         if (platformFee > 0)
             lines.Add(new PriceComponent("Platform Fee", "Platform service fee", platformFee));
         if (gstAmount > 0)
-            lines.Add(new PriceComponent("GST", $"{_quotePricing.GstPercent}% on delivery + platform fee", gstAmount));
+            lines.Add(new PriceComponent("GST", "GST on delivery + platform fee", gstAmount));
 
         return (platformFee, gstAmount, JsonSerializer.Serialize(lines));
     }

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/GetQuote/GetQuoteCommandHandler.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/GetQuote/GetQuoteCommandHandler.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using MediatR;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using RallyAPI.Delivery.Application.DTOs;
 using RallyAPI.Delivery.Domain.Abstractions;
 using RallyAPI.Delivery.Domain.Entities;
@@ -23,6 +24,7 @@ public sealed class GetQuoteCommandHandler : IRequestHandler<GetQuoteCommand, Re
     private readonly IDeliveryQuoteRepository _quoteRepository;
     private readonly IGeocodingService _geocodingService;
     private readonly IDistanceCalculator _distanceCalculator;
+    private readonly QuotePricingOptions _quotePricing;
     private readonly ILogger<GetQuoteCommandHandler> _logger;
 
     private const double SearchRadiusKm = 5.0;
@@ -35,6 +37,7 @@ public sealed class GetQuoteCommandHandler : IRequestHandler<GetQuoteCommand, Re
         IDeliveryQuoteRepository quoteRepository,
         IGeocodingService geocodingService,
         IDistanceCalculator distanceCalculator,
+        IOptions<QuotePricingOptions> quotePricing,
         ILogger<GetQuoteCommandHandler> logger)
     {
         _riderQueryService = riderQueryService;
@@ -43,7 +46,34 @@ public sealed class GetQuoteCommandHandler : IRequestHandler<GetQuoteCommand, Re
         _quoteRepository = quoteRepository;
         _geocodingService = geocodingService;
         _distanceCalculator = distanceCalculator;
+        _quotePricing = quotePricing.Value;
         _logger = logger;
+    }
+
+    /// <summary>
+    /// Platform fee + GST on (delivery fee + platform fee). Applied uniformly to every quote —
+    /// own fleet AND 3PL — because the customer always pays OUR price. Returns the two amounts and
+    /// the breakdown (base delivery lines + Platform Fee + GST) serialized to JSON for storage.
+    /// </summary>
+    private (decimal PlatformFee, decimal GstAmount, string? BreakdownJson) BuildCustomerCharges(
+        decimal deliveryFee,
+        IReadOnlyList<PriceComponent>? deliveryBreakdown)
+    {
+        var platformFee = _quotePricing.CustomerPlatformFee;
+        var gstAmount = Math.Round((deliveryFee + platformFee) * _quotePricing.GstPercent / 100m, 2);
+
+        var lines = new List<PriceComponent>();
+        if (deliveryBreakdown is { Count: > 0 })
+            lines.AddRange(deliveryBreakdown);
+        else
+            lines.Add(new PriceComponent("Delivery Fee", "Delivery charge", deliveryFee));
+
+        if (platformFee > 0)
+            lines.Add(new PriceComponent("Platform Fee", "Platform service fee", platformFee));
+        if (gstAmount > 0)
+            lines.Add(new PriceComponent("GST", $"{_quotePricing.GstPercent}% on delivery + platform fee", gstAmount));
+
+        return (platformFee, gstAmount, JsonSerializer.Serialize(lines));
     }
 
     public async Task<Result<DeliveryQuoteDto>> Handle(
@@ -198,9 +228,8 @@ public sealed class GetQuoteCommandHandler : IRequestHandler<GetQuoteCommand, Re
             return null;
         }
 
-        var breakdownJson = priceResult.Breakdown.Any()
-            ? JsonSerializer.Serialize(priceResult.Breakdown)
-            : null;
+        var (platformFee, gstAmount, breakdownJson) =
+            BuildCustomerCharges(priceResult.FinalFee, priceResult.Breakdown);
 
         return DeliveryQuote.CreateOwnFleet(
             id: Guid.NewGuid(),
@@ -220,7 +249,9 @@ public sealed class GetQuoteCommandHandler : IRequestHandler<GetQuoteCommand, Re
             expiresAt: priceResult.ExpiresAt,
             breakdownJson: breakdownJson,
             surgeMultiplier: priceResult.SurgeMultiplier,
-            surgeReason: priceResult.SurgeReason);
+            surgeReason: priceResult.SurgeReason,
+            platformFee: platformFee,
+            gstAmount: gstAmount);
     }
 
     private async Task<DeliveryQuote?> CreateThirdPartyQuote(
@@ -249,8 +280,30 @@ public sealed class GetQuoteCommandHandler : IRequestHandler<GetQuoteCommand, Re
             return null;
         }
 
-        // Select best quote (already sorted by price in provider)
+        // Serviceability confirmed. We IGNORE the provider's price — the customer always pays OUR
+        // tier price (the provider quote is our cost only). Compute our delivery fee + platform + GST.
         var bestQuote = quotesResult.Quotes.First();
+
+        var priceResult = await _pricingCalculator.CalculateAsync(
+            new DeliveryPriceRequest
+            {
+                PickupLatitude = request.PickupLatitude,
+                PickupLongitude = request.PickupLongitude,
+                DropLatitude = request.DropLatitude,
+                DropLongitude = request.DropLongitude,
+                City = city,
+                OrderAmount = request.OrderAmount,
+                RestaurantId = request.RestaurantId
+            }, ct);
+
+        if (!priceResult.IsSuccess)
+        {
+            _logger.LogWarning("Own-tier pricing failed for 3PL quote: {Error}", priceResult.ErrorMessage);
+            return null;
+        }
+
+        var (platformFee, gstAmount, breakdownJson) =
+            BuildCustomerCharges(priceResult.FinalFee, priceResult.Breakdown);
 
         return DeliveryQuote.CreateThirdParty(
             id: Guid.NewGuid(),
@@ -263,11 +316,15 @@ public sealed class GetQuoteCommandHandler : IRequestHandler<GetQuoteCommand, Re
             city: city,
             orderAmount: request.OrderAmount,
             restaurantId: request.RestaurantId,
-            price: bestQuote.PriceForward,
-            estimatedMinutes: bestQuote.SlaMins,
+            price: priceResult.FinalFee,          // OUR delivery fee, not bestQuote.PriceForward
+            estimatedMinutes: bestQuote.SlaMins,  // provider SLA for the ETA is fine
             providerName: quotesResult.ProviderName!,
             providerQuoteId: quotesResult.QuoteId!,
-            expiresAt: quotesResult.ValidUntil ?? DateTime.UtcNow.AddMinutes(5));
+            expiresAt: priceResult.ExpiresAt,
+            platformFee: platformFee,
+            gstAmount: gstAmount,
+            distanceKm: priceResult.DistanceKm,
+            breakdownJson: breakdownJson);
     }
 
     private static DeliveryQuoteDto MapToDto(DeliveryQuote quote)
@@ -288,6 +345,9 @@ public sealed class GetQuoteCommandHandler : IRequestHandler<GetQuoteCommand, Re
         {
             Id = quote.Id,
             DeliveryFee = quote.FinalFee,
+            PlatformFee = quote.PlatformFee,
+            Gst = quote.GstAmount,
+            TotalPayable = quote.CustomerTotal,
             DistanceKm = quote.DistanceKm,
             EstimatedMinutes = quote.EstimatedMinutes,
             SurgeMultiplier = quote.SurgeMultiplier,

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/GetQuote/QuotePricingOptions.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/GetQuote/QuotePricingOptions.cs
@@ -1,0 +1,18 @@
+namespace RallyAPI.Delivery.Application.Commands.GetQuote;
+
+/// <summary>
+/// Customer-facing quote add-ons applied uniformly to every quote (own fleet AND 3PL):
+/// a flat platform fee and GST on (delivery fee + platform fee). All values are config-bound
+/// so they can be tuned from Railway without a redeploy.
+/// Bound from appsettings section "Delivery:Quote".
+/// </summary>
+public sealed class QuotePricingOptions
+{
+    public const string SectionName = "Delivery:Quote";
+
+    /// <summary>Flat platform fee charged to the customer, on top of the delivery fee.</summary>
+    public decimal CustomerPlatformFee { get; set; } = 10m;
+
+    /// <summary>GST percentage on (delivery fee + platform fee). e.g. 18 = 18%.</summary>
+    public decimal GstPercent { get; set; } = 18m;
+}

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/GetQuote/QuotePricingOptions.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/GetQuote/QuotePricingOptions.cs
@@ -13,6 +13,10 @@ public sealed class QuotePricingOptions
     /// <summary>Flat platform fee charged to the customer, on top of the delivery fee.</summary>
     public decimal CustomerPlatformFee { get; set; } = 10m;
 
-    /// <summary>GST percentage on (delivery fee + platform fee). e.g. 18 = 18%.</summary>
-    public decimal GstPercent { get; set; } = 18m;
+    /// <summary>GST percentage on the delivery fee. e.g. 18 = 18%.</summary>
+    public decimal DeliveryGstPercent { get; set; } = 18m;
+
+    /// <summary>GST percentage on the platform fee. e.g. 18 = 18%. Kept separate from
+    /// <see cref="DeliveryGstPercent"/> so the two can diverge in future without a code change.</summary>
+    public decimal PlatformGstPercent { get; set; } = 18m;
 }

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/DTOs/DeliveryQuoteDto.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/DTOs/DeliveryQuoteDto.cs
@@ -3,7 +3,19 @@
 public sealed record DeliveryQuoteDto
 {
     public Guid Id { get; init; }
+
+    /// <summary>Delivery fee only (no platform fee / GST).</summary>
     public decimal DeliveryFee { get; init; }
+
+    /// <summary>Flat platform fee charged to the customer.</summary>
+    public decimal PlatformFee { get; init; }
+
+    /// <summary>GST on (delivery fee + platform fee).</summary>
+    public decimal Gst { get; init; }
+
+    /// <summary>What the customer pays for delivery = DeliveryFee + PlatformFee + Gst.</summary>
+    public decimal TotalPayable { get; init; }
+
     public decimal DistanceKm { get; init; }
     public int EstimatedMinutes { get; init; }
     public decimal SurgeMultiplier { get; init; }

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/DependencyInjection.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/DependencyInjection.cs
@@ -32,6 +32,9 @@ public static class DependencyInjection
         services.Configure<DispatchOptions>(
             configuration.GetSection(DispatchOptions.SectionName));
 
+        services.Configure<RallyAPI.Delivery.Application.Commands.GetQuote.QuotePricingOptions>(
+            configuration.GetSection(RallyAPI.Delivery.Application.Commands.GetQuote.QuotePricingOptions.SectionName));
+
         // Services
         services.AddScoped<PrepTimeCalculator>();
         services.AddScoped<RiderDispatchOrchestrator>();

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Services/RiderDispatchOrchestrator.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Services/RiderDispatchOrchestrator.cs
@@ -136,45 +136,37 @@ public sealed class RiderDispatchOrchestrator
         else
         {
             _logger.LogInformation(
-                "3PL already attempted for delivery {DeliveryId}; own-fleet retry exhausted — marking failed.",
+                "3PL already booked for delivery {DeliveryId}; own fleet found nobody — staying in 3PL search.",
                 deliveryRequest.Id);
         }
 
-        // Own fleet + 3PL exhausted → terminal failure. Same fresh-reload + retry so a
-        // reject/accept that changed xmin never turns into a spurious concurrency crash, and a
-        // genuine assignment is honored instead of clobbered to Failed.
-        for (var attempt = 0; attempt < MaxConcurrencyRetries; attempt++)
+        // Own fleet found no rider and 3PL wasn't booked this round (provider error, or the
+        // handoff didn't stick). We NEVER fail an order for lack of a rider — 3PL is the
+        // guaranteed backstop, it just takes time and costs more. Leave the delivery in 3PL
+        // search so the recovery service keeps re-booking the provider until an agent is
+        // assigned. A concurrent accept short-circuits.
+        fresh = await _requestRepository.GetByIdFreshAsync(deliveryRequest.Id, ct);
+        if (fresh is null)
         {
-            fresh = await _requestRepository.GetByIdFreshAsync(deliveryRequest.Id, ct);
-            if (fresh is null)
-            {
-                return DispatchResult.Failed("Delivery request no longer exists");
-            }
-            if (fresh.Status >= DeliveryRequestStatus.RiderAssigned)
-            {
-                _logger.LogInformation(
-                    "Delivery {DeliveryId} was assigned ({Status}) before the terminal fail — honoring it.",
-                    fresh.Id, fresh.Status);
-                return DispatchResult.Success(fresh.FleetType ?? FleetType.OwnFleet, fresh.RiderId);
-            }
-
-            // MarkFailed self-guards against Status >= RiderAssigned, so this only fails a
-            // request that is genuinely still unassigned.
-            fresh.MarkFailed(
-                DeliveryFailureReason.NoRidersAvailable,
-                "All dispatch options exhausted (Own Fleet declined/unavailable and 3PL failed/timed out)");
-
-            if (await _requestRepository.TryUpdateAsync(fresh, ct))
-            {
-                return DispatchResult.Failed("All dispatch options exhausted");
-            }
-            // Lost to a concurrent write — reload and re-check whether it was an assignment.
+            return DispatchResult.Failed("Delivery request no longer exists");
+        }
+        if (fresh.Status >= DeliveryRequestStatus.RiderAssigned)
+        {
+            return DispatchResult.Success(fresh.FleetType ?? FleetType.OwnFleet, fresh.RiderId);
         }
 
+        // Put/keep it in 3PL search with no live task so the recovery service re-books promptly.
+        if (fresh.Status == DeliveryRequestStatus.SearchingOwnFleet)
+            fresh.StartSearching3PL();
+        else if (fresh.Status == DeliveryRequestStatus.Searching3PL)
+            fresh.ResetForThirdPartyRetry();
+        await _requestRepository.TryUpdateAsync(fresh, ct);
+
         _logger.LogWarning(
-            "Delivery {DeliveryId} terminal-fail write kept losing the concurrency race; leaving for the recovery service.",
+            "No rider yet for delivery {DeliveryId} (own fleet empty; 3PL not booked this round). " +
+            "Keeping it in 3PL search — recovery will keep retrying the provider until an agent is assigned.",
             deliveryRequest.Id);
-        return DispatchResult.Failed("All dispatch options exhausted (contended)");
+        return DispatchResult.Failed("No rider yet — staying in 3PL search");
     }
 
     /// <summary>
@@ -378,16 +370,14 @@ public sealed class RiderDispatchOrchestrator
 
         if (!riders.Any())
         {
-            _logger.LogInformation("No riders available in Own Fleet");
-            deliveryRequest.MarkFailed(DeliveryFailureReason.NoRidersAvailable, "All dispatch options exhausted (ProRouting failed/timed out and Own Fleet unavailable)");
-            if (!await _requestRepository.TryUpdateAsync(deliveryRequest, ct))
-            {
-                _logger.LogInformation(
-                    "Delivery {DeliveryId} failure write rejected by concurrency token — a rider accepted concurrently. Honoring the assignment.",
-                    deliveryRequest.Id);
-                return DispatchResult.Success(FleetType.OwnFleet, null);
-            }
-            return DispatchResult.Failed("No riders available after exhausting all options.");
+            // Never fail for lack of an own-fleet rider — hand to the 3PL backstop and let the
+            // recovery service keep it searching until the provider assigns an agent.
+            _logger.LogInformation(
+                "No own-fleet riders for delivery {DeliveryId}; handing to 3PL search (never failing for no rider).",
+                deliveryRequest.Id);
+            deliveryRequest.StartSearching3PL();
+            await _requestRepository.TryUpdateAsync(deliveryRequest, ct);
+            return DispatchResult.Failed("No own-fleet riders — staying in 3PL search");
         }
 
         // Sequential notification
@@ -477,19 +467,22 @@ public sealed class RiderDispatchOrchestrator
         }
 
         _logger.LogInformation(
-            "All {Count} Own Fleet riders exhausted",
-            riders.Count);
+            "All {Count} Own Fleet riders exhausted for delivery {DeliveryId}; handing to 3PL search (never failing for no rider).",
+            riders.Count, deliveryRequest.Id);
 
-        deliveryRequest.MarkFailed(DeliveryFailureReason.NoRidersAvailable, "All dispatch options exhausted (ProRouting failed/timed out and Own Fleet declined)");
-        if (!await _requestRepository.TryUpdateAsync(deliveryRequest, ct))
+        // Never fail for no rider — hand to the 3PL backstop and let recovery keep it searching.
+        deliveryRequest = (await _requestRepository.GetByIdFreshAsync(deliveryRequest.Id, ct))!;
+        if (deliveryRequest is null)
+            return DispatchResult.Failed("Delivery request no longer exists");
+        if (deliveryRequest.Status >= DeliveryRequestStatus.RiderAssigned)
+            return DispatchResult.Success(deliveryRequest.FleetType ?? FleetType.OwnFleet, deliveryRequest.RiderId);
+        if (deliveryRequest.Status == DeliveryRequestStatus.SearchingOwnFleet)
         {
-            _logger.LogInformation(
-                "Delivery {DeliveryId} failure write rejected by concurrency token — a rider accepted concurrently. Honoring the assignment.",
-                deliveryRequest.Id);
-            return DispatchResult.Success(FleetType.OwnFleet, null);
+            deliveryRequest.StartSearching3PL();
+            await _requestRepository.TryUpdateAsync(deliveryRequest, ct);
         }
 
-        return DispatchResult.Failed("All riders exhausted");
+        return DispatchResult.Failed("Own fleet exhausted — staying in 3PL search");
     }
 
     private async Task<DispatchResult> AssignVia3PLAsync(
@@ -660,8 +653,9 @@ public sealed class DispatchOptions
 
     /// <summary>
     /// How long we let the 3PL provider search for an agent (after a non-blocking handoff)
-    /// before the recovery service cancels the task and retries own fleet once. Enforced
-    /// out-of-band by DeliveryDispatchRecoveryService, not by blocking the dispatch thread.
+    /// before the recovery service cancels the stale task and RE-BOOKS a fresh 3PL task. We never
+    /// give up / fail for lack of a rider — 3PL is the guaranteed backstop, it just takes time.
+    /// Enforced out-of-band by DeliveryDispatchRecoveryService, not by blocking the dispatch thread.
     /// </summary>
     public int ThirdPartySearchTimeoutMinutes { get; set; } = 15;
 

--- a/src/Modules/Delivery/RallyAPI.Delivery.Domain/Abstractions/IDeliveryRequestRepository.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Domain/Abstractions/IDeliveryRequestRepository.cs
@@ -24,8 +24,14 @@ public interface IDeliveryRequestRepository
     /// (no status change) since before <paramref name="stuckBefore"/>. Used by the
     /// dispatch recovery service to re-trigger dispatch for orders whose inline
     /// dispatch was interrupted and never retried.
+    ///
+    /// <paramref name="createdAfter"/> is a hard age floor: requests created before it are
+    /// NEVER returned. This stops a deploy/restart from resurrecting long-dead orders — a stuck
+    /// order worth recovering is minutes old, not weeks. (Incident 2026-07-09: without this floor,
+    /// the recovery service re-dispatched 68 April/May orders and booked real 3PL riders for them.)
     /// </summary>
-    Task<IReadOnlyList<DeliveryRequest>> GetStuckForRedispatchAsync(DateTime stuckBefore, CancellationToken ct = default);
+    Task<IReadOnlyList<DeliveryRequest>> GetStuckForRedispatchAsync(
+        DateTime stuckBefore, DateTime createdAfter, CancellationToken ct = default);
 
     /// <summary>
     /// Returns deliveries handed off to the 3PL provider (status <c>Searching3PL</c> with a

--- a/src/Modules/Delivery/RallyAPI.Delivery.Domain/Entities/DeliveryQuote.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Domain/Entities/DeliveryQuote.cs
@@ -26,7 +26,21 @@ public sealed class DeliveryQuote : BaseEntity
     // Distance & Pricing
     public decimal DistanceKm { get; private set; }
     public decimal BaseFee { get; private set; }
+
+    /// <summary>
+    /// Delivery fee only (rider-earnings basis / 3PL order amount). Never includes platform fee or GST.
+    /// </summary>
     public decimal FinalFee { get; private set; }
+
+    /// <summary>Flat platform fee charged to the customer on top of the delivery fee.</summary>
+    public decimal PlatformFee { get; private set; }
+
+    /// <summary>GST charged on (delivery fee + platform fee).</summary>
+    public decimal GstAmount { get; private set; }
+
+    /// <summary>Total the customer pays for delivery: FinalFee + PlatformFee + GstAmount.</summary>
+    public decimal CustomerTotal => FinalFee + PlatformFee + GstAmount;
+
     public decimal SurgeMultiplier { get; private set; } = 1.0m;
     public string? SurgeReason { get; private set; }
     public int EstimatedMinutes { get; private set; }
@@ -63,7 +77,9 @@ public sealed class DeliveryQuote : BaseEntity
         DateTime expiresAt,
         string? breakdownJson = null,
         decimal surgeMultiplier = 1.0m,
-        string? surgeReason = null)
+        string? surgeReason = null,
+        decimal platformFee = 0m,
+        decimal gstAmount = 0m)
     {
         return new DeliveryQuote
         {
@@ -80,6 +96,8 @@ public sealed class DeliveryQuote : BaseEntity
             DistanceKm = distanceKm,
             BaseFee = baseFee,
             FinalFee = finalFee,
+            PlatformFee = platformFee,
+            GstAmount = gstAmount,
             EstimatedMinutes = estimatedMinutes,
             SurgeMultiplier = surgeMultiplier,
             SurgeReason = surgeReason,
@@ -102,7 +120,11 @@ public sealed class DeliveryQuote : BaseEntity
         int estimatedMinutes,
         string providerName,
         string providerQuoteId,
-        DateTime expiresAt)
+        DateTime expiresAt,
+        decimal platformFee = 0m,
+        decimal gstAmount = 0m,
+        decimal? distanceKm = null,
+        string? breakdownJson = null)
     {
         return new DeliveryQuote
         {
@@ -116,15 +138,20 @@ public sealed class DeliveryQuote : BaseEntity
             City = city,
             OrderAmount = orderAmount,
             RestaurantId = restaurantId,
-            DistanceKm = 0, // Unknown for 3PL
+            DistanceKm = distanceKm ?? 0,
+            // price is OUR customer delivery fee (we charge our price even for 3PL — the
+            // provider's price is our cost, tracked elsewhere, never the customer's fee).
             BaseFee = price,
             FinalFee = price,
+            PlatformFee = platformFee,
+            GstAmount = gstAmount,
             EstimatedMinutes = estimatedMinutes,
             FleetType = FleetType.ThirdParty,
             ProviderName = providerName,
             ProviderQuoteId = providerQuoteId,
             CreatedAt = DateTime.UtcNow,
-            ExpiresAt = NormalizeToUtc(expiresAt)
+            ExpiresAt = NormalizeToUtc(expiresAt),
+            BreakdownJson = breakdownJson
         };
     }
 

--- a/src/Modules/Delivery/RallyAPI.Delivery.Domain/Entities/DeliveryRequest.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Domain/Entities/DeliveryRequest.cs
@@ -489,6 +489,29 @@ public sealed class DeliveryRequest : AggregateRoot
         UpdatedAt = DateTime.UtcNow;
     }
 
+    /// <summary>
+    /// Resets a 3PL search whose provider task timed out (no agent yet) so a FRESH task can be
+    /// booked. Stays in <see cref="DeliveryRequestStatus.Searching3PL"/> and clears the stale task
+    /// identifiers AND <see cref="ThirdPartyDispatchedAt"/>, so the next dispatch creates a new
+    /// provider task. We never give up on 3PL for lack of a rider — it always assigns eventually,
+    /// it just takes time. Cancelling the stale provider task is the caller's responsibility.
+    /// </summary>
+    public void ResetForThirdPartyRetry()
+    {
+        EnsureStatus(DeliveryRequestStatus.Searching3PL);
+
+        ExternalTaskId = null;
+        ExternalTrackingUrl = null;
+        ExternalLspName = null;
+        ExternalRiderName = null;
+        ExternalRiderPhone = null;
+        ThirdPartyDispatchedAt = null;
+
+        Status = DeliveryRequestStatus.Searching3PL;
+        FleetType = Enums.FleetType.ThirdParty;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
     #endregion
 
     #region Rider Offers

--- a/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/DependencyInjection.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/DependencyInjection.cs
@@ -42,6 +42,10 @@ public static class DependencyInjection
         // Cross-module read consumed by Orders (customer bill/label delivery OTP)
         services.AddScoped<IOrderDeliveryCodeService, OrderDeliveryCodeService>();
 
+        // Cross-module read consumed by Orders for backend-authoritative order pricing.
+        services.AddScoped<RallyAPI.SharedKernel.Abstractions.Delivery.IDeliveryQuoteReader,
+            Services.DeliveryQuoteReader>();
+
         // IRiderNotificationService is registered by the host (SignalRRiderNotificationService).
         // Do not register the stub here — it would silently mask the real implementation
         // if the host-level override were ever removed.

--- a/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Migrations/20260710195522_AddQuotePlatformFeeAndGst.Designer.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Migrations/20260710195522_AddQuotePlatformFeeAndGst.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RallyAPI.Delivery.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using RallyAPI.Delivery.Infrastructure.Persistence;
 namespace RallyAPI.Delivery.Infrastructure.Migrations
 {
     [DbContext(typeof(DeliveryDbContext))]
-    partial class DeliveryDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260710195522_AddQuotePlatformFeeAndGst")]
+    partial class AddQuotePlatformFeeAndGst
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Migrations/20260710195522_AddQuotePlatformFeeAndGst.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Migrations/20260710195522_AddQuotePlatformFeeAndGst.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RallyAPI.Delivery.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddQuotePlatformFeeAndGst : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "gst_amount",
+                schema: "delivery",
+                table: "quotes",
+                type: "numeric(10,2)",
+                precision: 10,
+                scale: 2,
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "platform_fee",
+                schema: "delivery",
+                table: "quotes",
+                type: "numeric(10,2)",
+                precision: 10,
+                scale: 2,
+                nullable: false,
+                defaultValue: 0m);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "gst_amount",
+                schema: "delivery",
+                table: "quotes");
+
+            migrationBuilder.DropColumn(
+                name: "platform_fee",
+                schema: "delivery",
+                table: "quotes");
+        }
+    }
+}

--- a/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Persistence/Configurations/DeliveryQuoteConfiguration.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Persistence/Configurations/DeliveryQuoteConfiguration.cs
@@ -75,6 +75,21 @@ public sealed class DeliveryQuoteConfiguration : IEntityTypeConfiguration<Delive
             .HasPrecision(10, 2)
             .IsRequired();
 
+        builder.Property(q => q.PlatformFee)
+            .HasColumnName("platform_fee")
+            .HasPrecision(10, 2)
+            .HasDefaultValue(0m)
+            .IsRequired();
+
+        builder.Property(q => q.GstAmount)
+            .HasColumnName("gst_amount")
+            .HasPrecision(10, 2)
+            .HasDefaultValue(0m)
+            .IsRequired();
+
+        // Computed from FinalFee + PlatformFee + GstAmount — not persisted.
+        builder.Ignore(q => q.CustomerTotal);
+
         builder.Property(q => q.SurgeMultiplier)
             .HasColumnName("surge_multiplier")
             .HasPrecision(4, 2)

--- a/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Repositories/DeliveryRequestRepository.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Repositories/DeliveryRequestRepository.cs
@@ -69,6 +69,7 @@ public sealed class DeliveryRequestRepository : IDeliveryRequestRepository
 
     public async Task<IReadOnlyList<DeliveryRequest>> GetStuckForRedispatchAsync(
         DateTime stuckBefore,
+        DateTime createdAfter,
         CancellationToken ct = default)
     {
         return await _dbContext.DeliveryRequests
@@ -77,6 +78,9 @@ public sealed class DeliveryRequestRepository : IDeliveryRequestRepository
                      || r.Status == DeliveryRequestStatus.SearchingOwnFleet
                      || r.Status == DeliveryRequestStatus.Searching3PL)
             .Where(r => r.RiderId == null)
+            // Hard age floor: never resurrect stale orders. A recoverable stuck order is minutes
+            // old; anything older is dead and must not be re-dispatched (or re-booked to 3PL).
+            .Where(r => r.CreatedAt >= createdAfter)
             // Exclude deliveries that have been handed off to the 3PL provider and are legitimately
             // waiting on its webhook — re-triggering those would create a duplicate provider task.
             // Their timeout is enforced separately by GetThirdPartySearchTimedOutAsync.

--- a/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Services/DeliveryQuoteReader.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Infrastructure/Services/DeliveryQuoteReader.cs
@@ -1,0 +1,30 @@
+using RallyAPI.Delivery.Domain.Abstractions;
+using RallyAPI.SharedKernel.Abstractions.Delivery;
+
+namespace RallyAPI.Delivery.Infrastructure.Services;
+
+/// <summary>
+/// Exposes stored delivery-quote pricing to other modules (Orders) so the order bill can be built
+/// from what we quoted, not from the frontend. Reads the DeliveryQuote aggregate by id.
+/// </summary>
+public sealed class DeliveryQuoteReader : IDeliveryQuoteReader
+{
+    private readonly IDeliveryQuoteRepository _quotes;
+
+    public DeliveryQuoteReader(IDeliveryQuoteRepository quotes) => _quotes = quotes;
+
+    public async Task<DeliveryQuotePricing?> GetPricingAsync(Guid quoteId, CancellationToken ct = default)
+    {
+        var quote = await _quotes.GetByIdAsync(quoteId, ct);
+        if (quote is null)
+            return null;
+
+        return new DeliveryQuotePricing(
+            QuoteId: quote.Id,
+            DeliveryFee: quote.FinalFee,
+            PlatformFee: quote.PlatformFee,
+            Gst: quote.GstAmount,
+            IsUsed: quote.IsUsed,
+            IsExpired: quote.IsExpired);
+    }
+}

--- a/src/Modules/Integrations/ProRouting/ProRoutingOptions.cs
+++ b/src/Modules/Integrations/ProRouting/ProRoutingOptions.cs
@@ -61,8 +61,11 @@ public sealed class ProRoutingOptions
 
     /// <summary>
     /// Cancellation reason code sent to ProRouting on order cancel.
-    /// ProRouting's cancel API expects a coded reason id (e.g. "005"),
-    /// not free text. Configurable in case they change the code table.
+    /// ProRouting's cancel API expects a coded reason id, not free text.
+    /// "010" = "Buyer wants to modify details" — the correct buyer-side,
+    /// no-fault code for our automated re-dispatch / rollback cancels
+    /// (using "005 Merchant rejected" would falsely blame the restaurant).
+    /// Configurable in case the code table changes.
     /// </summary>
-    public string DefaultCancellationReasonId { get; set; } = "005";
+    public string DefaultCancellationReasonId { get; set; } = "010";
 }

--- a/src/Modules/Integrations/ProRouting/ProRoutingOptions.cs
+++ b/src/Modules/Integrations/ProRouting/ProRoutingOptions.cs
@@ -58,4 +58,11 @@ public sealed class ProRoutingOptions
     /// Enable or disable the provider (useful for testing/fallback).
     /// </summary>
     public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Cancellation reason code sent to ProRouting on order cancel.
+    /// ProRouting's cancel API expects a coded reason id (e.g. "005"),
+    /// not free text. Configurable in case they change the code table.
+    /// </summary>
+    public string DefaultCancellationReasonId { get; set; } = "005";
 }

--- a/src/Modules/Integrations/ProRouting/ProRoutingTaskService.cs
+++ b/src/Modules/Integrations/ProRouting/ProRoutingTaskService.cs
@@ -285,7 +285,9 @@ public sealed class ProRoutingTaskService : IThirdPartyDeliveryProvider, IIgmPro
 
         try
         {
-            var request = new { order_id = taskId };
+            // ProRouting expects a nested order object: { "order": { "id": ... } }.
+            // SnakeCaseLower maps Order/Id -> order/id.
+            var request = new { Order = new { Id = taskId } };
 
             var response = await _httpClient.PostAsJsonAsync(
                 StatusEndpoint, request, JsonOptions, ct);

--- a/src/Modules/Integrations/ProRouting/ProRoutingTaskService.cs
+++ b/src/Modules/Integrations/ProRouting/ProRoutingTaskService.cs
@@ -238,9 +238,21 @@ public sealed class ProRoutingTaskService : IThirdPartyDeliveryProvider, IIgmPro
 
         try
         {
-            var request = new { order_id = taskId, reason };
+            // ProRouting expects a nested order object with a coded reason id,
+            // NOT a flat { order_id, reason }. SnakeCaseLower policy maps these
+            // to { "order": { "id": ..., "cancellation_reason_id": ... } }.
+            var request = new
+            {
+                Order = new
+                {
+                    Id = taskId,
+                    CancellationReasonId = _options.DefaultCancellationReasonId
+                }
+            };
 
-            _logger.LogInformation("Cancelling ProRouting task: {TaskId}", taskId);
+            _logger.LogInformation(
+                "Cancelling ProRouting task {TaskId} (reason: {Reason}, code: {ReasonId})",
+                taskId, reason, _options.DefaultCancellationReasonId);
 
             var response = await _httpClient.PostAsJsonAsync(
                 CancelEndpoint, request, JsonOptions, ct);

--- a/src/Modules/Orders/RallyAPI.Orders.Application/Commands/PlaceOrder/PlaceOrderCommandHandler.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/Commands/PlaceOrder/PlaceOrderCommandHandler.cs
@@ -10,6 +10,7 @@ using RallyAPI.Orders.Domain.Abstractions;
 using RallyAPI.Orders.Domain.Entities;
 using RallyAPI.Orders.Domain.Errors;
 using RallyAPI.Orders.Domain.ValueObjects;
+using RallyAPI.SharedKernel.Abstractions.Delivery;
 using RallyAPI.SharedKernel.Abstractions.Restaurants;
 using RallyAPI.SharedKernel.Results;
 
@@ -31,8 +32,10 @@ public sealed class PlaceOrderCommandHandler : IRequestHandler<PlaceOrderCommand
     private readonly ICartRepository _cartRepository;
     private readonly ICartCacheService _cartCache;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IDeliveryQuoteReader _quoteReader;
     private readonly ILogger<PlaceOrderCommandHandler> _logger;
     private readonly OrderPlacementOptions _placementOptions;
+    private readonly PlatformFeeOptions _platformFee;
 
     private const string DefaultCurrency = "INR";
 
@@ -45,8 +48,10 @@ public sealed class PlaceOrderCommandHandler : IRequestHandler<PlaceOrderCommand
         ICartRepository cartRepository,
         ICartCacheService cartCache,
         IUnitOfWork unitOfWork,
+        IDeliveryQuoteReader quoteReader,
         ILogger<PlaceOrderCommandHandler> logger,
-        IOptions<OrderPlacementOptions> placementOptions)
+        IOptions<OrderPlacementOptions> placementOptions,
+        IOptions<PlatformFeeOptions> platformFee)
     {
         _orderRepository = orderRepository;
         _orderNumberGenerator = orderNumberGenerator;
@@ -56,8 +61,10 @@ public sealed class PlaceOrderCommandHandler : IRequestHandler<PlaceOrderCommand
         _cartRepository = cartRepository;
         _cartCache = cartCache;
         _unitOfWork = unitOfWork;
+        _quoteReader = quoteReader;
         _logger = logger;
         _placementOptions = placementOptions.Value;
+        _platformFee = platformFee.Value;
     }
 
     public async Task<Result<OrderDto>> Handle(PlaceOrderCommand command, CancellationToken cancellationToken)
@@ -231,10 +238,48 @@ public sealed class PlaceOrderCommandHandler : IRequestHandler<PlaceOrderCommand
             command.Request.Pricing.DeliveryFee,
             command.Request.Pricing.Tax);
 
-            // Step 8: Create pricing (already calculated by Cart/Delivery Module)
+            // Step 8: Backend-authoritative delivery-side pricing. We do NOT trust the frontend's
+            // deliveryFee / platform / GST — we source them from what WE quoted (delivery orders)
+            // or from config (pickup: platform fee + its GST only, no delivery). Food subtotal +
+            // food tax + optional fees (packaging/service/tip/discount) still come from the request.
+            decimal authoritativeDeliveryFee;
+            decimal platformFee;
+            decimal serviceGst;
+
+            if (fulfillmentType == Domain.Enums.FulfillmentType.Delivery)
+            {
+                if (string.IsNullOrWhiteSpace(command.DeliveryQuoteId)
+                    || !Guid.TryParse(command.DeliveryQuoteId, out var quoteGuid))
+                {
+                    return Result.Failure<OrderDto>(Error.Validation(
+                        "A delivery quote is required. Please refresh your quote and try again."));
+                }
+
+                var quotePricing = await _quoteReader.GetPricingAsync(quoteGuid, cancellationToken);
+                if (quotePricing is null)
+                {
+                    return Result.Failure<OrderDto>(Error.Validation(
+                        "Delivery quote not found. Please refresh your quote and try again."));
+                }
+
+                authoritativeDeliveryFee = quotePricing.DeliveryFee;
+                platformFee = quotePricing.PlatformFee;
+                serviceGst = quotePricing.Gst;
+            }
+            else // Pickup — platform fee + its GST only.
+            {
+                authoritativeDeliveryFee = 0m;
+                platformFee = _platformFee.CustomerPlatformFee;
+                serviceGst = Math.Round(platformFee * _platformFee.PlatformGstPercent / 100m, 2);
+            }
+
+            _logger.LogInformation(
+                "Authoritative pricing — Fulfillment: {Type}, DeliveryFee: {Del}, PlatformFee: {Plat}, ServiceGst: {Gst}",
+                fulfillmentType, authoritativeDeliveryFee, platformFee, serviceGst);
+
             var pricing = OrderPricing.Create(
                 Money.FromDecimal(command.Request.Pricing.SubTotal, DefaultCurrency),
-                Money.FromDecimal(command.Request.Pricing.DeliveryFee, DefaultCurrency),
+                Money.FromDecimal(authoritativeDeliveryFee, DefaultCurrency),
                 Money.FromDecimal(command.Request.Pricing.Tax, DefaultCurrency),
                 Money.FromDecimal(command.Request.Pricing.Discount, DefaultCurrency),
                 command.Request.Pricing.PackagingFee > 0
@@ -247,7 +292,9 @@ public sealed class PlaceOrderCommandHandler : IRequestHandler<PlaceOrderCommand
                     ? Money.FromDecimal(command.Request.Pricing.Tip, DefaultCurrency)
                     : null,
                 command.Request.Pricing.DiscountCode,
-                command.Request.Pricing.DiscountDescription);
+                command.Request.Pricing.DiscountDescription,
+                platformFee: Money.FromDecimal(platformFee, DefaultCurrency),
+                serviceGst: Money.FromDecimal(serviceGst, DefaultCurrency));
 
 
             _logger.LogInformation("OrderPricing created - SubTotal: {Sub}, Total: {Total}",

--- a/src/Modules/Orders/RallyAPI.Orders.Application/DTOs/OrderPricingDto.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/DTOs/OrderPricingDto.cs
@@ -12,6 +12,13 @@ public sealed record OrderPricingDto
     public decimal PackagingFee { get; init; }
     public decimal ServiceFee { get; init; }
     public decimal Tip { get; init; }
+
+    /// <summary>Flat platform fee (delivery AND pickup orders).</summary>
+    public decimal PlatformFee { get; init; }
+
+    /// <summary>GST on delivery fee + platform fee (18%). Distinct from Tax (food GST).</summary>
+    public decimal ServiceGst { get; init; }
+
     public decimal Total { get; init; }
     public string Currency { get; init; } = "INR";
     public string? DiscountCode { get; init; }
@@ -21,6 +28,8 @@ public sealed record OrderPricingDto
     public string SubTotalDisplay { get; init; } = string.Empty;
     public string DeliveryFeeDisplay { get; init; } = string.Empty;
     public string TaxDisplay { get; init; } = string.Empty;
+    public string PlatformFeeDisplay { get; init; } = string.Empty;
+    public string ServiceGstDisplay { get; init; } = string.Empty;
     public string DiscountDisplay { get; init; } = string.Empty;
     public string TotalDisplay { get; init; } = string.Empty;
 }

--- a/src/Modules/Orders/RallyAPI.Orders.Application/EventHandlers/OrderDeliveredPayoutLedgerHandler.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/EventHandlers/OrderDeliveredPayoutLedgerHandler.cs
@@ -1,6 +1,8 @@
 using MediatR;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using RallyAPI.Orders.Application.Abstractions;
+using RallyAPI.Orders.Application.Options;
 using RallyAPI.Orders.Domain.Abstractions;
 using RallyAPI.Orders.Domain.Entities;
 using RallyAPI.Orders.Domain.Events;
@@ -19,6 +21,7 @@ public sealed class OrderDeliveredPayoutLedgerHandler : INotificationHandler<Ord
     private readonly IPayoutLedgerRepository _ledgerRepository;
     private readonly IRestaurantQueryService _restaurantQueryService;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly RestaurantChargeOptions _restaurantCharge;
     private readonly ILogger<OrderDeliveredPayoutLedgerHandler> _logger;
 
     public OrderDeliveredPayoutLedgerHandler(
@@ -26,12 +29,14 @@ public sealed class OrderDeliveredPayoutLedgerHandler : INotificationHandler<Ord
         IPayoutLedgerRepository ledgerRepository,
         IRestaurantQueryService restaurantQueryService,
         IUnitOfWork unitOfWork,
+        IOptions<RestaurantChargeOptions> restaurantCharge,
         ILogger<OrderDeliveredPayoutLedgerHandler> logger)
     {
         _orderRepository = orderRepository;
         _ledgerRepository = ledgerRepository;
         _restaurantQueryService = restaurantQueryService;
         _unitOfWork = unitOfWork;
+        _restaurantCharge = restaurantCharge.Value;
         _logger = logger;
     }
 
@@ -77,19 +82,25 @@ public sealed class OrderDeliveredPayoutLedgerHandler : INotificationHandler<Ord
             // (delivery fee, tips, service fees are not part of restaurant's earnings)
             var orderAmount = order.Pricing.SubTotal.Amount;
 
+            // Restaurant charge = ₹35 delivery + ₹15 platform = ₹50 (kept separate in config for
+            // clarity), + 18% GST — REPLACES the per-restaurant commission flat fee.
+            var restaurantCharge = _restaurantCharge.TotalCharge;
+
             var ledgerEntry = PayoutLedger.Create(
                 ownerId: restaurant.OwnerId.Value,
                 outletId: restaurant.Id,
                 orderId: order.Id,
                 orderAmount: orderAmount,
-                commissionFlatFee: restaurant.CommissionFlatFee);
+                commissionFlatFee: restaurantCharge,
+                commissionGstPercent: _restaurantCharge.GstPercent);
 
             await _ledgerRepository.AddAsync(ledgerEntry, cancellationToken);
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation(
-                "Created payout ledger entry for order {OrderNumber}: amount={Amount}, commissionFlatFee={Commission}, net={Net}",
-                notification.OrderNumber, orderAmount, restaurant.CommissionFlatFee, ledgerEntry.NetAmount);
+                "Created payout ledger entry for order {OrderNumber}: amount={Amount}, charge=₹{Charge} (delivery ₹{Del} + platform ₹{Plat}), gst={GstPct}%, net={Net}",
+                notification.OrderNumber, orderAmount, restaurantCharge,
+                _restaurantCharge.DeliveryFee, _restaurantCharge.PlatformFee, _restaurantCharge.GstPercent, ledgerEntry.NetAmount);
         }
         catch (Exception ex)
         {

--- a/src/Modules/Orders/RallyAPI.Orders.Application/Mappings/OrderMappingExtensions.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/Mappings/OrderMappingExtensions.cs
@@ -216,6 +216,8 @@ public static class OrderMappingExtensions
             PackagingFee = pricing.PackagingFee.Amount,
             ServiceFee = pricing.ServiceFee.Amount,
             Tip = pricing.Tip.Amount,
+            PlatformFee = pricing.PlatformFee.Amount,
+            ServiceGst = pricing.ServiceGst.Amount,
             Total = pricing.Total.Amount,
             Currency = pricing.SubTotal.Currency,
             DiscountCode = pricing.DiscountCode,
@@ -224,6 +226,8 @@ public static class OrderMappingExtensions
             SubTotalDisplay = pricing.SubTotal.ToDisplayString(),
             DeliveryFeeDisplay = pricing.DeliveryFee.ToDisplayString(),
             TaxDisplay = pricing.Tax.ToDisplayString(),
+            PlatformFeeDisplay = pricing.PlatformFee.ToDisplayString(),
+            ServiceGstDisplay = pricing.ServiceGst.ToDisplayString(),
             DiscountDisplay = pricing.Discount.ToDisplayString(),
             TotalDisplay = pricing.Total.ToDisplayString()
         };

--- a/src/Modules/Orders/RallyAPI.Orders.Application/Options/PlatformFeeOptions.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/Options/PlatformFeeOptions.cs
@@ -1,0 +1,16 @@
+namespace RallyAPI.Orders.Application.Options;
+
+/// <summary>
+/// Platform fee + its GST, used to price the platform charge on PICKUP orders (which have no
+/// delivery quote). Bound to the SAME config section the Delivery quote uses
+/// ("Delivery:Quote") so the value is a single source of truth across modules — change it once
+/// in Railway and both the delivery quote and pickup bill move together.
+/// For DELIVERY orders these amounts come from the stored quote, not this config.
+/// </summary>
+public sealed class PlatformFeeOptions
+{
+    public const string SectionName = "Delivery:Quote";
+
+    public decimal CustomerPlatformFee { get; set; } = 10m;
+    public decimal PlatformGstPercent { get; set; } = 18m;
+}

--- a/src/Modules/Orders/RallyAPI.Orders.Application/Options/RestaurantChargeOptions.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/Options/RestaurantChargeOptions.cs
@@ -1,0 +1,19 @@
+namespace RallyAPI.Orders.Application.Options;
+
+/// <summary>
+/// What the restaurant is charged per delivered order — a ₹35 delivery + ₹15 platform charge
+/// (kept as two values for clarity; summed to one commission of ₹50) plus 18% GST. This REPLACES
+/// the per-restaurant commission flat fee. Config-bound so it can be tuned from Railway.
+/// Section "Delivery:RestaurantCharge".
+/// </summary>
+public sealed class RestaurantChargeOptions
+{
+    public const string SectionName = "Delivery:RestaurantCharge";
+
+    public decimal DeliveryFee { get; set; } = 35m;
+    public decimal PlatformFee { get; set; } = 15m;
+    public decimal GstPercent { get; set; } = 18m;
+
+    /// <summary>The single commission charge (delivery + platform), kept transparent as a sum.</summary>
+    public decimal TotalCharge => DeliveryFee + PlatformFee;
+}

--- a/src/Modules/Orders/RallyAPI.Orders.Domain/Entities/Order.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Domain/Entities/Order.cs
@@ -416,6 +416,13 @@ public sealed class Order : AggregateRoot
     /// </summary>
     public void MarkFailed(string? reason = null)
     {
+        // Never clobber a terminal order. A delivered/cancelled/rejected/refunded order must not
+        // flip to Failed because a late or stale delivery-failure event arrived after completion —
+        // that was showing customers "Failed" on orders they had actually received. Also makes
+        // re-fails idempotent.
+        if (Status.IsTerminal())
+            return;
+
         Status = OrderStatus.Failed;
         CancellationNotes = reason?.Trim();
         UpdatedAt = DateTime.UtcNow;

--- a/src/Modules/Orders/RallyAPI.Orders.Domain/Entities/PayoutLedger.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Domain/Entities/PayoutLedger.cs
@@ -42,7 +42,8 @@ public sealed class PayoutLedger : BaseEntity
         Guid outletId,
         Guid orderId,
         decimal orderAmount,
-        decimal commissionFlatFee)
+        decimal commissionFlatFee,
+        decimal commissionGstPercent = 18m)
     {
         if (ownerId == Guid.Empty)
             throw new ArgumentException("Owner ID is required.", nameof(ownerId));
@@ -62,7 +63,7 @@ public sealed class PayoutLedger : BaseEntity
         // Phase 2 financial breakdown per Indian tax law.
         var gstAmount = Math.Round(orderAmount * 0.05m, 2);              // 5% GST on food (Section 9(5) CGST)
         var commissionAmount = Math.Round(commissionFlatFee, 2);
-        var commissionGst = Math.Round(commissionAmount * 0.18m, 2);     // 18% GST on commission (service)
+        var commissionGst = Math.Round(commissionAmount * commissionGstPercent / 100m, 2); // GST on commission (service, default 18%)
         var tdsAmount = Math.Round(orderAmount * 0.01m, 2);              // 1% TDS on gross subtotal (Section 194-O)
         var netAmount = orderAmount - commissionAmount - commissionGst - tdsAmount;
 

--- a/src/Modules/Orders/RallyAPI.Orders.Domain/ValueObjects/OrderPricing.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Domain/ValueObjects/OrderPricing.cs
@@ -18,6 +18,8 @@ public sealed class OrderPricing : ValueObject
         PackagingFee = Money.Zero();
         ServiceFee = Money.Zero();
         Tip = Money.Zero();
+        PlatformFee = Money.Zero();
+        ServiceGst = Money.Zero();
         Total = Money.Zero();
     }
     public Money SubTotal { get; private set; } = Money.Zero();
@@ -28,6 +30,13 @@ public sealed class OrderPricing : ValueObject
     public Money PackagingFee { get; private set; } = Money.Zero();
     public Money ServiceFee { get; private set; } = Money.Zero();
     public Money Tip { get; private set; } = Money.Zero();
+
+    /// <summary>Flat platform fee charged to the customer (delivery AND pickup orders).</summary>
+    public Money PlatformFee { get; private set; } = Money.Zero();
+
+    /// <summary>GST on delivery fee + platform fee (18%). Separate from <see cref="Tax"/> (food GST).</summary>
+    public Money ServiceGst { get; private set; } = Money.Zero();
+
     public string? DiscountCode { get; private set; }
     public string? DiscountDescription { get; private set; }
 
@@ -40,7 +49,9 @@ public sealed class OrderPricing : ValueObject
         Money serviceFee,
         Money tip,
         string? discountCode,
-        string? discountDescription)
+        string? discountDescription,
+        Money platformFee,
+        Money serviceGst)
     {
         SubTotal = subTotal;
         DeliveryFee = deliveryFee;
@@ -49,11 +60,13 @@ public sealed class OrderPricing : ValueObject
         PackagingFee = packagingFee;
         ServiceFee = serviceFee;
         Tip = tip;
+        PlatformFee = platformFee;
+        ServiceGst = serviceGst;
         DiscountCode = discountCode;
         DiscountDescription = discountDescription;
 
         // Calculate total
-        Total = subTotal + deliveryFee + tax + packagingFee + serviceFee + tip - discount;
+        Total = subTotal + deliveryFee + tax + platformFee + serviceGst + packagingFee + serviceFee + tip - discount;
     }
 
     public static OrderPricing Create(
@@ -65,7 +78,9 @@ public sealed class OrderPricing : ValueObject
         Money? serviceFee = null,
         Money? tip = null,
         string? discountCode = null,
-        string? discountDescription = null)
+        string? discountDescription = null,
+        Money? platformFee = null,
+        Money? serviceGst = null)
     {
         var currency = subTotal.Currency;
 
@@ -78,7 +93,9 @@ public sealed class OrderPricing : ValueObject
             serviceFee ?? Money.Zero(currency),
             tip ?? Money.Zero(currency),
             discountCode,
-            discountDescription);
+            discountDescription,
+            platformFee ?? Money.Zero(currency),
+            serviceGst ?? Money.Zero(currency));
     }
 
     /// <summary>
@@ -105,7 +122,9 @@ public sealed class OrderPricing : ValueObject
             Money.Zero(currency),
             Money.Zero(currency),
             null,
-            null);
+            null,
+            Money.Zero(currency),
+            Money.Zero(currency));
     }
 
     /// <summary>
@@ -122,7 +141,9 @@ public sealed class OrderPricing : ValueObject
             ServiceFee,
             Tip,
             DiscountCode,
-            DiscountDescription);
+            DiscountDescription,
+            PlatformFee,
+            ServiceGst);
     }
 
     /// <summary>
@@ -139,7 +160,9 @@ public sealed class OrderPricing : ValueObject
             ServiceFee,
             tip,
             DiscountCode,
-            DiscountDescription);
+            DiscountDescription,
+            PlatformFee,
+            ServiceGst);
     }
 
     /// <summary>
@@ -156,7 +179,9 @@ public sealed class OrderPricing : ValueObject
             ServiceFee,
             Tip,
             code ?? DiscountCode,
-            description ?? DiscountDescription);
+            description ?? DiscountDescription,
+            PlatformFee,
+            ServiceGst);
     }
 
     protected override IEnumerable<object> GetEqualityComponents()
@@ -168,9 +193,11 @@ public sealed class OrderPricing : ValueObject
         yield return PackagingFee;
         yield return ServiceFee;
         yield return Tip;
+        yield return PlatformFee;
+        yield return ServiceGst;
         yield return Total;
     }
 
     public override string ToString() =>
-        $"SubTotal: {SubTotal}, Delivery: {DeliveryFee}, Tax: {Tax}, Discount: {Discount}, Total: {Total}";
+        $"SubTotal: {SubTotal}, Delivery: {DeliveryFee}, Platform: {PlatformFee}, ServiceGst: {ServiceGst}, Tax: {Tax}, Discount: {Discount}, Total: {Total}";
 }

--- a/src/Modules/Orders/RallyAPI.Orders.Infrastructure/Configurations/OrderConfiguration.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Infrastructure/Configurations/OrderConfiguration.cs
@@ -202,6 +202,16 @@ public sealed class OrderConfiguration : IEntityTypeConfiguration<Order>
                 money.Property(m => m.Amount).HasColumnName("tip").HasPrecision(10, 2).IsRequired();
                 money.Property(m => m.Currency).HasColumnName("tip_currency").HasMaxLength(3).HasDefaultValue("INR");
             });
+            pricing.OwnsOne(p => p.PlatformFee, money =>
+            {
+                money.Property(m => m.Amount).HasColumnName("platform_fee").HasPrecision(10, 2).HasDefaultValue(0m).IsRequired();
+                money.Property(m => m.Currency).HasColumnName("platform_fee_currency").HasMaxLength(3).HasDefaultValue("INR");
+            });
+            pricing.OwnsOne(p => p.ServiceGst, money =>
+            {
+                money.Property(m => m.Amount).HasColumnName("service_gst").HasPrecision(10, 2).HasDefaultValue(0m).IsRequired();
+                money.Property(m => m.Currency).HasColumnName("service_gst_currency").HasMaxLength(3).HasDefaultValue("INR");
+            });
             pricing.OwnsOne(p => p.Total, money =>
             {
                 money.Property(m => m.Amount).HasColumnName("total").HasPrecision(10, 2).IsRequired();

--- a/src/Modules/Orders/RallyAPI.Orders.Infrastructure/DependencyInjection.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Infrastructure/DependencyInjection.cs
@@ -106,6 +106,8 @@ public static class DependencyInjection
             configuration.GetSection(RallyAPI.Orders.Application.Options.PlatformOptions.SectionName));
         services.Configure<RallyAPI.Orders.Application.Options.PlatformFeeOptions>(
             configuration.GetSection(RallyAPI.Orders.Application.Options.PlatformFeeOptions.SectionName));
+        services.Configure<RallyAPI.Orders.Application.Options.RestaurantChargeOptions>(
+            configuration.GetSection(RallyAPI.Orders.Application.Options.RestaurantChargeOptions.SectionName));
 
         return services;
     }

--- a/src/Modules/Orders/RallyAPI.Orders.Infrastructure/DependencyInjection.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Infrastructure/DependencyInjection.cs
@@ -104,6 +104,8 @@ public static class DependencyInjection
             configuration.GetSection(RallyAPI.Orders.Application.Options.OrderPlacementOptions.SectionName));
         services.Configure<RallyAPI.Orders.Application.Options.PlatformOptions>(
             configuration.GetSection(RallyAPI.Orders.Application.Options.PlatformOptions.SectionName));
+        services.Configure<RallyAPI.Orders.Application.Options.PlatformFeeOptions>(
+            configuration.GetSection(RallyAPI.Orders.Application.Options.PlatformFeeOptions.SectionName));
 
         return services;
     }

--- a/src/Modules/Orders/RallyAPI.Orders.Infrastructure/Migrations/20260710202203_AddOrderPlatformFeeAndServiceGst.Designer.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Infrastructure/Migrations/20260710202203_AddOrderPlatformFeeAndServiceGst.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RallyAPI.Orders.Infrastructure;
@@ -11,9 +12,11 @@ using RallyAPI.Orders.Infrastructure;
 namespace RallyAPI.Orders.Infrastructure.Migrations
 {
     [DbContext(typeof(OrdersDbContext))]
-    partial class OrdersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260710202203_AddOrderPlatformFeeAndServiceGst")]
+    partial class AddOrderPlatformFeeAndServiceGst
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Modules/Orders/RallyAPI.Orders.Infrastructure/Migrations/20260710202203_AddOrderPlatformFeeAndServiceGst.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Infrastructure/Migrations/20260710202203_AddOrderPlatformFeeAndServiceGst.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RallyAPI.Orders.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrderPlatformFeeAndServiceGst : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "platform_fee",
+                schema: "orders",
+                table: "orders",
+                type: "numeric(10,2)",
+                precision: 10,
+                scale: 2,
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.AddColumn<string>(
+                name: "platform_fee_currency",
+                schema: "orders",
+                table: "orders",
+                type: "character varying(3)",
+                maxLength: 3,
+                nullable: false,
+                defaultValue: "INR");
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "service_gst",
+                schema: "orders",
+                table: "orders",
+                type: "numeric(10,2)",
+                precision: 10,
+                scale: 2,
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.AddColumn<string>(
+                name: "service_gst_currency",
+                schema: "orders",
+                table: "orders",
+                type: "character varying(3)",
+                maxLength: 3,
+                nullable: false,
+                defaultValue: "INR");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "platform_fee",
+                schema: "orders",
+                table: "orders");
+
+            migrationBuilder.DropColumn(
+                name: "platform_fee_currency",
+                schema: "orders",
+                table: "orders");
+
+            migrationBuilder.DropColumn(
+                name: "service_gst",
+                schema: "orders",
+                table: "orders");
+
+            migrationBuilder.DropColumn(
+                name: "service_gst_currency",
+                schema: "orders",
+                table: "orders");
+        }
+    }
+}

--- a/src/Modules/Pricing/RallyAPI.Pricing.Infrastructure/Services/DeliveryPricingCalculator.cs
+++ b/src/Modules/Pricing/RallyAPI.Pricing.Infrastructure/Services/DeliveryPricingCalculator.cs
@@ -69,7 +69,8 @@ public sealed class DeliveryPricingCalculator : IDeliveryPricingCalculator
                 distanceResult.ErrorMessage, distanceKm, straightLineKm, _options.StraightLineRoadFactor);
         }
 
-        // Calculate fee
+        // Calculate delivery fee only. Platform fee + GST are applied uniformly (both fleets)
+        // in the Delivery module's GetQuote handler, not here.
         var fee = CalculateFee(distanceKm);
 
         // Build breakdown
@@ -150,9 +151,9 @@ public sealed class DeliveryPricingOptions
     public const string SectionName = "Delivery:Pricing";
 
     /// <summary>
-    /// Base delivery fee (covers first X km).
+    /// Base delivery fee (covers first X km). Customer-facing delivery charge.
     /// </summary>
-    public decimal BaseFee { get; set; } = 30m;
+    public decimal BaseFee { get; set; } = 20m;
 
     /// <summary>
     /// Distance covered by base fee.
@@ -162,7 +163,7 @@ public sealed class DeliveryPricingOptions
     /// <summary>
     /// Rate per km beyond base distance.
     /// </summary>
-    public decimal PerKmRate { get; set; } = 10m;
+    public decimal PerKmRate { get; set; } = 15m;
 
     /// <summary>
     /// How long quotes are valid (minutes).

--- a/src/RallyAPI.Host/BackgroundServices/DeliveryDispatchRecoveryService.cs
+++ b/src/RallyAPI.Host/BackgroundServices/DeliveryDispatchRecoveryService.cs
@@ -23,10 +23,10 @@ namespace RallyAPI.Host.BackgroundServices;
 ///
 /// (2) 3PL search timeout: after own fleet finds no rider we hand off to the 3PL provider
 /// NON-BLOCKING (status Searching3PL). The provider's webhook flips us to Assigned3PL when an
-/// agent accepts. This service enforces the ceiling: a Searching3PL delivery whose provider
-/// search has run past <see cref="DispatchOptions.ThirdPartySearchTimeoutMinutes"/> gets its
-/// provider task cancelled and own fleet retried once (which then fails if still no rider —
-/// ThirdPartyDispatchedAt marks that 3PL was already attempted).
+/// agent accepts. If a Searching3PL delivery's provider search runs past
+/// <see cref="DispatchOptions.ThirdPartySearchTimeoutMinutes"/> with no agent, this service
+/// cancels the stale task and RE-BOOKS a fresh 3PL task (never gives up / never fails for lack
+/// of a rider — 3PL is the guaranteed backstop, it just takes time).
 ///
 /// Re-dispatch is safe: TriggerDispatch is idempotent per state, and the xmin concurrency token
 /// rejects a losing write (skipped, retried next tick).
@@ -181,14 +181,14 @@ public sealed class DeliveryDispatchRecoveryService : BackgroundService
 
         var batch = timedOut.Take(BatchSize).ToList();
         _logger.LogWarning(
-            "3PL search timeout: {Total} delivery(ies) past {Minutes}min with no agent, retrying own fleet for {Batch}",
+            "3PL search timeout: {Total} delivery(ies) past {Minutes}min with no agent, re-booking a fresh 3PL task for {Batch}",
             timedOut.Count, _dispatchOptions.ThirdPartySearchTimeoutMinutes, batch.Count);
 
         foreach (var request in batch)
         {
             try
             {
-                // Reload fresh and take over only if still genuinely waiting on 3PL — a webhook
+                // Reload fresh and act only if still genuinely waiting on 3PL — a webhook
                 // may have assigned an agent between the query and now.
                 var fresh = await repository.GetByIdFreshAsync(request.Id, ct);
                 if (fresh is null || fresh.Status != DeliveryRequestStatus.Searching3PL)
@@ -196,36 +196,38 @@ public sealed class DeliveryDispatchRecoveryService : BackgroundService
 
                 var taskId = fresh.ExternalTaskId;
 
-                // Flip to own-fleet search FIRST (xmin-guarded). If a concurrent webhook assigned
-                // an agent, this loses the race — skip, don't cancel the live task.
-                fresh.TransitionToOwnFleetSearch();
+                // Reset the 3PL search FIRST (xmin-guarded), clearing the stale task so the next
+                // dispatch books a FRESH one. If a concurrent webhook assigned an agent, this loses
+                // the race — skip, don't cancel the live task. We never give up on 3PL for lack of
+                // a rider; it always assigns eventually, it just takes time.
+                fresh.ResetForThirdPartyRetry();
                 if (!await repository.TryUpdateAsync(fresh, ct))
                 {
                     _logger.LogInformation(
-                        "3PL timeout takeover of delivery {DeliveryId} lost the race to a webhook assignment; skipping.",
+                        "3PL timeout re-book of delivery {DeliveryId} lost the race to a webhook assignment; skipping.",
                         request.Id);
                     continue;
                 }
 
                 _logger.LogWarning(
-                    "3PL search timed out for delivery {DeliveryId} (Order {OrderId}, task {TaskId}); cancelling and retrying own fleet.",
+                    "3PL search timed out for delivery {DeliveryId} (Order {OrderId}, task {TaskId}); cancelling stale task and re-booking 3PL.",
                     fresh.Id, fresh.OrderId, taskId);
 
                 if (!string.IsNullOrEmpty(taskId))
                 {
-                    var cancel = await provider.CancelTaskAsync(taskId, "3PL search timeout — retrying own fleet", ct);
+                    var cancel = await provider.CancelTaskAsync(taskId, "3PL search timeout — re-booking a fresh task", ct);
                     if (!cancel.IsSuccess)
                         _logger.LogWarning(
                             "Failed to cancel timed-out 3PL task {TaskId} for delivery {DeliveryId}: {Error}",
                             taskId, fresh.Id, cancel.ErrorMessage);
                 }
 
-                // Retry own fleet once. The fallback in the orchestrator sees ThirdPartyDispatchedAt
-                // is set and will mark the delivery Failed rather than looping back to 3PL.
+                // Re-dispatch: the delivery is Searching3PL with no live task, so dispatch books a
+                // fresh 3PL task and keeps searching. The order is never failed for lack of a rider.
                 var result = await sender.Send(new TriggerDispatchCommand { DeliveryRequestId = fresh.Id }, ct);
                 if (result.IsFailure)
                     _logger.LogWarning(
-                        "Own-fleet retry after 3PL timeout for delivery {DeliveryId} returned failure: {Error}",
+                        "3PL re-book after timeout for delivery {DeliveryId} returned failure: {Error}",
                         fresh.Id, result.Error);
             }
             catch (Exception ex)

--- a/src/RallyAPI.Host/BackgroundServices/DeliveryDispatchRecoveryService.cs
+++ b/src/RallyAPI.Host/BackgroundServices/DeliveryDispatchRecoveryService.cs
@@ -35,6 +35,13 @@ public sealed class DeliveryDispatchRecoveryService : BackgroundService
 {
     private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(15);
     private static readonly TimeSpan StuckThreshold = TimeSpan.FromMinutes(2);
+
+    // Hard age floor for stuck-recovery: never re-dispatch an order created longer ago than this.
+    // A genuinely recoverable stuck order (interrupted dispatch) is minutes old; anything older is
+    // dead. Without this, a deploy/restart re-dispatches the entire historical backlog and books
+    // real 3PL riders for months-old orders (incident 2026-07-09: 68 April/May orders re-booked).
+    private static readonly TimeSpan StuckMaxAge = TimeSpan.FromHours(3);
+
     private const int BatchSize = 10;
 
     private readonly IServiceScopeFactory _scopeFactory;
@@ -132,8 +139,10 @@ public sealed class DeliveryDispatchRecoveryService : BackgroundService
         var repository = scope.ServiceProvider.GetRequiredService<IDeliveryRequestRepository>();
         var sender = scope.ServiceProvider.GetRequiredService<ISender>();
 
-        var stuckBefore = DateTime.UtcNow - StuckThreshold;
-        var stuck = await repository.GetStuckForRedispatchAsync(stuckBefore, ct);
+        var now = DateTime.UtcNow;
+        var stuckBefore = now - StuckThreshold;
+        var createdAfter = now - StuckMaxAge;
+        var stuck = await repository.GetStuckForRedispatchAsync(stuckBefore, createdAfter, ct);
         if (stuck.Count == 0)
             return;
 

--- a/src/RallyAPI.SharedKernel/Abstractions/Delivery/IDeliveryQuoteReader.cs
+++ b/src/RallyAPI.SharedKernel/Abstractions/Delivery/IDeliveryQuoteReader.cs
@@ -1,0 +1,27 @@
+namespace RallyAPI.SharedKernel.Abstractions.Delivery;
+
+/// <summary>
+/// Reads a previously-issued delivery quote's authoritative pricing by id. Lets the Orders module
+/// build the order bill from what WE quoted (backend-authoritative) instead of trusting the
+/// frontend's numbers. Implemented in the Delivery module over the stored DeliveryQuote.
+/// </summary>
+public interface IDeliveryQuoteReader
+{
+    Task<DeliveryQuotePricing?> GetPricingAsync(Guid quoteId, CancellationToken ct = default);
+}
+
+/// <summary>
+/// The customer-facing delivery-side charges captured on a quote.
+/// <paramref name="Gst"/> is the total GST on (delivery fee + platform fee).
+/// </summary>
+public sealed record DeliveryQuotePricing(
+    Guid QuoteId,
+    decimal DeliveryFee,
+    decimal PlatformFee,
+    decimal Gst,
+    bool IsUsed,
+    bool IsExpired)
+{
+    /// <summary>What the customer pays for delivery = DeliveryFee + PlatformFee + Gst.</summary>
+    public decimal Total => DeliveryFee + PlatformFee + Gst;
+}

--- a/src/RallyAPI.SharedKernel/Abstractions/Pricing/DeliveryPriceResult.cs
+++ b/src/RallyAPI.SharedKernel/Abstractions/Pricing/DeliveryPriceResult.cs
@@ -23,7 +23,9 @@ public sealed record DeliveryPriceResult
     public decimal BaseFee { get; private init; }
 
     /// <summary>
-    /// Final fee including all surges.
+    /// Final DELIVERY fee including all surges. This is the rider-earnings basis and the 3PL
+    /// order amount — it never includes the platform fee or GST (those are applied in the
+    /// Delivery module's GetQuote handler).
     /// </summary>
     public decimal FinalFee { get; private init; }
 

--- a/tests/Modules/Delivery/RallyAPI.Delivery.Application.Tests/RiderDispatchOrchestratorTests.cs
+++ b/tests/Modules/Delivery/RallyAPI.Delivery.Application.Tests/RiderDispatchOrchestratorTests.cs
@@ -159,7 +159,7 @@ public class RiderDispatchOrchestratorTests
     }
 
     [Fact]
-    public async Task DispatchAsync_When3PLFailsAndNoRidersAvailable_ShouldMarkFailedAndReturnFailure()
+    public async Task DispatchAsync_When3PLFailsAndNoRidersAvailable_ShouldStayInThirdPartySearchNotFail()
     {
         var deliveryRequest = BuildCreatedRequest();
 
@@ -173,12 +173,14 @@ public class RiderDispatchOrchestratorTests
 
         var result = await _orchestrator.DispatchAsync(deliveryRequest);
 
+        // We never fail an order for lack of a rider — it stays in 3PL search so recovery re-books.
         result.IsSuccess.Should().BeFalse();
-        deliveryRequest.Status.Should().Be(DeliveryRequestStatus.Failed);
+        deliveryRequest.Status.Should().Be(DeliveryRequestStatus.Searching3PL);
+        deliveryRequest.Status.Should().NotBe(DeliveryRequestStatus.Failed);
     }
 
     [Fact]
-    public async Task DispatchAsync_When3PLFailsAndAllRidersDecline_ShouldMarkFailedAfterExhaustingRiders()
+    public async Task DispatchAsync_When3PLFailsAndAllRidersDecline_ShouldStayInThirdPartySearchNotFail()
     {
         var riderId = Guid.NewGuid();
         var deliveryRequest = BuildCreatedRequest();
@@ -198,22 +200,27 @@ public class RiderDispatchOrchestratorTests
             .Returns(_ => deliveryRequest);
 
         _repository
+            .GetByIdFreshAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
+            .Returns(_ => deliveryRequest);
+
+        _repository
             .GetCurrentStatusAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
             .Returns(_ => (DeliveryRequestStatus?)deliveryRequest.Status);
 
         var result = await _orchestrator.DispatchAsync(deliveryRequest);
 
+        // No rider accepted, but we never fail — the delivery is handed back to 3PL search.
         result.IsSuccess.Should().BeFalse();
-        deliveryRequest.Status.Should().Be(DeliveryRequestStatus.Failed);
+        deliveryRequest.Status.Should().Be(DeliveryRequestStatus.Searching3PL);
+        deliveryRequest.Status.Should().NotBe(DeliveryRequestStatus.Failed);
     }
 
     [Fact]
-    public async Task DispatchAsync_WhenRiderAcceptsAsTerminalFailWriteRaces_ShouldHonorAssignmentNotFail()
+    public async Task DispatchAsync_WhenRiderAcceptsBeforeTerminal_ShouldHonorAssignmentNotFail()
     {
-        // The residual sub-second race: every fresh status probe still reads SearchingOwnFleet,
-        // but the rider's acceptance commits on another connection right before the terminal
-        // Failed write. xmin catches it — TryUpdateAsync returns false (UPDATE matched 0 rows).
-        // The orchestrator must treat that as the rider winning, NOT fail the delivery.
+        // A rider's acceptance commits on another connection just as own fleet is exhausted.
+        // The loop's stale probes still read SearchingOwnFleet, but the terminal fresh reload
+        // sees the assignment and honors it — the delivery is never failed nor overwritten.
         var riderId = Guid.NewGuid();
         var deliveryRequest = BuildCreatedRequest();
 
@@ -229,20 +236,26 @@ public class RiderDispatchOrchestratorTests
             .GetByIdWithOffersAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
             .Returns(_ => deliveryRequest);
 
-        // Probes never see the accept (stale identity-map symptom the token defends against).
+        // Probes never see the accept (stale identity-map symptom the fresh reload defends against).
         _repository
             .GetCurrentStatusAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
             .Returns(_ => (DeliveryRequestStatus?)deliveryRequest.Status);
 
-        // The guarded terminal write loses the race.
+        // The terminal fresh reload sees the concurrent acceptance.
         _repository
-            .TryUpdateAsync(Arg.Any<DeliveryRequest>(), Arg.Any<CancellationToken>())
-            .Returns(false);
+            .GetByIdFreshAsync(deliveryRequest.Id, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                if (deliveryRequest.Status == DeliveryRequestStatus.SearchingOwnFleet)
+                    deliveryRequest.AssignOwnFleetRider(riderId, "Rider", "+91999");
+                return deliveryRequest;
+            });
 
         var result = await _orchestrator.DispatchAsync(deliveryRequest);
 
         result.IsSuccess.Should().BeTrue();
         result.FleetType.Should().Be(FleetType.OwnFleet);
+        deliveryRequest.Status.Should().NotBe(DeliveryRequestStatus.Failed);
     }
 
     [Fact]
@@ -435,7 +448,7 @@ public class RiderDispatchOrchestratorTests
     }
 
     [Fact]
-    public async Task OwnFleetFirst_WhenOwnFleetAnd3PLBothFail_ShouldMarkFailed()
+    public async Task OwnFleetFirst_WhenOwnFleetAnd3PLBothFail_ShouldStayInThirdPartySearchNeverFail()
     {
         var deliveryRequest = BuildCreatedRequest();
 
@@ -455,9 +468,11 @@ public class RiderDispatchOrchestratorTests
 
         var result = await orchestrator.DispatchAsync(deliveryRequest);
 
+        // Own fleet empty and 3PL booking failed this round — the order must NOT fail. It stays
+        // in 3PL search so the recovery service keeps re-booking the provider.
         result.IsSuccess.Should().BeFalse();
-        deliveryRequest.Status.Should().Be(DeliveryRequestStatus.Failed);
-        deliveryRequest.FailureReason.Should().Be(DeliveryFailureReason.NoRidersAvailable);
+        deliveryRequest.Status.Should().Be(DeliveryRequestStatus.Searching3PL);
+        deliveryRequest.Status.Should().NotBe(DeliveryRequestStatus.Failed);
     }
 
     [Fact]
@@ -510,11 +525,11 @@ public class RiderDispatchOrchestratorTests
     }
 
     [Fact]
-    public async Task OwnFleetFirst_WhenThirdPartyAlreadyDispatched_RetryOwnFleetFailsInsteadOfLoopingBackTo3PL()
+    public async Task OwnFleetFirst_WhenOwnFleetEmptyAfterPriorThirdParty_ShouldStayInThirdPartySearchNeverFail()
     {
-        // Simulate the post-3PL-timeout state the recovery service produces: 3PL was tried
-        // (ThirdPartyDispatchedAt set) then handed back to own fleet. If this own-fleet retry
-        // also finds no rider, the delivery must be Failed — NOT dispatched to 3PL a second time.
+        // Even in the legacy post-3PL state (ThirdPartyDispatchedAt set, handed to own fleet),
+        // an empty own fleet must NOT fail the order — it goes back to 3PL search so recovery
+        // keeps re-booking the provider. 3PL is the guaranteed backstop; we never give up.
         var deliveryRequest = BuildCreatedRequest();
         deliveryRequest.StartSearchingOwnFleet();
         deliveryRequest.StartSearching3PL();
@@ -535,10 +550,8 @@ public class RiderDispatchOrchestratorTests
         var result = await orchestrator.DispatchAsync(deliveryRequest);
 
         result.IsSuccess.Should().BeFalse();
-        deliveryRequest.Status.Should().Be(DeliveryRequestStatus.Failed);
-        // Must NOT book 3PL again.
-        await _thirdPartyProvider.DidNotReceive().CreateTaskAsync(
-            Arg.Any<CreateTaskRequest>(), Arg.Any<CancellationToken>());
+        deliveryRequest.Status.Should().Be(DeliveryRequestStatus.Searching3PL);
+        deliveryRequest.Status.Should().NotBe(DeliveryRequestStatus.Failed);
     }
 
     #region Helpers

--- a/tests/Modules/Orders/RallyAPI.Orders.Domain.Tests/OrderAggregateTests.cs
+++ b/tests/Modules/Orders/RallyAPI.Orders.Domain.Tests/OrderAggregateTests.cs
@@ -303,6 +303,39 @@ public class OrderAggregateTests
     }
 
     [Fact]
+    public void MarkFailed_WhenOrderIsDelivered_ShouldNotClobberToFailed()
+    {
+        // Regression: a late/stale delivery-failure event must NOT flip a delivered order to
+        // Failed — customers were seeing "Failed" on orders they had actually received.
+        var order = CreatePaidOrder();
+        order.Confirm();
+        order.StartPreparing();
+        order.MarkReadyForPickup();
+        order.AssignRider(Guid.NewGuid());
+        order.MarkPickedUp();
+        order.MarkDelivered();
+
+        order.MarkFailed("Delivery failed: stale event");
+
+        order.Status.Should().Be(OrderStatus.Delivered);
+        order.DeliveredAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void MarkFailed_WhenOrderStillInProgress_ShouldFail()
+    {
+        // The guard only protects terminal orders — a genuinely in-progress order can still fail.
+        var order = CreatePaidOrder();
+        order.Confirm();
+        order.StartPreparing();
+        order.MarkReadyForPickup();
+
+        order.MarkFailed("Delivery failed");
+
+        order.Status.Should().Be(OrderStatus.Failed);
+    }
+
+    [Fact]
     public void GetValidTransitions_WhenPaid_ShouldReturnPreparingConfirmedRejectedCancelled()
     {
         var order = CreatePaidOrder();

--- a/tests/Modules/Orders/RallyAPI.Orders.Domain.Tests/OrderPricingTests.cs
+++ b/tests/Modules/Orders/RallyAPI.Orders.Domain.Tests/OrderPricingTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using RallyAPI.Orders.Domain.ValueObjects;
+using Xunit;
+
+namespace RallyAPI.Orders.Domain.Tests;
+
+public class OrderPricingTests
+{
+    private static Money Inr(decimal v) => Money.FromDecimal(v, "INR");
+
+    [Fact]
+    public void Create_IncludesPlatformFeeAndServiceGstInTotal()
+    {
+        var pricing = OrderPricing.Create(
+            subTotal: Inr(200m),
+            deliveryFee: Inr(20m),
+            tax: Inr(10m),          // food GST (5%)
+            discount: Inr(0m),
+            platformFee: Inr(10m),
+            serviceGst: Inr(5.40m)); // 18% of (20 + 10)
+
+        pricing.PlatformFee.Amount.Should().Be(10m);
+        pricing.ServiceGst.Amount.Should().Be(5.40m);
+        // 200 + 20 + 10 (food tax) + 10 (platform) + 5.40 (service gst) = 245.40
+        pricing.Total.Amount.Should().Be(245.40m);
+    }
+
+    [Fact]
+    public void Create_DefaultsPlatformFeeAndServiceGstToZero_TotalUnchanged()
+    {
+        // Backward compatibility: an old caller that doesn't pass platform/GST gets the same
+        // total it always did (no phantom charges).
+        var pricing = OrderPricing.Create(
+            subTotal: Inr(200m),
+            deliveryFee: Inr(30m),
+            tax: Inr(10m),
+            discount: Inr(0m));
+
+        pricing.PlatformFee.Amount.Should().Be(0m);
+        pricing.ServiceGst.Amount.Should().Be(0m);
+        pricing.Total.Amount.Should().Be(240m);
+    }
+}

--- a/tests/RallyAPI.Integration.Tests/Flows/EarlyDispatchIntegrationTests.cs
+++ b/tests/RallyAPI.Integration.Tests/Flows/EarlyDispatchIntegrationTests.cs
@@ -120,11 +120,32 @@ public sealed class EarlyDispatchIntegrationTests : IntegrationTestBase
         var past = await SeedPendingRequestAsync(dispatchAt: now.AddMinutes(-1));
 
         // Simulate the recovery tick 5 min later so the idle (UpdatedAt) threshold is satisfied.
-        var stuck = await QueryAsync(repo => repo.GetStuckForRedispatchAsync(now.AddMinutes(5)));
+        // createdAfter is a day back so the age floor doesn't exclude the freshly-seeded rows.
+        var stuck = await QueryAsync(repo =>
+            repo.GetStuckForRedispatchAsync(now.AddMinutes(5), now.AddDays(-1)));
 
         stuck.Should().Contain(r => r.Id == past, "a past-due PendingDispatch is genuinely stuck");
         stuck.Should().NotContain(r => r.Id == future,
             "a PendingDispatch scheduled for the future must not be front-run by the 2-min net");
+    }
+
+    // ─── Scenario 6: stuck-recovery age floor — never resurrect old orders ──────────────────────
+
+    [Fact]
+    public async Task GetStuckForRedispatch_ExcludesOrdersOlderThanAgeFloor()
+    {
+        var now = DateTime.UtcNow;
+
+        var recent = await SeedPendingRequestAsync(dispatchAt: now.AddMinutes(-1));
+        var ancient = await SeedPendingRequestAsync(dispatchAt: now.AddMinutes(-1), createdAt: now.AddDays(-40));
+
+        // Age floor at 3h back: the 40-day-old order must be excluded, the fresh one included.
+        var stuck = await QueryAsync(repo =>
+            repo.GetStuckForRedispatchAsync(now.AddMinutes(5), now.AddHours(-3)));
+
+        stuck.Should().Contain(r => r.Id == recent, "a recent stuck order is recoverable");
+        stuck.Should().NotContain(r => r.Id == ancient,
+            "an order older than the age floor must never be re-dispatched (the 2026-07-09 backlog bug)");
     }
 
     // NOTE: a full place-order → confirm → event-pipeline HTTP test is intentionally omitted.
@@ -171,7 +192,7 @@ public sealed class EarlyDispatchIntegrationTests : IntegrationTestBase
         return quote.Id;
     }
 
-    private async Task<Guid> SeedPendingRequestAsync(DateTime dispatchAt)
+    private async Task<Guid> SeedPendingRequestAsync(DateTime dispatchAt, DateTime? createdAt = null)
     {
         using var scope = Factory.Services.CreateScope();
         var repo = scope.ServiceProvider.GetRequiredService<IDeliveryRequestRepository>();
@@ -187,6 +208,16 @@ public sealed class EarlyDispatchIntegrationTests : IntegrationTestBase
             dropAddress: "Gate", dropContactName: "C", dropContactPhone: "+919876543210",
             dispatchAt: dispatchAt);
         await repo.AddAsync(request);
+
+        // CreatedAt is stamped to now by the factory; backdate it via raw SQL when a test needs
+        // to simulate an old order (the age-floor scenario).
+        if (createdAt is not null)
+        {
+            var db = scope.ServiceProvider.GetRequiredService<DeliveryDbContext>();
+            await db.Database.ExecuteSqlRawAsync(
+                "update delivery.delivery_requests set created_at = {0} where id = {1}",
+                createdAt.Value, request.Id);
+        }
         return request.Id;
     }
 


### PR DESCRIPTION
## 1. Pricing: platform fee + GST (config-driven) — #153, #154
- New delivery-fee tiers; delivery is now always charged (no free-delivery threshold).
- Adds a **platform fee** and **GST**, with **separate GST rates** configurable for
  delivery vs platform fee (Railway env vars — no redeploy to tune).
- Order bill is now **backend-authoritative**: server computes the full breakdown
  (subtotal, delivery, platform fee, GST) instead of trusting the client.
- Restaurant charge = configured delivery + platform fee, **replacing the old
  commission model**. Payout ledger updated accordingly.
- Pickup orders: platform fee only (no delivery fee).

## 2. Dispatch resilience — #150
- Never fail an order just because no rider is available — keep the 3PL search going.
- Age floor on the stuck-order recovery service so it never resurrects old orders
  (prevents the re-dispatch backlog incident).
- Never clobber a terminal order back to `Failed`.

## 3. ProRouting (3PL) format fixes — #152
- Send cancel and status calls in ProRouting's required nested-order format.
- Use reason code `010` (buyer modify) for 3PL cancels.

## 4. Menu-item options fix
- `PUT` update of a menu item with option groups no longer 500s
  (`DbUpdateConcurrencyException` / 0-row UPDATE). New options/groups are now
  explicitly inserted instead of being misdetected as updates.
