### PR TITLE
fix(orders): sync 3PL-delivered orders past ReadyForPickup

### DIFF
--- a/src/Modules/Orders/RallyAPI.Orders.Application/EventHandlers/DeliveryRiderAssignedEventHandler.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/EventHandlers/DeliveryRiderAssignedEventHandler.cs
@@ -40,15 +40,27 @@ public sealed class DeliveryRiderAssignedEventHandler : INotificationHandler<Del
             return;
         }
 
-        order.AssignRider(
-            notification.RiderId,
-            notification.RiderName,
-            notification.RiderPhone,
-            notification.TrackingUrl);
+        try
+        {
+            order.AssignRider(
+                notification.RiderId,
+                notification.RiderName,
+                notification.RiderPhone,
+                notification.TrackingUrl);
 
-        _orderRepository.Update(order);
-        await _unitOfWork.SaveChangesAsync(cancellationToken);
+            _orderRepository.Update(order);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
-        _logger.LogInformation("Updated Order {OrderNumber} with rider information", order.OrderNumber.Value);
+            _logger.LogInformation("Updated Order {OrderNumber} with rider information", order.OrderNumber.Value);
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or ArgumentException)
+        {
+            // Never let a rider-assignment hiccup bubble up and fail the whole caller
+            // (e.g. a ProRouting webhook or the manual refresh-status reconcile). The
+            // order simply keeps its current rider info; reconcile can be retried.
+            _logger.LogWarning(ex,
+                "Failed to apply rider assignment to Order {OrderId} (rider {RiderId}, name '{RiderName}')",
+                notification.OrderId, notification.RiderId, notification.RiderName);
+        }
     }
 }

--- a/src/Modules/Orders/RallyAPI.Orders.Domain/Entities/DeliveryInfo.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Domain/Entities/DeliveryInfo.cs
@@ -96,14 +96,19 @@ public sealed class DeliveryInfo : BaseEntity
     }
 
     /// <summary>
-    /// Assigns a rider to the delivery
+    /// Assigns a rider to the delivery.
+    /// Own-fleet riders carry an internal <paramref name="riderId"/>; third-party (3PL)
+    /// riders have no internal GUID and are identified only by name/phone. At least one
+    /// form of identity is required. <see cref="AssignedAt"/> is the canonical
+    /// "a rider has been assigned" signal for both fleet types.
     /// </summary>
-    public void AssignRider(Guid riderId, string? riderName = null, string? riderPhone = null)
+    public void AssignRider(Guid? riderId, string? riderName = null, string? riderPhone = null)
     {
-        if (riderId == Guid.Empty)
-            throw new ArgumentException("Rider ID is required", nameof(riderId));
+        var hasInternalId = riderId.HasValue && riderId.Value != Guid.Empty;
+        if (!hasInternalId && string.IsNullOrWhiteSpace(riderName))
+            throw new ArgumentException("A rider identity (id or name) is required", nameof(riderId));
 
-        RiderId = riderId;
+        RiderId = hasInternalId ? riderId : null;
         RiderName = riderName;
         RiderPhone = riderPhone;
         AssignedAt = DateTime.UtcNow;

--- a/src/Modules/Orders/RallyAPI.Orders.Domain/Entities/Order.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Domain/Entities/Order.cs
@@ -331,7 +331,9 @@ public sealed class Order : AggregateRoot
 
         EnsureValidTransition(OrderStatus.PickedUp);
 
-        if (DeliveryInfo is null || !DeliveryInfo.RiderId.HasValue || DeliveryInfo.RiderId == Guid.Empty)
+        // A rider is "assigned" once DeliveryInfo.AssignedAt is set — true for both
+        // own-fleet riders (internal RiderId) and 3PL riders (external, no internal GUID).
+        if (DeliveryInfo is null || DeliveryInfo.AssignedAt is null)
             throw new InvalidOperationException("Cannot mark order as picked up: no rider has been assigned.");
 
         Status = OrderStatus.PickedUp;
@@ -368,7 +370,7 @@ public sealed class Order : AggregateRoot
         if (DeliveryInfo is null)
             throw new InvalidOperationException("Cannot assign rider: no delivery info");
 
-        DeliveryInfo.AssignRider(riderId ?? Guid.Empty, riderName, riderPhone);
+        DeliveryInfo.AssignRider(riderId, riderName, riderPhone);
 
         if (!string.IsNullOrWhiteSpace(trackingUrl))
         {
@@ -506,7 +508,7 @@ public sealed class Order : AggregateRoot
         if (FulfillmentType == FulfillmentType.Pickup || DeliveryInfo is null)
             throw new InvalidOperationException("Cannot update rider for a pickup order");
 
-        DeliveryInfo.AssignRider(riderId ?? Guid.Empty, riderName, riderPhone);
+        DeliveryInfo.AssignRider(riderId, riderName, riderPhone);
         UpdatedAt = DateTime.UtcNow;
     }
 


### PR DESCRIPTION
3PL (ProRouting) riders have no internal GUID, but Order.AssignRider coerced the null rider id to Guid.Empty and DeliveryInfo.AssignRider threw on Guid.Empty. Every 3PL rider assignment therefore threw:
 - via webhook the throw was swallowed by DomainEventInterceptor, so the order stuck silently at ReadyForPickup while the delivery completed;
 - via the refresh-status reconcile the throw bubbled up unhandled and returned 400 "Invalid request.".

Fix:
 - DeliveryInfo.AssignRider now accepts a nullable rider id and a 3PL rider identified by name/phone (RiderId stays null, AssignedAt set).
 - Order.AssignRider / UpdateRiderInfo pass the nullable id through.
 - Order.MarkPickedUp keys off DeliveryInfo.AssignedAt (true for both own-fleet and 3PL) instead of rejecting Guid.Empty.
 - DeliveryRiderAssignedEventHandler wraps the assignment so a hiccup can no longer fail the whole webhook/refresh caller.