### PR TITLE
fix(orders): make fleet type explicit so 3PL and own riders can't be …

### DIFF
--- a/src/Modules/Orders/RallyAPI.Orders.Application/Commands/AdminAssignRider/AdminAssignRiderCommandHandler.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/Commands/AdminAssignRider/AdminAssignRiderCommandHandler.cs
@@ -49,7 +49,8 @@ public sealed class AdminAssignRiderCommandHandler : IRequestHandler<AdminAssign
 
         try
         {
-            order.AssignRider(rider.RiderId, rider.Name, rider.Phone);
+            // Admin manual assignment always targets a Rally rider looked up above, never a 3PL agent.
+            order.AssignRider(rider.RiderId, isOwnFleet: true, rider.Name, rider.Phone);
 
             _orderRepository.Update(order);
             await _unitOfWork.SaveChangesAsync(cancellationToken);

--- a/src/Modules/Orders/RallyAPI.Orders.Application/Commands/AssignRider/AssignRiderCommandHandler.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/Commands/AssignRider/AssignRiderCommandHandler.cs
@@ -53,7 +53,8 @@ public sealed class AssignRiderCommandHandler : IRequestHandler<AssignRiderComma
 
         try
         {
-            order.UpdateRiderInfo(command.RiderId, command.RiderName, command.RiderPhone);
+            // Admin/restaurant manual assignment names a Rally rider by id — never a 3PL agent.
+            order.UpdateRiderInfo(command.RiderId, isOwnFleet: true, command.RiderName, command.RiderPhone);
 
             _orderRepository.Update(order);
             await _unitOfWork.SaveChangesAsync(cancellationToken);

--- a/src/Modules/Orders/RallyAPI.Orders.Application/Commands/AssignRider/AssignRiderCommandValidator.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/Commands/AssignRider/AssignRiderCommandValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+
+namespace RallyAPI.Orders.Application.Commands.AssignRider;
+
+public sealed class AssignRiderCommandValidator : AbstractValidator<AssignRiderCommand>
+{
+    public AssignRiderCommandValidator()
+    {
+        RuleFor(x => x.OrderId).NotEmpty();
+
+        // This command only ever assigns an own-fleet rider, who must have a real Rally id.
+        // 3PL agents reach an order through the Delivery module's assignment event instead.
+        RuleFor(x => x.RiderId).NotEmpty();
+
+        RuleFor(x => x.RiderName).MaximumLength(200).When(x => x.RiderName != null);
+        RuleFor(x => x.RiderPhone).MaximumLength(20).When(x => x.RiderPhone != null);
+    }
+}

--- a/src/Modules/Orders/RallyAPI.Orders.Application/EventHandlers/DeliveryRiderAssignedEventHandler.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Application/EventHandlers/DeliveryRiderAssignedEventHandler.cs
@@ -44,6 +44,7 @@ public sealed class DeliveryRiderAssignedEventHandler : INotificationHandler<Del
         {
             order.AssignRider(
                 notification.RiderId,
+                notification.IsOwnFleet,
                 notification.RiderName,
                 notification.RiderPhone,
                 notification.TrackingUrl);
@@ -51,7 +52,9 @@ public sealed class DeliveryRiderAssignedEventHandler : INotificationHandler<Del
             _orderRepository.Update(order);
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
-            _logger.LogInformation("Updated Order {OrderNumber} with rider information", order.OrderNumber.Value);
+            _logger.LogInformation(
+                "Updated Order {OrderNumber} with rider information (ownFleet: {IsOwnFleet})",
+                order.OrderNumber.Value, notification.IsOwnFleet);
         }
         catch (Exception ex) when (ex is InvalidOperationException or ArgumentException)
         {
@@ -59,8 +62,8 @@ public sealed class DeliveryRiderAssignedEventHandler : INotificationHandler<Del
             // (e.g. a ProRouting webhook or the manual refresh-status reconcile). The
             // order simply keeps its current rider info; reconcile can be retried.
             _logger.LogWarning(ex,
-                "Failed to apply rider assignment to Order {OrderId} (rider {RiderId}, name '{RiderName}')",
-                notification.OrderId, notification.RiderId, notification.RiderName);
+                "Failed to apply rider assignment to Order {OrderId} (ownFleet: {IsOwnFleet}, rider {RiderId}, name '{RiderName}')",
+                notification.OrderId, notification.IsOwnFleet, notification.RiderId, notification.RiderName);
         }
     }
 }

--- a/src/Modules/Orders/RallyAPI.Orders.Domain/Entities/DeliveryInfo.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Domain/Entities/DeliveryInfo.cs
@@ -97,18 +97,30 @@ public sealed class DeliveryInfo : BaseEntity
 
     /// <summary>
     /// Assigns a rider to the delivery.
-    /// Own-fleet riders carry an internal <paramref name="riderId"/>; third-party (3PL)
-    /// riders have no internal GUID and are identified only by name/phone. At least one
-    /// form of identity is required. <see cref="AssignedAt"/> is the canonical
-    /// "a rider has been assigned" signal for both fleet types.
+    /// <paramref name="isOwnFleet"/> is the authoritative fleet discriminator and must come from
+    /// the Delivery module's FleetType — never infer it from whether an id happens to be present.
+    /// An own-fleet rider always has an internal <paramref name="riderId"/>; a third-party (3PL)
+    /// rider never does, and may not even have a name yet (the provider can report an assignment
+    /// before it reports the agent). <see cref="RiderId"/> staying null for 3PL is what keeps
+    /// own-rider queries — earnings, stats, order auth — from ever matching a 3PL rider.
+    /// <see cref="AssignedAt"/> is the canonical "a rider has been assigned" signal for both fleets.
     /// </summary>
-    public void AssignRider(Guid? riderId, string? riderName = null, string? riderPhone = null)
+    public void AssignRider(Guid? riderId, bool isOwnFleet, string? riderName = null, string? riderPhone = null)
     {
-        var hasInternalId = riderId.HasValue && riderId.Value != Guid.Empty;
-        if (!hasInternalId && string.IsNullOrWhiteSpace(riderName))
-            throw new ArgumentException("A rider identity (id or name) is required", nameof(riderId));
+        if (isOwnFleet)
+        {
+            if (!riderId.HasValue || riderId.Value == Guid.Empty)
+                throw new ArgumentException("An own-fleet rider requires an internal rider id", nameof(riderId));
 
-        RiderId = hasInternalId ? riderId : null;
+            RiderId = riderId;
+        }
+        else
+        {
+            // A 3PL rider has no Rally account, so never keep an id for one even if a caller
+            // passes a stray value — that id would make them look like own fleet downstream.
+            RiderId = null;
+        }
+
         RiderName = riderName;
         RiderPhone = riderPhone;
         AssignedAt = DateTime.UtcNow;

--- a/src/Modules/Orders/RallyAPI.Orders.Domain/Entities/Order.cs
+++ b/src/Modules/Orders/RallyAPI.Orders.Domain/Entities/Order.cs
@@ -361,8 +361,9 @@ public sealed class Order : AggregateRoot
 
     /// <summary>
     /// Assigns a rider to the order. Only valid for delivery orders.
+    /// <paramref name="isOwnFleet"/> must reflect the Delivery module's FleetType for this delivery.
     /// </summary>
-    public void AssignRider(Guid? riderId, string? riderName = null, string? riderPhone = null, string? trackingUrl = null)
+    public void AssignRider(Guid? riderId, bool isOwnFleet, string? riderName = null, string? riderPhone = null, string? trackingUrl = null)
     {
         if (FulfillmentType == FulfillmentType.Pickup)
             throw new InvalidOperationException("Cannot assign rider to a pickup order");
@@ -370,7 +371,7 @@ public sealed class Order : AggregateRoot
         if (DeliveryInfo is null)
             throw new InvalidOperationException("Cannot assign rider: no delivery info");
 
-        DeliveryInfo.AssignRider(riderId, riderName, riderPhone);
+        DeliveryInfo.AssignRider(riderId, isOwnFleet, riderName, riderPhone);
 
         if (!string.IsNullOrWhiteSpace(trackingUrl))
         {
@@ -499,8 +500,9 @@ public sealed class Order : AggregateRoot
 
     /// <summary>
     /// Updates rider info (called when Delivery Module assigns rider).
+    /// <paramref name="isOwnFleet"/> must reflect the Delivery module's FleetType for this delivery.
     /// </summary>
-    public void UpdateRiderInfo(Guid? riderId, string? riderName = null, string? riderPhone = null)
+    public void UpdateRiderInfo(Guid? riderId, bool isOwnFleet, string? riderName = null, string? riderPhone = null)
     {
         if (Status.IsTerminal())
             throw new InvalidOperationException("Cannot update rider for completed order");
@@ -508,7 +510,7 @@ public sealed class Order : AggregateRoot
         if (FulfillmentType == FulfillmentType.Pickup || DeliveryInfo is null)
             throw new InvalidOperationException("Cannot update rider for a pickup order");
 
-        DeliveryInfo.AssignRider(riderId, riderName, riderPhone);
+        DeliveryInfo.AssignRider(riderId, isOwnFleet, riderName, riderPhone);
         UpdatedAt = DateTime.UtcNow;
     }
 

--- a/tests/Modules/Orders/RallyAPI.Orders.Domain.Tests/OrderAggregateTests.cs
+++ b/tests/Modules/Orders/RallyAPI.Orders.Domain.Tests/OrderAggregateTests.cs
@@ -263,7 +263,7 @@ public class OrderAggregateTests
         order.Confirm();
         order.StartPreparing();
         order.MarkReadyForPickup();
-        order.AssignRider(riderId);
+        order.AssignRider(riderId, isOwnFleet: true);
         order.MarkPickedUp();
         order.MarkDelivered();
 
@@ -293,7 +293,7 @@ public class OrderAggregateTests
         order.MarkReadyForPickup();
         order.Status.Should().Be(OrderStatus.ReadyForPickup);
 
-        order.AssignRider(riderId, "Suresh", "+919876543210");
+        order.AssignRider(riderId, isOwnFleet: true, "Suresh", "+919876543210");
         order.MarkPickedUp();
         order.Status.Should().Be(OrderStatus.PickedUp);
 
@@ -311,7 +311,7 @@ public class OrderAggregateTests
         order.Confirm();
         order.StartPreparing();
         order.MarkReadyForPickup();
-        order.AssignRider(Guid.NewGuid());
+        order.AssignRider(Guid.NewGuid(), isOwnFleet: true);
         order.MarkPickedUp();
         order.MarkDelivered();
 

--- a/tests/Modules/Orders/RallyAPI.Orders.Domain.Tests/RiderFleetSeparationTests.cs
+++ b/tests/Modules/Orders/RallyAPI.Orders.Domain.Tests/RiderFleetSeparationTests.cs
@@ -1,0 +1,309 @@
+using FluentAssertions;
+using RallyAPI.Orders.Domain.Entities;
+using RallyAPI.Orders.Domain.Enums;
+using RallyAPI.Orders.Domain.Events;
+using RallyAPI.Orders.Domain.ValueObjects;
+using Xunit;
+
+namespace RallyAPI.Orders.Domain.Tests;
+
+/// <summary>
+/// Own-fleet riders (Rally riders with an account and an internal id) and third-party/3PL
+/// riders (ProRouting agents, external, no Rally account) must never be mistaken for one
+/// another. The rule the whole system rests on:
+///
+///   own fleet  => DeliveryInfo.RiderId is the rider's internal id
+///   3PL        => DeliveryInfo.RiderId is ALWAYS null; the rider is name/phone only
+///
+/// That null is load-bearing: every own-rider query (earnings, stats, order auth, active
+/// deliveries) matches on RiderId, so a 3PL agent carrying an id would leak into rider
+/// payouts and could unlock another rider's order. Conversely, AssignedAt — not RiderId —
+/// is the "a rider is assigned" signal, because 3PL riders legitimately have no id.
+///
+/// Regression origin: 3PL assignment used to throw (null id coerced to Guid.Empty), which
+/// the event pipeline swallowed, stranding real orders at ReadyForPickup while the 3PL
+/// rider actually delivered them (ORD-20260716-00303).
+/// </summary>
+public class RiderFleetSeparationTests
+{
+    #region Test Helpers
+
+    private static Order CreateDeliveryOrderReadyForPickup()
+    {
+        var order = CreatePaidDeliveryOrder();
+        order.Confirm();
+        order.StartPreparing();
+        order.MarkReadyForPickup();
+        return order;
+    }
+
+    private static Order CreatePaidDeliveryOrder()
+    {
+        var deliveryAddress = Address.Create(
+            street: "123 MG Road",
+            city: "Bengaluru",
+            pincode: "560001",
+            latitude: 12.9716,
+            longitude: 77.5946);
+
+        var deliveryInfo = DeliveryInfo.Create(
+            pickupLatitude: 12.9352,
+            pickupLongitude: 77.6245,
+            pickupPincode: "560095",
+            deliveryAddress: deliveryAddress,
+            pickupAddress: "Restaurant Street");
+
+        var order = Order.CreatePendingOrder(
+            orderNumber: OrderNumber.Create(dailySequence: 1),
+            customerId: Guid.NewGuid(),
+            customerName: "Ravi Kumar",
+            restaurantId: Guid.NewGuid(),
+            restaurantName: "Biryani House",
+            pricing: OrderPricing.CreateSimple(subTotal: 250m, deliveryFee: 40m),
+            deliveryInfo: deliveryInfo);
+
+        order.AddItem(OrderItem.Create(
+            Guid.NewGuid(), "Chicken Biryani",
+            Money.FromDecimal(250m, "INR"), 1));
+        order.ConfirmPayment("PAY-001", null);
+        return order;
+    }
+
+    #endregion
+
+    #region Own-fleet assignment
+
+    [Fact]
+    public void AssignRider_WithOwnFleetRider_ShouldStoreInternalRiderId()
+    {
+        var order = CreateDeliveryOrderReadyForPickup();
+        var riderId = Guid.NewGuid();
+
+        order.AssignRider(riderId, isOwnFleet: true, "Suresh", "+919876543210");
+
+        order.DeliveryInfo!.RiderId.Should().Be(riderId);
+        order.DeliveryInfo.RiderName.Should().Be("Suresh");
+        order.DeliveryInfo.RiderPhone.Should().Be("+919876543210");
+        order.DeliveryInfo.AssignedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AssignRider_WithOwnFleetButNoRiderId_ShouldThrow()
+    {
+        var order = CreateDeliveryOrderReadyForPickup();
+
+        var act = () => order.AssignRider(null, isOwnFleet: true, "Suresh", "+919876543210");
+
+        act.Should().Throw<ArgumentException>();
+        order.DeliveryInfo!.AssignedAt.Should().BeNull("a failed assignment must not look assigned");
+    }
+
+    [Fact]
+    public void AssignRider_WithOwnFleetButEmptyRiderId_ShouldThrow()
+    {
+        // Guard against a caller that forgot to bind the id: Guid.Empty is not a rider.
+        // It must be rejected outright, never quietly downgraded to a 3PL-shaped record.
+        var order = CreateDeliveryOrderReadyForPickup();
+
+        var act = () => order.AssignRider(Guid.Empty, isOwnFleet: true, "Suresh", "+919876543210");
+
+        act.Should().Throw<ArgumentException>();
+        order.DeliveryInfo!.RiderId.Should().BeNull();
+        order.DeliveryInfo.AssignedAt.Should().BeNull();
+    }
+
+    #endregion
+
+    #region 3PL assignment
+
+    [Fact]
+    public void AssignRider_WithThirdPartyRider_ShouldNeverStoreAnInternalRiderId()
+    {
+        var order = CreateDeliveryOrderReadyForPickup();
+
+        order.AssignRider(null, isOwnFleet: false, "ProRouting Agent", "+919000000001", "https://track.example/abc");
+
+        order.DeliveryInfo!.RiderId.Should().BeNull("a 3PL agent has no Rally account and must never match own-rider queries");
+        order.DeliveryInfo.RiderName.Should().Be("ProRouting Agent");
+        order.DeliveryInfo.RiderPhone.Should().Be("+919000000001");
+        order.DeliveryInfo.TrackingUrl.Should().Be("https://track.example/abc");
+        order.DeliveryInfo.AssignedAt.Should().NotBeNull("AssignedAt is the fleet-agnostic 'rider assigned' signal");
+    }
+
+    [Fact]
+    public void AssignRider_WithThirdPartyRiderAndStrayRiderId_ShouldDiscardTheId()
+    {
+        // Defence in depth: if a provider payload or a future caller ever supplies an id on a
+        // 3PL assignment, keeping it would make an external agent indistinguishable from a
+        // Rally rider — they would show up in rider earnings and could pass order auth checks.
+        var order = CreateDeliveryOrderReadyForPickup();
+        var strayId = Guid.NewGuid();
+
+        order.AssignRider(strayId, isOwnFleet: false, "ProRouting Agent", "+919000000001");
+
+        order.DeliveryInfo!.RiderId.Should().BeNull();
+    }
+
+    [Fact]
+    public void AssignRider_WithThirdPartyRiderWhoHasNoNameYet_ShouldStillAssign()
+    {
+        // ProRouting sends "agent-assigned" with the rider block absent (order.Rider?.Name is
+        // null) and fills the agent in later. Rejecting that assignment is what stranded orders
+        // at ReadyForPickup while the delivery was actually under way.
+        var order = CreateDeliveryOrderReadyForPickup();
+
+        var act = () => order.AssignRider(null, isOwnFleet: false, null, null, "https://track.example/abc");
+
+        act.Should().NotThrow();
+        order.DeliveryInfo!.AssignedAt.Should().NotBeNull();
+        order.DeliveryInfo.RiderId.Should().BeNull();
+        order.DeliveryInfo.TrackingUrl.Should().Be("https://track.example/abc");
+    }
+
+    #endregion
+
+    #region Pickup progression — the original incident
+
+    [Fact]
+    public void MarkPickedUp_AfterThirdPartyAssignment_ShouldSucceed()
+    {
+        // The original bug: a 3PL rider has no internal id, so an id-based "is a rider
+        // assigned?" check refused the pickup and the order stuck at ReadyForPickup.
+        var order = CreateDeliveryOrderReadyForPickup();
+        order.AssignRider(null, isOwnFleet: false, "ProRouting Agent", "+919000000001");
+
+        order.MarkPickedUp();
+
+        order.Status.Should().Be(OrderStatus.PickedUp);
+    }
+
+    [Fact]
+    public void MarkPickedUp_AfterOwnFleetAssignment_ShouldSucceed()
+    {
+        var order = CreateDeliveryOrderReadyForPickup();
+        order.AssignRider(Guid.NewGuid(), isOwnFleet: true, "Suresh", "+919876543210");
+
+        order.MarkPickedUp();
+
+        order.Status.Should().Be(OrderStatus.PickedUp);
+    }
+
+    [Fact]
+    public void MarkPickedUp_WithNoRiderAssigned_ShouldThrow()
+    {
+        // The loosened check must still reject a genuinely rider-less order.
+        var order = CreateDeliveryOrderReadyForPickup();
+
+        var act = () => order.MarkPickedUp();
+
+        act.Should().Throw<InvalidOperationException>();
+        order.Status.Should().Be(OrderStatus.ReadyForPickup);
+    }
+
+    [Fact]
+    public void ThirdPartyDelivery_FullLifecycle_ShouldReachDelivered()
+    {
+        // End-to-end shape of ORD-20260716-00303: a 3PL rider must carry an order all the way
+        // to Delivered, which is what the restaurant dashboard reports.
+        var order = CreatePaidDeliveryOrder();
+
+        order.Confirm();
+        order.StartPreparing();
+        order.MarkReadyForPickup();
+        order.AssignRider(null, isOwnFleet: false, "ProRouting Agent", "+919000000001");
+        order.MarkPickedUp();
+        order.MarkDelivered();
+
+        order.Status.Should().Be(OrderStatus.Delivered);
+        order.DeliveredAt.Should().NotBeNull();
+        order.DeliveryInfo!.RiderId.Should().BeNull();
+    }
+
+    #endregion
+
+    #region Events must not attribute 3PL work to a Rally rider
+
+    [Fact]
+    public void MarkPickedUp_WithThirdPartyRider_ShouldRaiseEventWithNullRiderId()
+    {
+        // Consumers key off this id to credit a Rally rider. A 3PL pickup must credit nobody.
+        var order = CreateDeliveryOrderReadyForPickup();
+        order.AssignRider(null, isOwnFleet: false, "ProRouting Agent", "+919000000001");
+
+        order.MarkPickedUp();
+
+        order.DomainEvents.OfType<OrderPickedUpEvent>().Should().ContainSingle()
+            .Which.RiderId.Should().BeNull();
+    }
+
+    [Fact]
+    public void MarkPickedUp_WithOwnFleetRider_ShouldRaiseEventWithThatRiderId()
+    {
+        var order = CreateDeliveryOrderReadyForPickup();
+        var riderId = Guid.NewGuid();
+        order.AssignRider(riderId, isOwnFleet: true, "Suresh", "+919876543210");
+
+        order.MarkPickedUp();
+
+        order.DomainEvents.OfType<OrderPickedUpEvent>().Should().ContainSingle()
+            .Which.RiderId.Should().Be(riderId);
+    }
+
+    #endregion
+
+    #region Fleet hand-over
+
+    [Fact]
+    public void AssignRider_WhenThirdPartyTakesOverFromOwnFleet_ShouldClearTheOwnRiderId()
+    {
+        // Dispatch falls back to 3PL after searching own fleet. The previously attached Rally
+        // rider must not stay on the order, or they keep accruing someone else's delivery.
+        var order = CreateDeliveryOrderReadyForPickup();
+        order.AssignRider(Guid.NewGuid(), isOwnFleet: true, "Suresh", "+919876543210");
+
+        order.AssignRider(null, isOwnFleet: false, "ProRouting Agent", "+919000000001");
+
+        order.DeliveryInfo!.RiderId.Should().BeNull();
+        order.DeliveryInfo.RiderName.Should().Be("ProRouting Agent");
+    }
+
+    [Fact]
+    public void AssignRider_WhenOwnFleetTakesOverFromThirdParty_ShouldStoreTheOwnRiderId()
+    {
+        var order = CreateDeliveryOrderReadyForPickup();
+        order.AssignRider(null, isOwnFleet: false, "ProRouting Agent", "+919000000001");
+        var riderId = Guid.NewGuid();
+
+        order.AssignRider(riderId, isOwnFleet: true, "Suresh", "+919876543210");
+
+        order.DeliveryInfo!.RiderId.Should().Be(riderId);
+        order.DeliveryInfo.RiderName.Should().Be("Suresh");
+    }
+
+    #endregion
+
+    #region UpdateRiderInfo (manual admin/restaurant assignment — own fleet only)
+
+    [Fact]
+    public void UpdateRiderInfo_WithOwnFleetRider_ShouldStoreInternalRiderId()
+    {
+        var order = CreateDeliveryOrderReadyForPickup();
+        var riderId = Guid.NewGuid();
+
+        order.UpdateRiderInfo(riderId, isOwnFleet: true, "Suresh", "+919876543210");
+
+        order.DeliveryInfo!.RiderId.Should().Be(riderId);
+    }
+
+    [Fact]
+    public void UpdateRiderInfo_WithOwnFleetButEmptyRiderId_ShouldThrow()
+    {
+        var order = CreateDeliveryOrderReadyForPickup();
+
+        var act = () => order.UpdateRiderInfo(Guid.Empty, isOwnFleet: true, "Suresh", "+919876543210");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
…confused

The Orders module was inferring fleet type from whether a rider id happened to be present, even though the Delivery module already hands it an explicit IsOwnFleet flag on DeliveryRiderAssignedIntegrationEvent. Inference left two holes:

 - A 3PL rider whose name the provider hadn't reported yet (ProRouting sends agent-assigned with the rider block absent — order.Rider?.Name is null) had no identity at all, so the assignment was rejected. The event handler then swallowed the throw and the order stayed at ReadyForPickup while the 3PL rider actually delivered it — the original stuck-order bug, just narrowed.
 - An own-fleet assignment carrying Guid.Empty (a caller that forgot to bind the id, e.g. AssignRiderCommand.RiderId left at default) was silently downgraded to a 3PL-shaped record instead of being rejected.

Fix — pass the fleet through instead of guessing it:
 - DeliveryInfo.AssignRider takes a required isOwnFleet. Own fleet must have a real internal id (Guid.Empty rejected); 3PL always stores RiderId = null, discarding any stray id, and needs no name.
 - Order.AssignRider / UpdateRiderInfo thread isOwnFleet through; the required parameter makes the compiler prove every call site states its fleet.
 - DeliveryRiderAssignedEventHandler passes notification.IsOwnFleet.
 - Admin/restaurant manual assignment is own-fleet by construction.
 - AssignRiderCommand gains the missing validator (RiderId NotEmpty), so an unbound id is a 400 rather than an exception.

RiderId staying null for 3PL is the load-bearing invariant: every own-rider query (earnings, stats, order auth, active deliveries) matches on RiderId, so a 3PL agent holding an id would leak into rider payouts and could pass another rider's order-auth check.

Adds RiderFleetSeparationTests covering both fleets across assignment, pickup, events, and fleet hand-over. Each test was mutation-checked: reverting any part of the fix fails them.