### PR TITLE
fix(payments): normalize phone to 10 digits so PayU shows UPI

### DIFF
--- a/RallyAPI.sln
+++ b/RallyAPI.sln
@@ -111,6 +111,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RallyAPI.Marketing.Infrastr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RallyAPI.Marketing.Endpoints", "src\Modules\Marketing\RallyAPI.Marketing.Endpoints\RallyAPI.Marketing.Endpoints.csproj", "{6834DBA2-4D9B-4FD9-903A-0BCC1C05A26B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RallyAPI.Orders.Infrastructure.Tests", "tests\Modules\Orders\RallyAPI.Orders.Infrastructure.Tests\RallyAPI.Orders.Infrastructure.Tests.csproj", "{011A061C-EC88-4918-9807-9BE5DDDC83DA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -541,6 +543,18 @@ Global
 		{6834DBA2-4D9B-4FD9-903A-0BCC1C05A26B}.Release|x64.Build.0 = Release|Any CPU
 		{6834DBA2-4D9B-4FD9-903A-0BCC1C05A26B}.Release|x86.ActiveCfg = Release|Any CPU
 		{6834DBA2-4D9B-4FD9-903A-0BCC1C05A26B}.Release|x86.Build.0 = Release|Any CPU
+		{011A061C-EC88-4918-9807-9BE5DDDC83DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{011A061C-EC88-4918-9807-9BE5DDDC83DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{011A061C-EC88-4918-9807-9BE5DDDC83DA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{011A061C-EC88-4918-9807-9BE5DDDC83DA}.Debug|x64.Build.0 = Debug|Any CPU
+		{011A061C-EC88-4918-9807-9BE5DDDC83DA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{011A061C-EC88-4918-9807-9BE5DDDC83DA}.Debug|x86.Build.0 = Debug|Any CPU
+		{011A061C-EC88-4918-9807-9BE5DDDC83DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{011A061C-EC88-4918-9807-9BE5DDDC83DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{011A061C-EC88-4918-9807-9BE5DDDC83DA}.Release|x64.ActiveCfg = Release|Any CPU
+		{011A061C-EC88-4918-9807-9BE5DDDC83DA}.Release|x64.Build.0 = Release|Any CPU
+		{011A061C-EC88-4918-9807-9BE5DDDC83DA}.Release|x86.ActiveCfg = Release|Any CPU
+		{011A061C-EC88-4918-9807-9BE5DDDC83DA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -597,6 +611,7 @@ Global
 		{03F1052F-5E05-4D7E-AC3E-989537CB5E8E} = {579EE46F-5167-AEBB-918F-03560A7E36C1}
 		{90C6C2A2-9F66-4D43-B98E-C11D3A11AD1A} = {579EE46F-5167-AEBB-918F-03560A7E36C1}
 		{6834DBA2-4D9B-4FD9-903A-0BCC1C05A26B} = {579EE46F-5167-AEBB-918F-03560A7E36C1}
+		{011A061C-EC88-4918-9807-9BE5DDDC83DA} = {D6E41CD3-BAF9-3CB0-D841-5B88C8236130}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {152BBE83-99C5-41DC-A873-A4483A4FBB52}

--- a/src/Modules/Orders/RallyAPI.Orders.Infrastructure/Services/PayU/PayUService.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Infrastructure/Services/PayU/PayUService.cs
@@ -33,9 +33,18 @@ public class PayUService : IPayUService
     {
         var amountStr = amount.ToString("F2");
 
+        // Normalize productinfo so the hashed value and the posted value are byte-identical.
+        // (Hashing a trimmed value while posting the untrimmed one would break the PayU hash.)
+        var productInfoNormalized = productInfo.Trim();
+
+        // PayU hosted checkout validates `phone` as a bare 10-digit Indian mobile.
+        // The stored value is E.164 (e.g. "+919876543210"); a country-code-prefixed number
+        // fails PayU's validation and silently hides the UPI option while cards/netbanking
+        // still show. Strip to the last 10 digits before sending.
+        var phoneNormalized = NormalizePhone(phone);
+
         // PayU payment hash: key|txnid|amount|productinfo|firstname|email|||||||||SALT
-       // var hashString = $"{_options.MerchantKey}|{txnId}|{amountStr}|{productInfo}|{firstName}|{email}|||||||||||{_options.MerchantSalt}";
-        var hashString = $"{_options.MerchantKey}|{txnId}|{amountStr}|{productInfo.Trim()}|{firstName}|{email}|||||||||||{_options.MerchantSalt}";
+        var hashString = $"{_options.MerchantKey}|{txnId}|{amountStr}|{productInfoNormalized}|{firstName}|{email}|||||||||||{_options.MerchantSalt}";
         var hash = ComputeSha512(hashString);
 
         return new PayUCheckoutParams
@@ -43,10 +52,10 @@ public class PayUService : IPayUService
             Key = _options.MerchantKey,
             TxnId = txnId,
             Amount = amountStr,
-            ProductInfo = productInfo,
+            ProductInfo = productInfoNormalized,
             FirstName = firstName,
             Email = email,
-            Phone = phone,
+            Phone = phoneNormalized,
             Surl = _options.SuccessUrl,
             Furl = _options.FailureUrl,
             Hash = hash,
@@ -195,6 +204,16 @@ public class PayUService : IPayUService
     }
 
     // ========== Helpers ==========
+
+    // Strip everything except digits, then keep the last 10 (drops the country code / '+').
+    private static string NormalizePhone(string phone)
+    {
+        if (string.IsNullOrWhiteSpace(phone))
+            return string.Empty;
+
+        var digits = new string(phone.Where(char.IsDigit).ToArray());
+        return digits.Length > 10 ? digits[^10..] : digits;
+    }
 
     private string ComputeApiHash(string command, string var1)
     {

--- a/tests/Modules/Orders/RallyAPI.Orders.Infrastructure.Tests/PayU/PayUServiceTests.cs
+++ b/tests/Modules/Orders/RallyAPI.Orders.Infrastructure.Tests/PayU/PayUServiceTests.cs
@@ -1,0 +1,86 @@
+using System.Security.Cryptography;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RallyAPI.Orders.Infrastructure.Services.PayU;
+using Xunit;
+
+namespace RallyAPI.Orders.Infrastructure.Tests.PayU;
+
+public class PayUServiceTests
+{
+    private const string Key = "TESTKEY";
+    private const string Salt = "TESTSALT";
+
+    private static PayUService CreateService() =>
+        new(
+            Options.Create(new PayUOptions
+            {
+                MerchantKey = Key,
+                MerchantSalt = Salt,
+                BaseUrl = "https://secure.payu.in",
+                SuccessUrl = "https://rally.app/success",
+                FailureUrl = "https://rally.app/failure"
+            }),
+            new HttpClient(),
+            NullLogger<PayUService>.Instance);
+
+    private static string Sha512(string input)
+    {
+        var bytes = SHA512.HashData(Encoding.UTF8.GetBytes(input));
+        return BitConverter.ToString(bytes).Replace("-", "").ToLowerInvariant();
+    }
+
+    // PayU only offers UPI when `phone` is a bare 10-digit Indian mobile. The stored value is
+    // E.164 ("+919876543210"); anything longer suppresses UPI while cards/netbanking still show.
+    [Theory]
+    [InlineData("+919876543210", "9876543210")]
+    [InlineData("919876543210", "9876543210")]
+    [InlineData("9876543210", "9876543210")]
+    [InlineData("+91 98765 43210", "9876543210")]
+    [InlineData("098765-43210", "9876543210")]
+    public void GenerateCheckoutParams_NormalizesPhoneToTenDigits(string input, string expected)
+    {
+        var result = CreateService().GenerateCheckoutParams(
+            "TXN1", 499.00m, "Rally Order 123", "Yash", "y@rally.app", input);
+
+        result.Phone.Should().Be(expected);
+        result.Phone.Should().HaveLength(10);
+    }
+
+    [Fact]
+    public void GenerateCheckoutParams_WithEmptyPhone_ReturnsEmpty()
+    {
+        var result = CreateService().GenerateCheckoutParams(
+            "TXN1", 499.00m, "Rally Order 123", "Yash", "y@rally.app", "");
+
+        result.Phone.Should().BeEmpty();
+    }
+
+    // The hash MUST be computed over the exact productinfo that is posted, or PayU rejects the
+    // whole transaction. Guards against re-introducing a trim-in-hash-only mismatch.
+    [Fact]
+    public void GenerateCheckoutParams_HashMatchesPostedProductInfo()
+    {
+        var result = CreateService().GenerateCheckoutParams(
+            "TXN1", 499.00m, "  Rally Order 123  ", "Yash", "y@rally.app", "+919876543210");
+
+        result.ProductInfo.Should().Be("Rally Order 123");
+
+        var expectedHash = Sha512(
+            $"{Key}|TXN1|499.00|{result.ProductInfo}|Yash|y@rally.app|||||||||||{Salt}");
+        result.Hash.Should().Be(expectedHash);
+    }
+
+    [Fact]
+    public void GenerateCheckoutParams_BuildsPaymentUrlAndAmountFormat()
+    {
+        var result = CreateService().GenerateCheckoutParams(
+            "TXN1", 499m, "Rally Order 123", "Yash", "y@rally.app", "+919876543210");
+
+        result.Amount.Should().Be("499.00");
+        result.PayUBaseUrl.Should().Be("https://secure.payu.in/_payment");
+        result.Key.Should().Be(Key);
+    }
+}

--- a/tests/Modules/Orders/RallyAPI.Orders.Infrastructure.Tests/RallyAPI.Orders.Infrastructure.Tests.csproj
+++ b/tests/Modules/Orders/RallyAPI.Orders.Infrastructure.Tests/RallyAPI.Orders.Infrastructure.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>RallyAPI.Orders.Infrastructure.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Modules\Orders\RallyAPI.Orders.Infrastructure\RallyAPI.Orders.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
PayU hosted checkout only offers UPI when `phone` is a bare 10-digit Indian mobile. The stored value is E.164 (e.g. "+919876543210"), which fails PayU's validation and silently hides UPI while cards/netbanking still show. Strip to the last 10 digits before building the checkout params.

Also fixes a latent hash bug: the hash was computed over a trimmed productinfo while the untrimmed value was posted — harmless today but would break every payment if productinfo ever had whitespace. Both now use the same normalized value.

Adds RallyAPI.Orders.Infrastructure.Tests covering phone normalization and hash/productinfo consistency (8 tests).