### PR TITLE
fix(payments): redirect PayU return to SPA success page with orderId

### DIFF
--- a/src/Modules/Orders/RallyAPI.Orders.Endpoints/PaymentEndpoints.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Endpoints/PaymentEndpoints.cs
@@ -197,26 +197,66 @@ public static class PaymentEndpoints
         .RequireAuthorization("Admin")
         .WithName("RefundPayment");
 
-        // 5. Success/Failure return URLs (PayU redirects browser here)
-        group.MapPost("/return/success", (HttpContext ctx) =>
-        {
-            // PayU redirects here after successful payment.
-            // For web: redirect to your frontend success page.
-            // The form data contains the same fields as the webhook.
-            return Results.Redirect("/payment-success");
-        })
+        // 5. Success/Failure return URLs (PayU redirects the BROWSER here via POST).
+        //
+        // PayU posts the result form (txnid, status, hash, …) to these endpoints — a static
+        // SPA cannot read that POST body, so the browser must land on the backend first. We
+        // resolve the order id from the txnid and 302-redirect (GET) to the SPA page, which
+        // then confirms status via GET /api/payments/verify. The S2S /webhook remains the
+        // source of truth for actually marking the order paid — this redirect is UX only.
+        group.MapPost("/return/success", (HttpContext ctx,
+            RallyAPI.Orders.Domain.Repositories.IPaymentRepository payments,
+            Microsoft.Extensions.Options.IOptions<RallyAPI.Orders.Infrastructure.Services.PayU.PayUOptions> payuOptions,
+            CancellationToken ct) =>
+            BuildReturnRedirect(ctx, payments, payuOptions.Value.FrontendSuccessUrl, ct))
         .AllowAnonymous()
         .WithName("PaymentReturnSuccess");
 
-        group.MapPost("/return/failure", (HttpContext ctx) =>
-        {
-            return Results.Redirect("/payment-failed");
-        })
+        group.MapPost("/return/failure", (HttpContext ctx,
+            RallyAPI.Orders.Domain.Repositories.IPaymentRepository payments,
+            Microsoft.Extensions.Options.IOptions<RallyAPI.Orders.Infrastructure.Services.PayU.PayUOptions> payuOptions,
+            CancellationToken ct) =>
+            BuildReturnRedirect(ctx, payments, payuOptions.Value.FrontendFailureUrl, ct))
         .AllowAnonymous()
         .WithName("PaymentReturnFailure");
 
 
-        return app;  
+        return app;
+    }
+
+    /// <summary>
+    /// Reads PayU's POSTed return form, maps txnid → order id, and 302-redirects the browser
+    /// to the given SPA page with ?orderId=… appended. Falls back to the bare page (or "/") when
+    /// the txnid can't be resolved, so the user is never stranded on the API host.
+    /// </summary>
+    private static async Task<IResult> BuildReturnRedirect(
+        HttpContext ctx,
+        RallyAPI.Orders.Domain.Repositories.IPaymentRepository payments,
+        string frontendUrl,
+        CancellationToken ct)
+    {
+        // Never crash the browser redirect on a missing/oversized form — worst case we send
+        // the user to the bare success/failure page without an id.
+        string txnId = string.Empty;
+        if (ctx.Request.HasFormContentType)
+        {
+            var form = await ctx.Request.ReadFormAsync(ct);
+            txnId = form["txnid"].ToString();
+        }
+
+        var target = string.IsNullOrWhiteSpace(frontendUrl) ? "/" : frontendUrl;
+
+        if (!string.IsNullOrWhiteSpace(txnId))
+        {
+            var payment = await payments.GetByTxnIdAsync(txnId, ct);
+            if (payment is not null)
+            {
+                var separator = target.Contains('?') ? '&' : '?';
+                target = $"{target}{separator}orderId={payment.OrderId}";
+            }
+        }
+
+        return Results.Redirect(target);
     }
 }
 

--- a/src/Modules/Orders/RallyAPI.Orders.Infrastructure/Services/PayU/PayUOptions.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Infrastructure/Services/PayU/PayUOptions.cs
@@ -15,9 +15,23 @@ public class PayUOptions
     /// <summary>Test: https://test.payu.in  |  Production: https://secure.payu.in</summary>
     public string BaseUrl { get; set; } = "https://test.payu.in";
 
-    /// <summary>Where PayU redirects on successful payment</summary>
+    /// <summary>
+    /// Where PayU redirects the browser on successful payment. This must point at the
+    /// BACKEND return endpoint (…/api/payments/return/success), not the SPA directly:
+    /// PayU POSTs the result form here, and a static SPA cannot read a POST body. The
+    /// backend reads it and 302-redirects to <see cref="FrontendSuccessUrl"/>.
+    /// </summary>
     public string SuccessUrl { get; set; } = string.Empty;
 
-    /// <summary>Where PayU redirects on failed payment</summary>
+    /// <summary>Where PayU redirects the browser on failed payment (backend return endpoint).</summary>
     public string FailureUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// SPA success page the backend return endpoint redirects to (GET), with the resolved
+    /// order id appended as ?orderId=…  e.g. https://hivago.vercel.app/payment-success
+    /// </summary>
+    public string FrontendSuccessUrl { get; set; } = string.Empty;
+
+    /// <summary>SPA failure page the backend return endpoint redirects to (GET), with ?orderId=… when known.</summary>
+    public string FrontendFailureUrl { get; set; } = string.Empty;
 }


### PR DESCRIPTION
fix(payments): redirect PayU return to SPA success page with orderId

PayU POSTs its result form to surl/furl, and a static SPA cannot read a POST body — so the browser must land on the backend first. The old /return/success and /return/failure endpoints did a relative Results.Redirect("/payment-success") that resolved against the API host (a dead URL) and carried no order id.

Now the return endpoints read PayU's POSTed txnid, map it to the order via IPaymentRepository.GetByTxnIdAsync, and 302-redirect (GET) to the configured SPA page with ?orderId=<guid> appended. Falls back to the bare page when the txnid can't be resolved so the user is never stranded on the API host.

Adds PayU:FrontendSuccessUrl / FrontendFailureUrl config. The S2S /webhook remains the source of truth for marking the order paid; this redirect is UX only. No migration.


@