### PR TITLE
@

### DIFF
--- a/specs/delivery-quote-frontend.md
+++ b/specs/delivery-quote-frontend.md
@@ -1,0 +1,151 @@
+# Frontend Hand-off — Delivery Quote API (item cost + pickup support)
+
+## TL;DR
+`POST /api/delivery/quote` now returns the **full bill** (item cost + fees), not just delivery
+charges, and it now supports **pickup orders**. Two things for the UI:
+1. Use the new `itemTotal` / `grandTotal` fields to render the complete price summary.
+2. For pickup, send `fulfillmentType: "Pickup"` and skip the drop location — you get back a
+   quote with **zero delivery fee** (platform fee + GST only).
+
+Existing fields are unchanged in meaning, so nothing you already built breaks.
+
+---
+
+## Endpoint
+`POST /api/delivery/quote` — call at checkout, whenever items/address/fulfillment change.
+
+### Request
+```jsonc
+{
+  "restaurantId": "…",           // required
+  "pickupLatitude": 12.9352,     // required (restaurant location)
+  "pickupLongitude": 77.6245,    // required
+  "pickupPincode": "560034",     // optional (reverse-geocoded if omitted)
+
+  "dropLatitude": 12.9100,       // OPTIONAL now — required for delivery, omit for pickup
+  "dropLongitude": 77.6400,      // OPTIONAL now — required for delivery, omit for pickup
+  "dropPincode": "560102",       // optional
+  "city": "Bengaluru",           // optional
+
+  "orderAmount": 500,            // required — food subtotal (sum of item prices)
+  "fulfillmentType": "Delivery"  // NEW — "Delivery" (default) or "Pickup"
+}
+```
+- `fulfillmentType` is optional and defaults to `"Delivery"`, so your existing delivery call
+  keeps working with **no change**.
+- For **pickup**, set `"fulfillmentType": "Pickup"` and you may omit `dropLatitude`/`dropLongitude`.
+
+### Response (`DeliveryQuoteDto`)
+```jsonc
+{
+  "id": "…",                     // quote id — pass back as deliveryQuoteId when placing a DELIVERY order
+  "fulfillmentType": "Delivery", // "Delivery" or "Pickup"
+
+  "itemTotal": 500,              // NEW — food subtotal (echo of orderAmount)
+  "deliveryFee": 40,             // delivery charge only (0 for pickup)
+  "platformFee": 10,             // flat platform fee
+  "gst": 9.00,                   // GST on (deliveryFee + platformFee)
+  "totalPayable": 59.00,         // fees only = deliveryFee + platformFee + gst
+  "grandTotal": 559.00,          // NEW — itemTotal + totalPayable  ← show this as the amount due
+
+  "distanceKm": 3.2,             // 0 for pickup
+  "estimatedMinutes": 32,        // 0 for pickup
+  "surgeMultiplier": 1.0,
+  "surgeReason": null,
+  "expiresAt": "2026-07-14T10:30:00Z",
+  "breakdown": [                 // line items that sum to totalPayable (NOT including itemTotal)
+    { "name": "Delivery Fee",  "description": "Delivery charge",              "amount": 40 },
+    { "name": "Platform Fee",  "description": "Platform service fee",         "amount": 10 },
+    { "name": "GST",           "description": "GST on delivery + platform fee","amount": 9.00 }
+  ]
+}
+```
+
+> ⚠️ `totalPayable` is **fees only** — same as before. The amount the customer pays is
+> `grandTotal`. Do **not** sum `breakdown` and add `itemTotal` yourself; use `grandTotal`.
+
+---
+
+## Step-by-step
+
+### Step 1 — Update your quote type
+Add the three new fields to your `DeliveryQuote` TS type:
+```ts
+interface DeliveryQuote {
+  id: string;
+  fulfillmentType: "Delivery" | "Pickup"; // new
+  itemTotal: number;                       // new
+  deliveryFee: number;
+  platformFee: number;
+  gst: number;
+  totalPayable: number;                    // fees only
+  grandTotal: number;                      // new — itemTotal + totalPayable
+  distanceKm: number;
+  estimatedMinutes: number;
+  surgeMultiplier: number;
+  surgeReason: string | null;
+  expiresAt: string;
+  breakdown: { name: string; description: string; amount: number }[];
+}
+```
+
+### Step 2 — Send `fulfillmentType`
+Add it to the request body. Drive it from the delivery/pickup toggle the user already picks.
+```ts
+const body = {
+  restaurantId,
+  pickupLatitude, pickupLongitude, pickupPincode,
+  orderAmount: subTotal,
+  fulfillmentType,                 // "Delivery" | "Pickup"
+  ...(fulfillmentType === "Delivery"
+      ? { dropLatitude, dropLongitude, dropPincode, city }
+      : {}),                       // omit drop for pickup
+};
+```
+
+### Step 3 — Render the bill from the response (don't recompute)
+```
+Item total                itemTotal
+Delivery fee              deliveryFee     (hide the row when pickup / deliveryFee === 0)
+Platform fee              platformFee
+GST                       gst
+────────────────────────
+To pay                    grandTotal
+```
+A generic approach: render each `breakdown` row, show `itemTotal` above it, and `grandTotal`
+as the total. Never add `itemTotal` into the `breakdown` list — it isn't part of it.
+
+### Step 4 — Handle the pickup differences
+When `fulfillmentType === "Pickup"`:
+- `deliveryFee`, `distanceKm`, `estimatedMinutes` are all `0` — hide the delivery-fee row and
+  the ETA/distance UI.
+- `id` comes back as an all-zeros GUID (`00000000-0000-0000-0000-000000000000`). That's expected:
+  pickup pricing is recomputed server-side at order time, so **you do not pass a
+  `deliveryQuoteId` when placing a pickup order** (see Step 5).
+
+### Step 5 — Placing the order (unchanged contract, just be aware)
+- **Delivery order**: pass the quote's `id` as `deliveryQuoteId` in `POST /api/orders`. The
+  backend re-reads the quote and bills exactly what you were quoted.
+- **Pickup order**: send `"fulfillmentType": "Pickup"`, `"pricing": { …, "deliveryFee": 0 }`,
+  and **no** `deliveryQuoteId`. The backend applies the platform fee + GST from config.
+
+### Step 6 — Error handling (unchanged)
+Delivery quotes still return `400` when the drop is outside the service radius (>5 km), e.g.
+_"Delivery is only available within 5 km of the restaurant. This address is 7.3 km away."_
+Show it inline on the address step. Pickup quotes never hit this check.
+
+---
+
+## Why the backend is authoritative
+The customer always pays **our** price. The frontend must not compute delivery fee, platform
+fee, or GST itself — read them from this endpoint and, at order time, the backend re-derives
+them (from the stored quote for delivery, from config for pickup). Platform fee and GST% are
+tuned from Railway config (`Delivery:Quote`), so the quote and the final order bill always match.
+
+## Quick test cases
+| Scenario | Request | Expect |
+|----------|---------|--------|
+| Delivery, in range | `fulfillmentType:"Delivery"` + drop coords ≤5 km | `deliveryFee>0`, `id` set, `grandTotal = itemTotal + totalPayable` |
+| Delivery, out of range | drop coords >5 km | `400` with distance message |
+| Pickup | `fulfillmentType:"Pickup"`, no drop | `deliveryFee:0`, `distanceKm:0`, `id:"000…0"`, `grandTotal = itemTotal + platformFee + gst` |
+| Omit fulfillmentType | legacy body | treated as Delivery (backward compatible) |

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/GetQuote/GetQuoteCommand.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/GetQuote/GetQuoteCommand.cs
@@ -15,4 +15,12 @@ public sealed record GetQuoteCommand : IRequest<Result<DeliveryQuoteDto>>
     public string? DropPincode { get; init; }
     public string? City { get; init; }
     public required decimal OrderAmount { get; init; }
+
+    /// <summary>"Delivery" (default) or "Pickup". Pickup skips distance/rider/3PL and charges
+    /// no delivery fee — only platform fee + its GST on top of the item total.</summary>
+    public string? FulfillmentType { get; init; }
+
+    /// <summary>True when the customer collects the order themselves (no delivery leg).</summary>
+    public bool IsPickup =>
+        string.Equals(FulfillmentType, "Pickup", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/GetQuote/GetQuoteCommandHandler.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/GetQuote/GetQuoteCommandHandler.cs
@@ -85,8 +85,18 @@ public sealed class GetQuoteCommandHandler : IRequestHandler<GetQuoteCommand, Re
         CancellationToken cancellationToken)
     {
         _logger.LogInformation(
-            "Getting delivery quote for restaurant {RestaurantId}, City: {City}",
-            request.RestaurantId, request.City);
+            "Getting quote for restaurant {RestaurantId}, City: {City}, Fulfillment: {Fulfillment}",
+            request.RestaurantId, request.City, request.IsPickup ? "Pickup" : "Delivery");
+
+        // Pickup: no delivery leg. Skip distance/rider/3PL entirely and charge only the platform
+        // fee + its GST on top of the item total — exactly what PlaceOrder bills a pickup order
+        // (both read the same "Delivery:Quote" config, so quote and order stay in lockstep).
+        // Nothing is persisted: PlaceOrder recomputes pickup pricing from config, not from a quote.
+        if (request.IsPickup)
+        {
+            _logger.LogDebug("Pickup quote — pricing from config, no delivery leg");
+            return Result.Success(BuildPickupDto(request.OrderAmount));
+        }
 
         // Fail fast when the drop is outside our service area. Without this guard,
         // a 12km drop hits ProRouting and waits up to 30s for a guaranteed rejection.
@@ -331,6 +341,41 @@ public sealed class GetQuoteCommandHandler : IRequestHandler<GetQuoteCommand, Re
             breakdownJson: breakdownJson);
     }
 
+    /// <summary>
+    /// Builds a pickup quote entirely from config: no delivery fee, no distance/ETA, just the flat
+    /// platform fee + its GST charged on top of the item total. Not persisted.
+    /// </summary>
+    private DeliveryQuoteDto BuildPickupDto(decimal itemTotal)
+    {
+        var platformFee = _quotePricing.CustomerPlatformFee;
+        var gst = Math.Round(platformFee * _quotePricing.PlatformGstPercent / 100m, 2);
+        var totalPayable = platformFee + gst;
+
+        var breakdown = new List<PriceBreakdownItem>();
+        if (platformFee > 0)
+            breakdown.Add(new PriceBreakdownItem("Platform Fee", "Platform service fee", platformFee));
+        if (gst > 0)
+            breakdown.Add(new PriceBreakdownItem("GST", "GST on platform fee", gst));
+
+        return new DeliveryQuoteDto
+        {
+            Id = Guid.Empty, // no stored quote — pickup pricing is recomputed from config at order time
+            FulfillmentType = "Pickup",
+            ItemTotal = itemTotal,
+            DeliveryFee = 0m,
+            PlatformFee = platformFee,
+            Gst = gst,
+            TotalPayable = totalPayable,
+            GrandTotal = itemTotal + totalPayable,
+            DistanceKm = 0m,
+            EstimatedMinutes = 0,
+            SurgeMultiplier = 1.0m,
+            SurgeReason = null,
+            ExpiresAt = DateTime.UtcNow.AddMinutes(15),
+            Breakdown = breakdown
+        };
+    }
+
     private static DeliveryQuoteDto MapToDto(DeliveryQuote quote)
     {
         var breakdown = new List<PriceBreakdownItem>();
@@ -348,10 +393,13 @@ public sealed class GetQuoteCommandHandler : IRequestHandler<GetQuoteCommand, Re
         return new DeliveryQuoteDto
         {
             Id = quote.Id,
+            FulfillmentType = "Delivery",
+            ItemTotal = quote.OrderAmount,
             DeliveryFee = quote.FinalFee,
             PlatformFee = quote.PlatformFee,
             Gst = quote.GstAmount,
             TotalPayable = quote.CustomerTotal,
+            GrandTotal = quote.OrderAmount + quote.CustomerTotal,
             DistanceKm = quote.DistanceKm,
             EstimatedMinutes = quote.EstimatedMinutes,
             SurgeMultiplier = quote.SurgeMultiplier,

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/DTOs/DeliveryQuoteDto.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/DTOs/DeliveryQuoteDto.cs
@@ -4,7 +4,13 @@ public sealed record DeliveryQuoteDto
 {
     public Guid Id { get; init; }
 
-    /// <summary>Delivery fee only (no platform fee / GST).</summary>
+    /// <summary>"Delivery" or "Pickup". Pickup quotes carry no delivery fee / distance / ETA.</summary>
+    public string FulfillmentType { get; init; } = "Delivery";
+
+    /// <summary>Food subtotal (echo of the request's OrderAmount) so the UI can show the full bill.</summary>
+    public decimal ItemTotal { get; init; }
+
+    /// <summary>Delivery fee only (no platform fee / GST). Always 0 for pickup.</summary>
     public decimal DeliveryFee { get; init; }
 
     /// <summary>Flat platform fee charged to the customer.</summary>
@@ -13,8 +19,11 @@ public sealed record DeliveryQuoteDto
     /// <summary>GST on (delivery fee + platform fee).</summary>
     public decimal Gst { get; init; }
 
-    /// <summary>What the customer pays for delivery = DeliveryFee + PlatformFee + Gst.</summary>
+    /// <summary>What the customer pays in fees = DeliveryFee + PlatformFee + Gst.</summary>
     public decimal TotalPayable { get; init; }
+
+    /// <summary>The full amount the customer pays = ItemTotal + TotalPayable.</summary>
+    public decimal GrandTotal { get; init; }
 
     public decimal DistanceKm { get; init; }
     public int EstimatedMinutes { get; init; }

--- a/src/Modules/Delivery/RallyAPI.Delivery.Endpoints/DeliveryEndpoints.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Endpoints/DeliveryEndpoints.cs
@@ -52,11 +52,14 @@ public static class DeliveryEndpoints
             PickupLatitude = request.PickupLatitude,
             PickupLongitude = request.PickupLongitude,
             PickupPincode = request.PickupPincode,
-            DropLatitude = request.DropLatitude,
-            DropLongitude = request.DropLongitude,
+            // Pickup orders carry no drop; fall back to pickup coords so downstream
+            // distance/geocoding never sees a (0,0) location.
+            DropLatitude = request.DropLatitude ?? request.PickupLatitude,
+            DropLongitude = request.DropLongitude ?? request.PickupLongitude,
             DropPincode = request.DropPincode,
             City = request.City,
-            OrderAmount = request.OrderAmount
+            OrderAmount = request.OrderAmount,
+            FulfillmentType = request.FulfillmentType
         };
 
         var result = await mediator.Send(command, ct);

--- a/src/Modules/Delivery/RallyAPI.Delivery.Endpoints/Requests/GetQuoteRequest.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Endpoints/Requests/GetQuoteRequest.cs
@@ -6,9 +6,14 @@ public sealed record GetQuoteRequest
     public required double PickupLatitude { get; init; }
     public required double PickupLongitude { get; init; }
     public string? PickupPincode { get; init; }
-    public required double DropLatitude { get; init; }
-    public required double DropLongitude { get; init; }
+
+    // Drop is optional: pickup orders have no delivery destination.
+    public double? DropLatitude { get; init; }
+    public double? DropLongitude { get; init; }
     public string? DropPincode { get; init; }
     public string? City { get; init; }
     public required decimal OrderAmount { get; init; }
+
+    /// <summary>"Delivery" (default) or "Pickup".</summary>
+    public string? FulfillmentType { get; init; }
 }


### PR DESCRIPTION
feat(delivery): pickup quotes + item totals on the quote API

The deployed quote endpoint required non-nullable drop coordinates and had no FulfillmentType, so a self-pickup quote (no drop) failed JSON binding and returned 500 InternalError. Delivery quotes worked because they carry a drop.

- GetQuoteRequest: drop lat/lng now nullable; adds FulfillmentType.
- GetQuoteCommand: adds FulfillmentType + IsPickup helper.
- Endpoint: falls drop back to pickup coords so downstream distance/geocoding never sees (0,0).
- Handler: IsPickup short-circuits to BuildPickupDto — platform fee + its GST on the item total, no delivery leg, nothing persisted (PlaceOrder recomputes pickup pricing from the same Delivery:Quote config).
- DeliveryQuoteDto: adds FulfillmentType, ItemTotal (echo of orderAmount) and GrandTotal (ItemTotal + fees) so the UI can render the full bill from the quote.

No migration.


@