### PR TITLE
fix(delivery): stop sending order-level callback_url to ProRouting

### DIFF
--- a/src/Modules/Delivery/RallyAPI.Delivery.Application/Services/RiderDispatchOrchestrator.cs
+++ b/src/Modules/Delivery/RallyAPI.Delivery.Application/Services/RiderDispatchOrchestrator.cs
@@ -208,7 +208,7 @@ public sealed class RiderDispatchOrchestrator
                 PickupCode = deliveryRequest.PickupCode,
                 DropCode = deliveryRequest.DropCode,
                 OrderCategory = MapOrderCategory(deliveryRequest.OrderCategory),
-                CallbackUrl = _options.WebhookUrl,
+                CallbackUrl = _options.SendOrderLevelCallbackUrl ? _options.WebhookUrl : null,
                 SelectionMode = "fastest_agent"
             }, ct);
 
@@ -321,4 +321,12 @@ public sealed class DispatchOptions
     public int AcceptanceTimeoutSeconds { get; set; } = 30;
     public decimal RiderEarningsPercentage { get; set; } = 80;
     public string WebhookUrl { get; set; } = "https://your-domain.com/api/webhooks/prorouting";
+
+    /// <summary>
+    /// When false (default), we do NOT send an order-level callback_url on createasync,
+    /// so ProRouting uses its account-level callback config (which includes the x-pro-api-key
+    /// auth header). Set to true only if account-level callbacks are unavailable — note the
+    /// order-level callback arrives WITHOUT auth and our webhook will 401 it.
+    /// </summary>
+    public bool SendOrderLevelCallbackUrl { get; set; } = false;
 }

--- a/src/Modules/Integrations/ProRouting/Models/ProRoutingCreateRequest.cs
+++ b/src/Modules/Integrations/ProRouting/Models/ProRoutingCreateRequest.cs
@@ -19,8 +19,13 @@ public sealed class ProRoutingCreateRequest
     [JsonPropertyName("customer_promised_time")]
     public string? CustomerPromisedTime { get; init; }
 
+    // Omitted from the payload when null so ProRouting falls back to the
+    // account-level callback config (which carries the x-pro-api-key auth header).
+    // Sending an order-level callback_url overrides the account-level config and
+    // arrives WITHOUT auth → our webhook returns 401. See DispatchOptions.SendOrderLevelCallbackUrl.
     [JsonPropertyName("callback_url")]
-    public required string CallbackUrl { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CallbackUrl { get; init; }
 
     [JsonPropertyName("order_category")]
     public string OrderCategory { get; init; } = "F&B";

--- a/src/Modules/Integrations/ProRouting/ProRoutingTaskService.cs
+++ b/src/Modules/Integrations/ProRouting/ProRoutingTaskService.cs
@@ -600,7 +600,7 @@ public sealed class ProRoutingTaskService : IThirdPartyDeliveryProvider, IIgmPro
                 },
                 Otp = request.DropCode
             },
-            CallbackUrl = request.CallbackUrl,
+            CallbackUrl = string.IsNullOrWhiteSpace(request.CallbackUrl) ? null : request.CallbackUrl,
             OrderCategory = request.OrderCategory,
             OrderAmount = request.OrderAmount,
             CodAmount = request.CodAmount,

--- a/src/RallyAPI.SharedKernel/Abstractions/Delivery/CreateTaskRequest.cs
+++ b/src/RallyAPI.SharedKernel/Abstractions/Delivery/CreateTaskRequest.cs
@@ -116,9 +116,10 @@ public sealed record CreateTaskRequest
     public int? MaxSlaMins { get; init; }
 
     /// <summary>
-    /// Webhook URL for status callbacks.
+    /// Optional order-level webhook URL for status callbacks. Leave null to rely on
+    /// ProRouting's account-level callback config (preferred — it carries the auth header).
     /// </summary>
-    public required string CallbackUrl { get; init; }
+    public string? CallbackUrl { get; init; }
 }
 
 /// <summary>


### PR DESCRIPTION
ProRouting is moving callback auth (x-pro-api-key) to account level. A per-order callback_url on createasync overrides the account-level config and arrives WITHOUT the auth header, so our webhook 401s every status update (rider stuck At-pickup, order never advances).

- Make CallbackUrl optional on CreateTaskRequest and ProRoutingCreateRequest (omitted from JSON when null via JsonIgnoreCondition.WhenWritingNull).
- Add DispatchOptions.SendOrderLevelCallbackUrl (default false) so we can re-enable order-level callbacks via config without a redeploy if needed.
- Orchestrator sends callback_url only when the flag is on.

Pairs with setting PROROUTING_INBOUND_API_KEY on Railway to match the account-level x-pro-api-key value.