### PR TITLE
@

### DIFF
--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/GetQuote/GetQuoteCommandHandler.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/GetQuote/GetQuoteCommandHandler.cs
@@ -349,13 +349,16 @@ public sealed class GetQuoteCommandHandler : IRequestHandler<GetQuoteCommand, Re
     {
         var platformFee = _quotePricing.CustomerPlatformFee;
         var gst = Math.Round(platformFee * _quotePricing.PlatformGstPercent / 100m, 2);
-        var totalPayable = platformFee + gst;
+        var foodGst = Math.Round(itemTotal * _quotePricing.FoodGstPercent / 100m, 2);
+        var totalPayable = platformFee + gst + foodGst;
 
         var breakdown = new List<PriceBreakdownItem>();
         if (platformFee > 0)
             breakdown.Add(new PriceBreakdownItem("Platform Fee", "Platform service fee", platformFee));
         if (gst > 0)
             breakdown.Add(new PriceBreakdownItem("GST", "GST on platform fee", gst));
+        if (foodGst > 0)
+            breakdown.Add(new PriceBreakdownItem("GST on Food", $"{_quotePricing.FoodGstPercent}% GST on food", foodGst));
 
         return new DeliveryQuoteDto
         {
@@ -365,6 +368,7 @@ public sealed class GetQuoteCommandHandler : IRequestHandler<GetQuoteCommand, Re
             DeliveryFee = 0m,
             PlatformFee = platformFee,
             Gst = gst,
+            FoodGst = foodGst,
             TotalPayable = totalPayable,
             GrandTotal = itemTotal + totalPayable,
             DistanceKm = 0m,
@@ -376,7 +380,7 @@ public sealed class GetQuoteCommandHandler : IRequestHandler<GetQuoteCommand, Re
         };
     }
 
-    private static DeliveryQuoteDto MapToDto(DeliveryQuote quote)
+    private DeliveryQuoteDto MapToDto(DeliveryQuote quote)
     {
         var breakdown = new List<PriceBreakdownItem>();
 
@@ -390,6 +394,15 @@ public sealed class GetQuoteCommandHandler : IRequestHandler<GetQuoteCommand, Re
             catch { /* Ignore parsing errors */ }
         }
 
+        // Food GST (5%) on the item total — the stored quote only holds delivery + platform + their
+        // 18% GST (quote.CustomerTotal). Food GST is derived from OrderAmount here so the quote total
+        // matches what PlaceOrder bills (OrderPricing.Tax uses the same rate).
+        var foodGst = Math.Round(quote.OrderAmount * _quotePricing.FoodGstPercent / 100m, 2);
+        if (foodGst > 0)
+            breakdown.Add(new PriceBreakdownItem("GST on Food", $"{_quotePricing.FoodGstPercent}% GST on food", foodGst));
+
+        var totalPayable = quote.CustomerTotal + foodGst;
+
         return new DeliveryQuoteDto
         {
             Id = quote.Id,
@@ -398,8 +411,9 @@ public sealed class GetQuoteCommandHandler : IRequestHandler<GetQuoteCommand, Re
             DeliveryFee = quote.FinalFee,
             PlatformFee = quote.PlatformFee,
             Gst = quote.GstAmount,
-            TotalPayable = quote.CustomerTotal,
-            GrandTotal = quote.OrderAmount + quote.CustomerTotal,
+            FoodGst = foodGst,
+            TotalPayable = totalPayable,
+            GrandTotal = quote.OrderAmount + totalPayable,
             DistanceKm = quote.DistanceKm,
             EstimatedMinutes = quote.EstimatedMinutes,
             SurgeMultiplier = quote.SurgeMultiplier,

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/GetQuote/QuotePricingOptions.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Commands/GetQuote/QuotePricingOptions.cs
@@ -19,4 +19,9 @@ public sealed class QuotePricingOptions
     /// <summary>GST percentage on the platform fee. e.g. 18 = 18%. Kept separate from
     /// <see cref="DeliveryGstPercent"/> so the two can diverge in future without a code change.</summary>
     public decimal PlatformGstPercent { get; set; } = 18m;
+
+    /// <summary>GST percentage on the food subtotal (item total). e.g. 5 = 5% — the restaurant-service
+    /// GST the platform collects under Section 9(5) CGST. Distinct from delivery/platform GST (18%).
+    /// The order bill (OrderPricing.Tax / PayoutLedger) charges this same rate at order time.</summary>
+    public decimal FoodGstPercent { get; set; } = 5m;
 }

--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/DTOs/DeliveryQuoteDto.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/DTOs/DeliveryQuoteDto.cs
@@ -16,10 +16,13 @@ public sealed record DeliveryQuoteDto
     /// <summary>Flat platform fee charged to the customer.</summary>
     public decimal PlatformFee { get; init; }
 
-    /// <summary>GST on (delivery fee + platform fee).</summary>
+    /// <summary>GST on (delivery fee + platform fee) — 18%. Distinct from <see cref="FoodGst"/>.</summary>
     public decimal Gst { get; init; }
 
-    /// <summary>What the customer pays in fees = DeliveryFee + PlatformFee + Gst.</summary>
+    /// <summary>GST on the food subtotal (ItemTotal) — 5%. Restaurant-service GST the platform collects.</summary>
+    public decimal FoodGst { get; init; }
+
+    /// <summary>Everything the customer pays on top of the food = DeliveryFee + PlatformFee + Gst + FoodGst.</summary>
     public decimal TotalPayable { get; init; }
 
     /// <summary>The full amount the customer pays = ItemTotal + TotalPayable.</summary>


### PR DESCRIPTION
feat(delivery): add 5% food GST to the quote so it matches the order bill

The quote only charged 18% GST on delivery + platform, omitting the 5% food GST that PlaceOrder (OrderPricing.Tax / PayoutLedger) actually bills — so the quote grandTotal understated the real total by 5% of the subtotal.

- QuotePricingOptions: adds FoodGstPercent (default 5, config-bound via Delivery:Quote).
- DeliveryQuoteDto: adds FoodGst; TotalPayable/GrandTotal now include it.
- Handler: BuildPickupDto + MapToDto compute FoodGst = itemTotal * 5%, add a "GST on Food" breakdown line, and roll it into the totals (both pickup and delivery).

No migration.


@