### PR TITLE
fix(infra): raise prod rate limits to stop 429s on order/payment path

### DIFF
--- a/src/RallyAPI.Host/Program.cs
+++ b/src/RallyAPI.Host/Program.cs
@@ -293,7 +293,7 @@ builder.Services.AddRateLimiter(options =>
             _ => new RedisSlidingWindowRateLimiterOptions
             {
                 ConnectionMultiplexerFactory = () => ResolveRedis(context),
-                PermitLimit = relaxedLimits ? 100 : 3,
+                PermitLimit = relaxedLimits ? 100 : 20,
                 Window = relaxedLimits ? TimeSpan.FromMinutes(1) : TimeSpan.FromMinutes(10)
             }));
 
@@ -303,8 +303,8 @@ builder.Services.AddRateLimiter(options =>
             _ => new RedisSlidingWindowRateLimiterOptions
             {
                 ConnectionMultiplexerFactory = () => ResolveRedis(context),
-                PermitLimit = relaxedLimits ? 100 : 5,
-                Window = relaxedLimits ? TimeSpan.FromMinutes(1) : TimeSpan.FromMinutes(15)
+                PermitLimit = relaxedLimits ? 100 : 60,
+                Window = relaxedLimits ? TimeSpan.FromMinutes(1) : TimeSpan.FromMinutes(1)
             }));
 
     options.AddPolicy("refresh", context =>
@@ -313,7 +313,7 @@ builder.Services.AddRateLimiter(options =>
             _ => new RedisSlidingWindowRateLimiterOptions
             {
                 ConnectionMultiplexerFactory = () => ResolveRedis(context),
-                PermitLimit = relaxedLimits ? 100 : 10,
+                PermitLimit = relaxedLimits ? 100 : 60,
                 Window = TimeSpan.FromMinutes(1)
             }));
 
@@ -325,7 +325,7 @@ builder.Services.AddRateLimiter(options =>
             _ => new RedisSlidingWindowRateLimiterOptions
             {
                 ConnectionMultiplexerFactory = () => ResolveRedis(context),
-                PermitLimit = relaxedLimits ? 100 : 10,
+                PermitLimit = relaxedLimits ? 100 : 30,
                 Window = TimeSpan.FromMinutes(1)
             }));
 
@@ -339,7 +339,7 @@ builder.Services.AddRateLimiter(options =>
             _ => new RedisFixedWindowRateLimiterOptions
             {
                 ConnectionMultiplexerFactory = () => ResolveRedis(context),
-                PermitLimit = relaxedLimits ? 100 : 5,
+                PermitLimit = relaxedLimits ? 100 : 30,
                 Window = TimeSpan.FromMinutes(1)
             }));
 


### PR DESCRIPTION
Order placement and payment share the login policy (was 5/15min per IP), which throttled the money path in prod. Bump prod limits: login 60/min, refresh 60/min, otp 20/10min, lead-capture and admin-export 30/min. Staging/dev unchanged (still 100/min).